### PR TITLE
fix(ci): skip plotting extras in test_docstrings on Python 3.14

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
         run: nox -s test_coverage
 
       - name: Run docstring tests
-        run: nox -s test_docstrings
+        run: nox -s test_docstrings-${{ matrix.python-version }}
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -186,7 +186,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Run docstring tests
-        run: nox -s test_docstrings
+        run: nox -s test_docstrings-3.11
 
 
   examples:

--- a/noxfile.py
+++ b/noxfile.py
@@ -187,7 +187,7 @@ def test_examples(session: nox.Session) -> None:
     )
 
 
-@nox.session(venv_backend="uv")
+@nox.session(python=PYTHON_VERSIONS, venv_backend="uv")
 def test_docstrings(session: nox.Session) -> None:
     """Run docstring examples with pytest."""
     # Install dependencies
@@ -195,8 +195,7 @@ def test_docstrings(session: nox.Session) -> None:
         "uv",
         "sync",
         "--no-default-groups",
-        "--extra",
-        "plotting",
+        *_plotting_extras(session),
         "--group",
         "tests",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
@@ -208,6 +207,7 @@ def test_docstrings(session: nox.Session) -> None:
         "--doctest-modules",
         "--doctest-continue-on-failure",
         "--no-cov",
+        *_plotting_ignores(session),
         "src/yohou",
         *session.posargs,
     )


### PR DESCRIPTION
## Description

The `test_docstrings` nox session unconditionally installed `--extra plotting`, which fails on Python 3.14 because `tsdownsample` (via `plotly-resampler`) cannot compile (`argminmax` Rust build error). This caused the nightly build to fail on the 3.14 matrix entry.

Parameterizes `test_docstrings` with `PYTHON_VERSIONS` and reuses the existing `_plotting_extras()` / `_plotting_ignores()` helpers, matching the pattern already used by `test`, `test_fast`, and `test_slow`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Fixes #29

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Since `test_docstrings` is now parameterized, CI workflows are updated to use the versioned session name (`test_docstrings-3.11`, `test_docstrings-${{ matrix.python-version }}`).