### PR TITLE
chore: apply copier template update (fdb4552)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: b1350d0e5e9792ccf86faba9ee3899075a622462
+_commit: fdb4552a1ec1bc4eb78639a915006609cc9e2ded
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/noxfile.py
+++ b/noxfile.py
@@ -103,9 +103,11 @@ def test_fast(session: nox.Session) -> None:
     )
 
     # Run fast tests only with parallel execution
+    # --no-cov disables coverage (from addopts) so it cannot fail this step
     session.run(
         "pytest",
         "tests",
+        "--no-cov",
         "-m",
         "not slow and not integration and not example",
         "-n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,6 @@ dependencies = [
 [project.optional-dependencies]
 plotting = ["statsmodels>=0.14"]
 
-[project.scripts]
-pytest = "pytest:console_main"
-
 [dependency-groups]
 dev = [
     {include-group = "tests"},


### PR DESCRIPTION
## Description

Apply copier template update to commit `fdb4552` (`gh:stateful-y/python-package-copier`).

## Type of Change

- [x] Other (please describe): Copier template update

## Motivation and Context

Syncs the project scaffolding with the latest version of the upstream copier template.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just format` to format my code
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Changes applied by copier:
- `.copier-answers.yml`: bump tracked commit hash to `fdb4552`
- `noxfile.py`: add `--no-cov` flag to `test_fast` session to prevent coverage failures
- `pyproject.toml`: remove stray `[project.scripts]` entry added by template
