### PR TITLE
feat(preprocessing): add calendar, holiday, Fourier, and time index transformers

### DIFF
--- a/docs/pages/api/preprocessing.md
+++ b/docs/pages/api/preprocessing.md
@@ -40,6 +40,15 @@ Time series transformers for feature engineering, scaling, imputation, outlier h
 | [`Normalizer`](generated/yohou.preprocessing.sklearn_wrappers.Normalizer.md) | Normalize samples individually to unit norm. |
 | [`RobustScaler`](generated/yohou.preprocessing.sklearn_wrappers.RobustScaler.md) | Scale features using statistics that are robust to outliers. |
 
+### Calendar and time features
+
+| Name | Description |
+| --- | --- |
+| [`CalendarFeatureTransformer`](generated/yohou.preprocessing.calendar.CalendarFeatureTransformer.md) | Extract calendar-based features (month, day of week, etc.) from the time column. |
+| [`HolidayFeatureTransformer`](generated/yohou.preprocessing.calendar.HolidayFeatureTransformer.md) | Binary holiday indicator from a user-provided DataFrame of dates. |
+| [`FourierFeatureTransformer`](generated/yohou.preprocessing.time_features.FourierFeatureTransformer.md) | Generate Fourier sin/cos harmonics at a specified seasonal period. |
+| [`TimeIndexTransformer`](generated/yohou.preprocessing.time_features.TimeIndexTransformer.md) | Convert the time column to a numeric index with optional polynomial terms. |
+
 ### Feature engineering
 
 | Name | Description |

--- a/examples/datasets/australian_tourism_forecasting.py
+++ b/examples/datasets/australian_tourism_forecasting.py
@@ -1,6 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
+#     "statsmodels",
 #     "yohou",
 # ]
 # ///

--- a/examples/datasets/hospital_multivariate.py
+++ b/examples/datasets/hospital_multivariate.py
@@ -1,6 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
+#     "statsmodels",
 #     "yohou",
 # ]
 # ///

--- a/examples/datasets/pedestrian_counts_forecasting.py
+++ b/examples/datasets/pedestrian_counts_forecasting.py
@@ -1,6 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
+#     "statsmodels",
 #     "yohou",
 # ]
 # ///

--- a/examples/plotting/seasonal.py
+++ b/examples/plotting/seasonal.py
@@ -1,6 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
+#     "statsmodels",
 #     "yohou",
 # ]
 # ///

--- a/examples/preprocessing/time_derived_features.py
+++ b/examples/preprocessing/time_derived_features.py
@@ -1,0 +1,462 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "plotly",
+#     "yohou",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.20.2"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Time-Derived Features
+
+    This notebook demonstrates four stateless transformers that extract
+    features from the `"time"` column. Calendar and holiday features
+    encode temporal context, Fourier features capture cyclical
+    seasonality, and time index features model trend.
+
+    ## What You'll Learn
+
+    - [`CalendarFeatureTransformer`](/pages/api/generated/yohou.preprocessing.calendar.CalendarFeatureTransformer/): Auto-detect applicable calendar features from the time interval
+    - [`HolidayFeatureTransformer`](/pages/api/generated/yohou.preprocessing.calendar.HolidayFeatureTransformer/): Binary holiday indicator with optional proximity features
+    - [`FourierFeatureTransformer`](/pages/api/generated/yohou.preprocessing.time_features.FourierFeatureTransformer/): Sin/cos harmonics at a specified seasonal period
+    - [`TimeIndexTransformer`](/pages/api/generated/yohou.preprocessing.time_features.TimeIndexTransformer/): Integer, normalized, or polynomial trend indices
+    - Composing transformers with [`FeatureUnion`](/pages/api/generated/yohou.compose.feature_union.FeatureUnion/)
+
+    ## Prerequisites
+
+    Basic understanding of time series feature engineering and Fourier series.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    from datetime import date
+
+    import polars as pl
+
+    from yohou.compose import FeatureUnion
+    from yohou.datasets import fetch_sunspot
+    from yohou.plotting import plot_time_series
+    from yohou.preprocessing import (
+        CalendarFeatureTransformer,
+        FourierFeatureTransformer,
+        HolidayFeatureTransformer,
+        TimeIndexTransformer,
+    )
+
+    return (
+        CalendarFeatureTransformer,
+        FeatureUnion,
+        FourierFeatureTransformer,
+        HolidayFeatureTransformer,
+        TimeIndexTransformer,
+        date,
+        fetch_sunspot,
+        pl,
+        plot_time_series,
+    )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 1. Prepare Data
+
+    We load the monthly sunspot series for the calendar, Fourier, and trend
+    sections. Later we create a short daily series for holiday features.
+    """)
+    return
+
+
+@app.cell
+def _(fetch_sunspot, plot_time_series):
+    y = fetch_sunspot().frame.select("time", "sunspot_number").drop_nulls()
+    plot_time_series(y, title="Monthly Sunspot Number")
+    return (y,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 2. CalendarFeatureTransformer - Auto-detect
+
+    With `features=None` (the default), the transformer detects the data
+    interval and extracts all applicable features. For monthly data this
+    includes `year`, `month`, `quarter`, and the boolean boundary flags,
+    but excludes sub-daily features like `hour` and `minute`.
+    """)
+    return
+
+
+@app.cell
+def _(CalendarFeatureTransformer, y):
+    cal_tf = CalendarFeatureTransformer()
+    cal_tf.fit(y)
+    y_cal = cal_tf.transform(y)
+    y_cal.head(5)
+    return cal_tf, y_cal
+
+
+@app.cell
+def _(plot_time_series, y_cal):
+    plot_time_series(
+        y_cal.head(1000),
+        title="Extracted Calendar Features",
+    )
+    return
+
+
+@app.cell
+def _(cal_tf):
+    cal_tf.applicable_features_
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 3. Select Specific Features
+
+    Pass an explicit list to extract only the features you need.
+    """)
+    return
+
+
+@app.cell
+def _(CalendarFeatureTransformer, y):
+    cal_specific = CalendarFeatureTransformer(features=["month", "quarter", "is_year_start"])
+    cal_specific.fit(y)
+    y_specific = cal_specific.transform(y)
+    y_specific.head(5)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 4. HolidayFeatureTransformer
+
+    [`HolidayFeatureTransformer`](/pages/api/generated/yohou.preprocessing.calendar.HolidayFeatureTransformer/) takes a polars DataFrame of holiday dates
+    and produces a binary indicator column. The holidays DataFrame must
+    have a `"date"` column of `Date` or `Datetime` type.
+
+    We create a short daily series for this section since holidays are most
+    meaningful at daily granularity.
+    """)
+    return
+
+
+@app.cell
+def _(HolidayFeatureTransformer, date, pl):
+    holidays = pl.DataFrame({
+        "date": [
+            date(2020, 1, 1),
+            date(2020, 7, 4),
+            date(2020, 12, 25),
+        ]
+    })
+
+    X_daily = pl.DataFrame({
+        "time": pl.datetime_range(
+            start=date(2020, 1, 1),
+            end=date(2020, 1, 10),
+            interval="1d",
+            eager=True,
+        ),
+        "value": list(range(10)),
+    })
+
+    hol_tf = HolidayFeatureTransformer(holidays=holidays)
+    hol_tf.fit(X_daily)
+    X_hol = hol_tf.transform(X_daily)
+    X_hol
+    return X_daily, holidays
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 5. Holiday Proximity Features
+
+    With `days_to_next=True` and `days_since_last=True`, the transformer
+    adds columns that measure how far each timestamp is from the nearest
+    holiday. Values are `null` when no next or previous holiday exists
+    in the provided list.
+    """)
+    return
+
+
+@app.cell
+def _(HolidayFeatureTransformer, X_daily, holidays):
+    hol_prox = HolidayFeatureTransformer(holidays=holidays, days_to_next=True, days_since_last=True)
+    hol_prox.fit(X_daily)
+    X_prox = hol_prox.transform(X_daily)
+    X_prox
+    return (X_prox,)
+
+
+@app.cell
+def _(X_prox, plot_time_series):
+    plot_time_series(
+        X_prox,
+        columns=["holiday_indicator", "holiday_days_to_next", "holiday_days_since_last"],
+        title="Holiday Indicator and Proximity",
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 6. FourierFeatureTransformer - Single Seasonality
+
+    Specify the seasonal period as the number of time steps. For monthly data,
+    a yearly cycle is `seasonality=12`. The `harmonics` parameter controls
+    which frequency multiples to include - `[1]` captures the fundamental
+    frequency, `[1, 2, 3]` adds higher harmonics for sharper patterns.
+    """)
+    return
+
+
+@app.cell
+def _(FourierFeatureTransformer, y):
+    fourier_yearly = FourierFeatureTransformer(seasonality=12.0, harmonics=[1, 2])
+    fourier_yearly.fit(y)
+    y_fourier = fourier_yearly.transform(y)
+    y_fourier.head(5)
+    return (y_fourier,)
+
+
+@app.cell
+def _(plot_time_series, y_fourier):
+    plot_time_series(
+        y_fourier.head(1000),
+        title="Yearly Fourier Harmonics (period=12)",
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Notice the output column naming: `fourier_{seasonality}_sin_{k}` and
+    `fourier_{seasonality}_cos_{k}` for each harmonic `k`. Values are
+    always in the range [-1, 1].
+    """)
+    return
+
+
+@app.cell
+def _(pl, y_fourier):
+    y_fourier.select(pl.col("^fourier_.*$")).describe()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 7. Non-integer Seasonality
+
+    The `seasonality` parameter accepts floats. For instance, `365.25`
+    captures a yearly cycle on daily data accounting for leap years.
+    The sunspot cycle is approximately 132 months (~11 years).
+    """)
+    return
+
+
+@app.cell
+def _(FourierFeatureTransformer, pl, y):
+    fourier_solar = FourierFeatureTransformer(seasonality=132.0, harmonics=[1, 2, 3])
+    fourier_solar.fit(y)
+    y_solar = fourier_solar.transform(y)
+    y_solar.select("time", pl.col("^fourier_.*$")).head(5)
+    return (y_solar,)
+
+
+@app.cell
+def _(plot_time_series, y_solar):
+    plot_time_series(
+        y_solar.head(1000),
+        title="Solar Cycle Fourier Harmonics (period=132)",
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 8. Multiple Seasonalities with FeatureUnion
+
+    Use [`FeatureUnion`](/pages/api/generated/yohou.compose.feature_union.FeatureUnion/) to combine Fourier features at different
+    periods. Each `FourierFeatureTransformer` handles one seasonal period,
+    and the union concatenates their outputs.
+    """)
+    return
+
+
+@app.cell
+def _(FeatureUnion, FourierFeatureTransformer, y):
+    fourier_union = FeatureUnion(
+        transformer_list=[
+            ("yearly", FourierFeatureTransformer(seasonality=12.0, harmonics=[1, 2])),
+            ("solar", FourierFeatureTransformer(seasonality=132.0, harmonics=[1])),
+        ],
+    )
+    fourier_union.fit(y)
+    y_multi = fourier_union.transform(y)
+    y_multi.head(5)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 9. TimeIndexTransformer - Linear Index
+
+    [`TimeIndexTransformer`](/pages/api/generated/yohou.preprocessing.time_features.TimeIndexTransformer/) converts the time column into a sequential integer
+    index starting at 0. This is useful as a trend feature for
+    reduction forecasters.
+    """)
+    return
+
+
+@app.cell
+def _(TimeIndexTransformer, y):
+    idx_tf = TimeIndexTransformer()
+    idx_tf.fit(y)
+    y_idx = idx_tf.transform(y)
+    y_idx.select("time", "time_index").head(5)
+    return (y_idx,)
+
+
+@app.cell
+def _(plot_time_series, y_idx):
+    plot_time_series(
+        y_idx.head(1000),
+        title="Time Index",
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 10. Normalized and Polynomial Index
+
+    With `normalize=True`, the index is scaled to [0, 1] based on the fit
+    data length. The `degree` parameter adds polynomial terms for
+    non-linear trend modeling.
+    """)
+    return
+
+
+@app.cell
+def _(TimeIndexTransformer, y):
+    poly_tf = TimeIndexTransformer(normalize=True, degree=3)
+    poly_tf.fit(y)
+    y_poly = poly_tf.transform(y)
+    y_poly.select("time", "time_index", "time_index_2", "time_index_3").head(5)
+    return (y_poly,)
+
+
+@app.cell
+def _(plot_time_series, y_poly):
+    plot_time_series(
+        y_poly.head(1000),
+        title="Normalized Polynomial Time Index (degree=3)",
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Notice that `time_index` is `Float64` when normalized (instead of `Int64`),
+    and polynomial columns are always `Float64`.
+    """)
+    return
+
+
+@app.cell
+def _(y_poly):
+    y_poly.select("time_index", "time_index_2", "time_index_3").describe()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 11. Combining All with FeatureUnion
+
+    Combine calendar, Fourier, and time index transformers into a single
+    [`FeatureUnion`](/pages/api/generated/yohou.compose.feature_union.FeatureUnion/) pipeline.
+    """)
+    return
+
+
+@app.cell
+def _(
+    CalendarFeatureTransformer,
+    FeatureUnion,
+    FourierFeatureTransformer,
+    TimeIndexTransformer,
+    y,
+):
+    full_union = FeatureUnion(
+        transformer_list=[
+            ("calendar", CalendarFeatureTransformer(features=["month", "quarter"])),
+            ("fourier_12", FourierFeatureTransformer(seasonality=12.0, harmonics=[1, 2])),
+            ("fourier_132", FourierFeatureTransformer(seasonality=132.0, harmonics=[1])),
+            ("trend", TimeIndexTransformer(normalize=True, degree=2)),
+        ],
+    )
+    full_union.fit(y)
+    y_full = full_union.transform(y)
+    y_full.head(5)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Key Takeaways
+
+    - [`CalendarFeatureTransformer`](/pages/api/generated/yohou.preprocessing.calendar.CalendarFeatureTransformer/) auto-detects applicable features from the time interval, or accepts an explicit list
+    - [`HolidayFeatureTransformer`](/pages/api/generated/yohou.preprocessing.calendar.HolidayFeatureTransformer/) matches against a user-provided polars DataFrame of holiday dates; `days_to_next`/`days_since_last` add distance columns
+    - [`FourierFeatureTransformer`](/pages/api/generated/yohou.preprocessing.time_features.FourierFeatureTransformer/) produces sin/cos pairs for each harmonic; compose via [`FeatureUnion`](/pages/api/generated/yohou.compose.feature_union.FeatureUnion/) for multiple seasonalities
+    - [`TimeIndexTransformer`](/pages/api/generated/yohou.preprocessing.time_features.TimeIndexTransformer/) provides linear or polynomial trend features with optional normalization
+    - All four transformers are stateless, not invertible, and derive features purely from the `"time"` column
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Next Steps
+
+    - **Window transformers**: See [`window_transformers.py`](/examples/preprocessing/window_transformers/) for lag, rolling, and EMA features
+    - **Custom transforms**: See [`function_transformer.py`](/examples/preprocessing/function_transformer/) for wrapping arbitrary polars operations
+    - **Using in forecasters**: Pass to `feature_transformer` in [`PointReductionForecaster`](/pages/api/generated/yohou.point.reduction.PointReductionForecaster/)
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ fix = [
 examples = [
     "marimo>=0.19.0",
     "catboost>=1.2",
+    "statsmodels>=0.14",
     "yohou-optuna",
     "yohou-nixtla; python_version < '3.14'",
 ]

--- a/src/yohou/preprocessing/__init__.py
+++ b/src/yohou/preprocessing/__init__.py
@@ -1,5 +1,6 @@
 """Preprocessing transformers for stationarization and feature engineering."""
 
+from .calendar import CalendarFeatureTransformer, HolidayFeatureTransformer
 from .function import FunctionTransformer
 from .imputation import (
     SeasonalImputer,
@@ -35,6 +36,7 @@ from .sklearn_wrappers import (
     SplineTransformer,
     StandardScaler,
 )
+from .time_features import FourierFeatureTransformer, TimeIndexTransformer
 from .window import (
     ExponentialMovingAverage,
     LagTransformer,
@@ -78,4 +80,9 @@ __all__ = [
     # Outlier handling
     "OutlierThresholdHandler",
     "OutlierPercentileHandler",
+    # Calendar and time features
+    "CalendarFeatureTransformer",
+    "HolidayFeatureTransformer",
+    "FourierFeatureTransformer",
+    "TimeIndexTransformer",
 ]

--- a/src/yohou/preprocessing/calendar.py
+++ b/src/yohou/preprocessing/calendar.py
@@ -1,0 +1,499 @@
+"""Calendar and holiday feature transformers for time series."""
+
+import numpy as np
+import polars as pl
+from sklearn.base import _fit_context
+from sklearn.utils.validation import check_is_fitted
+
+from yohou.base import BaseTransformer
+from yohou.utils import validate_transformer_data
+
+ALL_FEATURES = (
+    "year",
+    "month",
+    "week",
+    "day_of_week",
+    "day_of_month",
+    "day_of_year",
+    "hour",
+    "minute",
+    "quarter",
+    "is_weekend",
+    "is_month_start",
+    "is_month_end",
+    "is_quarter_start",
+    "is_quarter_end",
+    "is_year_start",
+    "is_year_end",
+)
+
+BOOLEAN_FEATURES = frozenset({
+    "is_weekend",
+    "is_month_start",
+    "is_month_end",
+    "is_quarter_start",
+    "is_quarter_end",
+    "is_year_start",
+    "is_year_end",
+})
+
+_FEATURE_MIN_GRANULARITY: dict[str, set[str]] = {
+    "hour": {"1s", "1m", "5m", "10m", "15m", "30m", "1h"},
+    "minute": {"1s", "1m", "5m", "10m", "15m", "30m"},
+}
+
+
+def _interval_supports_feature(interval: str, feature: str) -> bool:
+    """Check whether a time interval supports extracting a given feature.
+
+    Parameters
+    ----------
+    interval : str
+        Detected time interval string (e.g., "1d", "1h").
+    feature : str
+        Calendar feature name.
+
+    Returns
+    -------
+    bool
+        True if the feature is applicable to the interval.
+
+    """
+    required = _FEATURE_MIN_GRANULARITY.get(feature)
+    if required is None:
+        return True
+    return interval in required
+
+
+def _extract_feature(feature: str) -> pl.Expr:
+    """Build a polars expression that extracts a calendar feature from the time column.
+
+    Parameters
+    ----------
+    feature : str
+        Calendar feature name.
+
+    Returns
+    -------
+    pl.Expr
+        Expression that produces the feature column.
+
+    """
+    col = pl.col("time")
+    if feature == "year":
+        return col.dt.year().cast(pl.Int32).alias("cal_year")
+    if feature == "month":
+        return col.dt.month().cast(pl.Int32).alias("cal_month")
+    if feature == "week":
+        return col.dt.week().cast(pl.Int32).alias("cal_week")
+    if feature == "day_of_week":
+        return col.dt.weekday().cast(pl.Int32).alias("cal_day_of_week")
+    if feature == "day_of_month":
+        return col.dt.day().cast(pl.Int32).alias("cal_day_of_month")
+    if feature == "day_of_year":
+        return col.dt.ordinal_day().cast(pl.Int32).alias("cal_day_of_year")
+    if feature == "hour":
+        return col.dt.hour().cast(pl.Int32).alias("cal_hour")
+    if feature == "minute":
+        return col.dt.minute().cast(pl.Int32).alias("cal_minute")
+    if feature == "quarter":
+        return col.dt.quarter().cast(pl.Int32).alias("cal_quarter")
+    if feature == "is_weekend":
+        return (col.dt.weekday() >= 6).cast(pl.Int32).alias("cal_is_weekend")
+    if feature == "is_month_start":
+        return (col.dt.day() == 1).cast(pl.Int32).alias("cal_is_month_start")
+    if feature == "is_month_end":
+        return (col.dt.day() == col.dt.month_end().dt.day()).cast(pl.Int32).alias("cal_is_month_end")
+    if feature == "is_quarter_start":
+        return ((col.dt.month() - 1) % 3 == 0).and_(col.dt.day() == 1).cast(pl.Int32).alias("cal_is_quarter_start")
+    if feature == "is_quarter_end":
+        return (
+            ((col.dt.month() % 3 == 0).and_(col.dt.day() == col.dt.month_end().dt.day()))
+            .cast(pl.Int32)
+            .alias("cal_is_quarter_end")
+        )
+    if feature == "is_year_start":
+        return (col.dt.ordinal_day() == 1).cast(pl.Int32).alias("cal_is_year_start")
+    if feature == "is_year_end":
+        return (col.dt.month().eq(12).and_(col.dt.day().eq(31))).cast(pl.Int32).alias("cal_is_year_end")
+    msg = f"Unknown feature: {feature}"
+    raise ValueError(msg)
+
+
+class CalendarFeatureTransformer(BaseTransformer):
+    r"""Extract calendar-based features from the time column.
+
+    Creates new integer feature columns derived from the datetime index,
+    useful for capturing seasonal and calendar effects in reduction
+    forecasters. Output columns are prefixed with ``cal_``.
+
+    Each feature is a deterministic function of the timestamp $t$:
+
+    $$f_j(t) = \text{calendar}_{j}(t) \quad \text{for } j \in \{\text{month}, \text{day_of_week}, \ldots\}$$
+
+    For example, $f_{\text{month}}(t) \in \{1, \ldots, 12\}$ and
+    $f_{\text{is_weekend}}(t) \in \{0, 1\}$.
+
+    Parameters
+    ----------
+    features : list of str or None, default=None
+        Calendar features to extract. If ``None``, extracts all features
+        applicable to the detected time interval. Valid options:
+        ``"year"``, ``"month"``, ``"week"``, ``"day_of_week"``,
+        ``"day_of_month"``, ``"day_of_year"``, ``"hour"``, ``"minute"``,
+        ``"quarter"``, ``"is_weekend"``, ``"is_month_start"``,
+        ``"is_month_end"``, ``"is_quarter_start"``, ``"is_quarter_end"``,
+        ``"is_year_start"``, ``"is_year_end"``.
+
+    Attributes
+    ----------
+    applicable_features_ : list of str
+        Calendar features that will be extracted during transform.
+
+    See Also
+    --------
+    `HolidayFeatureTransformer` : Binary holiday indicator from user-provided dates.
+    `FourierFeatureTransformer` : Sin/cos harmonics for cyclical encoding.
+    `TimeIndexTransformer` : Numeric time index for trend features.
+    `FunctionTransformer` : Custom function-based transforms.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from datetime import datetime
+    >>> time = pl.datetime_range(
+    ...     start=datetime(2020, 1, 1), end=datetime(2020, 3, 1), interval="1d", eager=True
+    ... )
+    >>> X = pl.DataFrame({"time": time, "value": range(len(time))})
+    >>> transformer = CalendarFeatureTransformer(features=["month", "day_of_week"])
+    >>> transformer.fit(X)
+    CalendarFeatureTransformer(features=['month', 'day_of_week'])
+    >>> X_t = transformer.transform(X)
+    >>> "cal_month" in X_t.columns
+    True
+
+    """
+
+    _parameter_constraints: dict = {
+        **BaseTransformer._parameter_constraints,
+        "features": [list, None],
+    }
+
+    def __init__(
+        self,
+        features: list[str] | None = None,
+    ):
+        self.features = features
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X: pl.DataFrame, y: pl.DataFrame | None = None, **params) -> "CalendarFeatureTransformer":
+        """Fit the transformer by detecting the time interval and applicable features.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            Feature time series with ``"time"`` column.
+        y : pl.DataFrame, optional
+            Target time series (unused, for API compatibility).
+        **params : dict
+            Metadata routing parameters.
+
+        Returns
+        -------
+        self
+
+        """
+        X = validate_transformer_data(self, X=X, reset=True)
+        BaseTransformer.fit(self, X, y, **params)
+
+        if self.features is not None:
+            invalid = set(self.features) - set(ALL_FEATURES)
+            if invalid:
+                raise ValueError(f"Unknown features: {sorted(invalid)}. Valid features: {list(ALL_FEATURES)}")
+            inapplicable = [f for f in self.features if not _interval_supports_feature(self.interval_, f)]
+            if inapplicable:
+                raise ValueError(
+                    f"Features {inapplicable} are not applicable to data with "
+                    f"interval '{self.interval_}'. These features require "
+                    f"sub-daily data."
+                )
+            self.applicable_features_ = list(self.features)
+        else:
+            self.applicable_features_ = [f for f in ALL_FEATURES if _interval_supports_feature(self.interval_, f)]
+
+        generated_names = [f"cal_{f}" for f in self.applicable_features_]
+        existing = set(X.columns) - {"time"}
+        conflicts = set(generated_names) & existing
+        if conflicts:
+            raise ValueError(
+                f"Generated column names {sorted(conflicts)} conflict with "
+                f"existing columns in X. Rename input columns or select "
+                f"different features."
+            )
+
+        return self
+
+    def transform(self, X: pl.DataFrame, **params) -> pl.DataFrame:
+        """Extract calendar features from the time column.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            Feature time series with ``"time"`` column.
+        **params : dict
+            Metadata routing parameters.
+
+        Returns
+        -------
+        pl.DataFrame
+            DataFrame with ``"time"`` column and extracted calendar features.
+
+        """
+        check_is_fitted(self, ["applicable_features_"])
+        X = validate_transformer_data(self, X=X, reset=False, check_continuity=False)
+
+        feature_exprs = [_extract_feature(f) for f in self.applicable_features_]
+
+        return X.select(pl.col("time"), *feature_exprs)
+
+    def get_feature_names_out(self, input_features=None) -> list[str]:
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input feature names (unused, for API compatibility).
+
+        Returns
+        -------
+        list of str
+            All non-time output column names.
+
+        """
+        check_is_fitted(self, ["applicable_features_"])
+        return [f"cal_{f}" for f in self.applicable_features_]
+
+
+class HolidayFeatureTransformer(BaseTransformer):
+    r"""Extract holiday indicator features from a user-provided holiday calendar.
+
+    Produces a binary ``holiday_indicator`` column (and optional proximity
+    features) by matching the ``"time"`` column against a provided DataFrame
+    of holiday dates. Output columns are prefixed with ``holiday_``.
+
+    Given a set of holiday dates $H = \{h_1, h_2, \ldots\}$, the indicator
+    for each timestamp $t$ is:
+
+    $$\text{is_holiday}(t) = \mathbb{1}[\text{date}(t) \in H]$$
+
+    When ``proximity=True``, the transformer also computes:
+
+    $$\text{days_to_next}(t) = \min_{h \in H, h \geq t} (h - t) \quad \text{(null if no future holiday)}$$
+
+    $$\text{days_since_last}(t) = \min_{h \in H, h \leq t} (t - h) \quad \text{(null if no past holiday)}$$
+
+    Parameters
+    ----------
+    holidays : pl.DataFrame
+        DataFrame with a ``"date"`` column containing holiday dates.
+        The column must be of ``Date`` or ``Datetime`` type.
+    days_to_next : bool, default=False
+        If ``True``, produce a ``holiday_days_to_next`` integer column
+        with the number of days until the next holiday (null if none).
+    days_since_last : bool, default=False
+        If ``True``, produce a ``holiday_days_since_last`` integer column
+        with the number of days since the last holiday (null if none).
+
+    Attributes
+    ----------
+    holiday_dates_ : list of date
+        Sorted list of holiday dates used for matching.
+
+    See Also
+    --------
+    `CalendarFeatureTransformer` : Calendar features (month, day of week, etc.).
+    `FourierFeatureTransformer` : Sin/cos harmonics for cyclical encoding.
+    `TimeIndexTransformer` : Numeric time index for trend features.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from datetime import datetime, date
+    >>> time = pl.datetime_range(
+    ...     start=datetime(2020, 12, 23), end=datetime(2020, 12, 27), interval="1d", eager=True
+    ... )
+    >>> X = pl.DataFrame({"time": time, "value": range(len(time))})
+    >>> holidays = pl.DataFrame({"date": [date(2020, 12, 25)]})
+    >>> transformer = HolidayFeatureTransformer(holidays=holidays)
+    >>> transformer.fit(X)  # doctest: +ELLIPSIS
+    HolidayFeatureTransformer(holidays=shape: (1, 1)...)
+    >>> X_t = transformer.transform(X)
+    >>> X_t["holiday_indicator"].to_list()
+    [0, 0, 1, 0, 0]
+
+    """
+
+    _parameter_constraints: dict = {
+        **BaseTransformer._parameter_constraints,
+        "holidays": "no_validation",
+        "days_to_next": ["boolean"],
+        "days_since_last": ["boolean"],
+    }
+
+    _PREFIX = "holiday"
+
+    def __init__(
+        self,
+        holidays: pl.DataFrame,
+        days_to_next: bool = False,
+        days_since_last: bool = False,
+    ):
+        self.holidays = holidays
+        self.days_to_next = days_to_next
+        self.days_since_last = days_since_last
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X: pl.DataFrame, y: pl.DataFrame | None = None, **params) -> "HolidayFeatureTransformer":
+        """Fit the transformer by validating the holiday calendar.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            Feature time series with ``"time"`` column.
+        y : pl.DataFrame, optional
+            Target time series (unused, for API compatibility).
+        **params : dict
+            Metadata routing parameters.
+
+        Returns
+        -------
+        self
+
+        Raises
+        ------
+        ValueError
+            If ``holidays`` DataFrame is missing a ``"date"`` column or has
+            wrong dtype.
+
+        """
+        if not isinstance(self.holidays, pl.DataFrame):
+            raise ValueError(f"holidays must be a polars DataFrame, got {type(self.holidays).__name__}")
+        if "date" not in self.holidays.columns:
+            raise ValueError("holidays DataFrame must have a 'date' column")
+        date_dtype = self.holidays["date"].dtype
+        if date_dtype not in (pl.Date, pl.Datetime, pl.Datetime("us"), pl.Datetime("ns"), pl.Datetime("ms")):
+            raise ValueError(f"holidays 'date' column must be Date or Datetime type, got {date_dtype}")
+
+        X = validate_transformer_data(self, X=X, reset=True)
+        BaseTransformer.fit(self, X, y, **params)
+
+        dates_series = self.holidays["date"].cast(pl.Date)
+        self.holiday_dates_ = sorted(dates_series.to_list())
+
+        generated_names = [f"{self._PREFIX}_indicator"]
+        if self.days_to_next:
+            generated_names.append(f"{self._PREFIX}_days_to_next")
+        if self.days_since_last:
+            generated_names.append(f"{self._PREFIX}_days_since_last")
+        existing = set(X.columns) - {"time"}
+        conflicts = set(generated_names) & existing
+        if conflicts:
+            raise ValueError(f"Generated column names {sorted(conflicts)} conflict with existing columns in X.")
+
+        return self
+
+    def transform(self, X: pl.DataFrame, **params) -> pl.DataFrame:
+        """Extract holiday features from the time column.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            Feature time series with ``"time"`` column.
+        **params : dict
+            Metadata routing parameters.
+
+        Returns
+        -------
+        pl.DataFrame
+            DataFrame with ``"time"`` column and holiday indicator features.
+
+        """
+        check_is_fitted(self, ["holiday_dates_"])
+        X = validate_transformer_data(self, X=X, reset=False, check_continuity=False)
+
+        dates = X["time"].cast(pl.Date)
+        holiday_set = set(self.holiday_dates_)
+        is_holiday = dates.map_elements(lambda d: 1 if d in holiday_set else 0, return_dtype=pl.Int32).alias(
+            f"{self._PREFIX}_indicator"
+        )
+
+        new_cols = [is_holiday]
+
+        if self.days_to_next or self.days_since_last:
+            holiday_arr = np.array(self.holiday_dates_, dtype="datetime64[D]")
+            dates_arr = dates.to_numpy().astype("datetime64[D]")
+
+            if len(holiday_arr) == 0:
+                if self.days_to_next:
+                    new_cols.append(
+                        pl.Series(
+                            f"{self._PREFIX}_days_to_next",
+                            [None] * len(X),
+                            dtype=pl.Int32,
+                        )
+                    )
+                if self.days_since_last:
+                    new_cols.append(
+                        pl.Series(
+                            f"{self._PREFIX}_days_since_last",
+                            [None] * len(X),
+                            dtype=pl.Int32,
+                        )
+                    )
+            else:
+                idx_next = np.searchsorted(holiday_arr, dates_arr, side="left")
+                idx_prev = idx_next - 1
+
+                if self.days_to_next:
+                    to_next = []
+                    for i, idx in enumerate(idx_next):
+                        if idx < len(holiday_arr):
+                            delta = int((holiday_arr[idx] - dates_arr[i]) / np.timedelta64(1, "D"))
+                            to_next.append(delta)
+                        else:
+                            to_next.append(None)
+                    new_cols.append(pl.Series(f"{self._PREFIX}_days_to_next", to_next, dtype=pl.Int32))
+
+                if self.days_since_last:
+                    since_last = []
+                    for i, idx in enumerate(idx_prev):
+                        if idx >= 0:
+                            delta = int((dates_arr[i] - holiday_arr[idx]) / np.timedelta64(1, "D"))
+                            since_last.append(delta)
+                        else:
+                            since_last.append(None)
+                    new_cols.append(pl.Series(f"{self._PREFIX}_days_since_last", since_last, dtype=pl.Int32))
+
+        return X.select(pl.col("time")).with_columns(*new_cols)
+
+    def get_feature_names_out(self, input_features=None) -> list[str]:
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input feature names (unused, for API compatibility).
+
+        Returns
+        -------
+        list of str
+            Generated holiday feature column names.
+
+        """
+        check_is_fitted(self, ["holiday_dates_"])
+        generated = [f"{self._PREFIX}_indicator"]
+        if self.days_to_next:
+            generated.append(f"{self._PREFIX}_days_to_next")
+        if self.days_since_last:
+            generated.append(f"{self._PREFIX}_days_since_last")
+        return generated

--- a/src/yohou/preprocessing/calendar.py
+++ b/src/yohou/preprocessing/calendar.py
@@ -294,7 +294,7 @@ class HolidayFeatureTransformer(BaseTransformer):
 
     Parameters
     ----------
-    holidays : pl.DataFrame
+    holidays : pl.DataFrame or None, default=None
         DataFrame with a ``"date"`` column containing holiday dates.
         The column must be of ``Date`` or ``Datetime`` type.
     days_to_next : bool, default=False
@@ -344,7 +344,7 @@ class HolidayFeatureTransformer(BaseTransformer):
 
     def __init__(
         self,
-        holidays: pl.DataFrame,
+        holidays: pl.DataFrame | None = None,
         days_to_next: bool = False,
         days_since_last: bool = False,
     ):
@@ -376,6 +376,8 @@ class HolidayFeatureTransformer(BaseTransformer):
             wrong dtype.
 
         """
+        if self.holidays is None:
+            raise ValueError("holidays must be provided as a polars DataFrame, got None")
         if not isinstance(self.holidays, pl.DataFrame):
             raise ValueError(f"holidays must be a polars DataFrame, got {type(self.holidays).__name__}")
         if "date" not in self.holidays.columns:

--- a/src/yohou/preprocessing/time_features.py
+++ b/src/yohou/preprocessing/time_features.py
@@ -67,7 +67,7 @@ class FourierFeatureTransformer(BaseTransformer):
     >>> X = pl.DataFrame({"time": time, "value": range(len(time))})
     >>> transformer = FourierFeatureTransformer(seasonality=7.0, harmonics=[1, 2])
     >>> transformer.fit(X)
-    FourierFeatureTransformer(harmonics=[1, 2], seasonality=7.0)
+    FourierFeatureTransformer(harmonics=[1, 2])
     >>> X_t = transformer.transform(X)
     >>> "fourier_7.0_sin_1" in X_t.columns
     True

--- a/src/yohou/preprocessing/time_features.py
+++ b/src/yohou/preprocessing/time_features.py
@@ -1,0 +1,425 @@
+"""Fourier and time index feature transformers for time series."""
+
+import math
+import numbers
+
+import numpy as np
+import polars as pl
+from pydantic import StrictInt
+from sklearn.base import _fit_context
+from sklearn.utils._param_validation import Interval
+from sklearn.utils.validation import check_is_fitted
+
+from yohou.base import BaseTransformer
+from yohou.utils import validate_transformer_data
+
+
+class FourierFeatureTransformer(BaseTransformer):
+    r"""Generate Fourier harmonic features from the time column.
+
+    Creates sin/cos feature pairs at specified harmonics of a given
+    seasonal period, useful for encoding cyclical patterns as inputs
+    to reduction forecasters. Output columns are prefixed with
+    ``fourier_``.
+
+    For each harmonic $k$ and seasonal period $S$, the features at
+    time step $t$ are:
+
+    $$\text{sin}_k(t) = \sin\!\left(\frac{2\pi k\, t}{S}\right), \quad \text{cos}_k(t) = \cos\!\left(\frac{2\pi k\, t}{S}\right)$$
+
+    where $t$ is the number of time steps since the first observed
+    timestamp, $S$ is the ``seasonality`` parameter, and $k$ ranges
+    over the selected ``harmonics``. Harmonics must satisfy
+    $k \leq S / 2$ (Nyquist limit).
+
+    Parameters
+    ----------
+    seasonality : float, default=7.0
+        Seasonal period length in number of time steps. Can be
+        non-integer (e.g., ``365.25`` for yearly on daily data).
+    harmonics : list of int or None, default=None
+        Which Fourier harmonics to include. For example,
+        ``[1, 2, 3]`` uses the first three harmonics. If ``None``,
+        defaults to ``[1]``.
+
+    Attributes
+    ----------
+    harmonics_ : list of int
+        Effective list of harmonics used for feature generation.
+    first_time_ : datetime
+        First observed timestamp, used as reference for index
+        computation.
+
+    See Also
+    --------
+    `CalendarFeatureTransformer` : Calendar features (month, day of week, etc.).
+    `HolidayFeatureTransformer` : Binary holiday indicator.
+    `TimeIndexTransformer` : Numeric time index for trend features.
+    `FourierSeasonalityForecaster` : Forecaster-level Fourier seasonality.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from datetime import datetime
+    >>> time = pl.datetime_range(
+    ...     start=datetime(2020, 1, 1), end=datetime(2020, 1, 15), interval="1d", eager=True
+    ... )
+    >>> X = pl.DataFrame({"time": time, "value": range(len(time))})
+    >>> transformer = FourierFeatureTransformer(seasonality=7.0, harmonics=[1, 2])
+    >>> transformer.fit(X)
+    FourierFeatureTransformer(harmonics=[1, 2], seasonality=7.0)
+    >>> X_t = transformer.transform(X)
+    >>> "fourier_7.0_sin_1" in X_t.columns
+    True
+
+    """
+
+    _parameter_constraints: dict = {
+        **BaseTransformer._parameter_constraints,
+        "seasonality": [Interval(numbers.Real, 0, None, closed="neither")],
+        "harmonics": [list, None],
+    }
+
+    def __init__(
+        self,
+        seasonality: float = 7.0,
+        harmonics: list[int] | None = None,
+    ):
+        self.seasonality = seasonality
+        self.harmonics = harmonics
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X: pl.DataFrame, y: pl.DataFrame | None = None, **params) -> "FourierFeatureTransformer":
+        """Fit the transformer by storing the reference time and validating harmonics.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            Feature time series with ``"time"`` column.
+        y : pl.DataFrame, optional
+            Target time series (unused, for API compatibility).
+        **params : dict
+            Metadata routing parameters.
+
+        Returns
+        -------
+        self
+
+        Raises
+        ------
+        ValueError
+            If harmonics are invalid or generated names conflict with
+            existing columns.
+
+        """
+        X = validate_transformer_data(self, X=X, reset=True)
+        BaseTransformer.fit(self, X, y, **params)
+
+        self.harmonics_ = self.harmonics if self.harmonics is not None else [1]
+
+        if not self.harmonics_:
+            raise ValueError("harmonics list cannot be empty")
+        if any(h < 1 for h in self.harmonics_):
+            raise ValueError("All harmonics must be positive integers")
+
+        max_harmonic = max(self.harmonics_)
+        if max_harmonic > self.seasonality / 2:
+            raise ValueError(
+                f"Maximum harmonic ({max_harmonic}) cannot exceed seasonality/2 "
+                f"({self.seasonality / 2:.1f}) due to Nyquist sampling theorem."
+            )
+
+        self.first_time_ = X["time"][0]
+
+        s = f"{self.seasonality}"
+        generated_names = []
+        for k in self.harmonics_:
+            generated_names.append(f"fourier_{s}_sin_{k}")
+            generated_names.append(f"fourier_{s}_cos_{k}")
+        existing = set(X.columns) - {"time"}
+        conflicts = set(generated_names) & existing
+        if conflicts:
+            raise ValueError(f"Generated column names {sorted(conflicts)} conflict with existing columns in X.")
+
+        return self
+
+    def transform(self, X: pl.DataFrame, **params) -> pl.DataFrame:
+        """Generate Fourier harmonic features from the time column.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            Feature time series with ``"time"`` column.
+        **params : dict
+            Metadata routing parameters.
+
+        Returns
+        -------
+        pl.DataFrame
+            DataFrame with ``"time"`` column and Fourier feature columns.
+
+        """
+        check_is_fitted(self, ["harmonics_", "first_time_"])
+        X = validate_transformer_data(self, X=X, reset=False, check_continuity=False)
+
+        interval = self.interval_
+        time_diff = X["time"] - self.first_time_
+        if interval.endswith("mo") or interval.endswith("y") or interval.endswith("q"):
+            t = np.arange(len(X), dtype=np.float64)
+        else:
+            t = time_diff.dt.total_seconds().to_numpy().astype(np.float64)
+            first_diff = (X["time"][1] - X["time"][0]).total_seconds() if len(X) > 1 else 1.0
+            if first_diff != 0:
+                t = t / first_diff
+
+        feature_cols = []
+        s = f"{self.seasonality}"
+        for k in self.harmonics_:
+            angle = 2.0 * math.pi * k * t / self.seasonality
+            sin_vals = np.sin(angle)
+            cos_vals = np.cos(angle)
+            feature_cols.append(pl.Series(f"fourier_{s}_sin_{k}", sin_vals, dtype=pl.Float64))
+            feature_cols.append(pl.Series(f"fourier_{s}_cos_{k}", cos_vals, dtype=pl.Float64))
+
+        return X.select(pl.col("time")).with_columns(*feature_cols)
+
+    def get_feature_names_out(self, input_features=None) -> list[str]:
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input feature names (unused, for API compatibility).
+
+        Returns
+        -------
+        list of str
+            Generated Fourier feature column names.
+
+        """
+        check_is_fitted(self, ["harmonics_"])
+        s = f"{self.seasonality}"
+        generated = []
+        for k in self.harmonics_:
+            generated.append(f"fourier_{s}_sin_{k}")
+            generated.append(f"fourier_{s}_cos_{k}")
+        return generated
+
+
+class TimeIndexTransformer(BaseTransformer):
+    r"""Convert the time column to a numeric index with optional polynomial terms.
+
+    Produces integer or normalized time step indices starting from the
+    first observed timestamp, useful as trend features for reduction
+    forecasters.
+
+    The base index at time step $t$ is:
+
+    $$x(t) = \frac{t - t_0}{\Delta t}$$
+
+    where $t_0$ is the first observed timestamp and $\Delta t$ is the
+    detected time interval. When ``normalize=True``, the index is
+    scaled by the number of fit steps:
+
+    $$\tilde{x}(t) = \frac{x(t)}{N - 1}$$
+
+    where $N$ is ``n_steps_``. Polynomial features of degree $d$ are
+    then $\tilde{x}(t),\, \tilde{x}(t)^2,\, \ldots,\, \tilde{x}(t)^d$.
+
+    Parameters
+    ----------
+    normalize : bool, default=False
+        If ``True``, scale the index to ``[0, 1]`` based on the number
+        of steps in the fit data. Values can exceed this range for
+        data beyond the fit range.
+    degree : int, default=1
+        Polynomial degree. ``1`` produces a linear index only, ``2``
+        adds a quadratic term, and so on.
+
+    Attributes
+    ----------
+    first_time_ : datetime
+        First observed timestamp, used as reference for index
+        computation.
+    n_steps_ : int
+        Number of time steps in the fit data. Used as normalization
+        denominator (``n_steps_ - 1``).
+
+    See Also
+    --------
+    `CalendarFeatureTransformer` : Calendar features (month, day of week, etc.).
+    `FourierFeatureTransformer` : Sin/cos harmonics for cyclical encoding.
+    `PolynomialTrendForecaster` : Forecaster-level polynomial trend estimation.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from datetime import datetime
+    >>> time = pl.datetime_range(
+    ...     start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True
+    ... )
+    >>> X = pl.DataFrame({"time": time, "value": range(len(time))})
+    >>> transformer = TimeIndexTransformer(degree=2)
+    >>> transformer.fit(X)
+    TimeIndexTransformer(degree=2)
+    >>> X_t = transformer.transform(X)
+    >>> X_t["time_index"][0]
+    0
+    >>> "time_index_2" in X_t.columns
+    True
+
+    """
+
+    _parameter_constraints: dict = {
+        **BaseTransformer._parameter_constraints,
+        "normalize": ["boolean"],
+        "degree": [Interval(numbers.Integral, 1, None, closed="left")],
+    }
+
+    _PREFIX = "time_index"
+
+    def __init__(
+        self,
+        normalize: bool = False,
+        degree: StrictInt = 1,
+    ):
+        self.normalize = normalize
+        self.degree = degree
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X: pl.DataFrame, y: pl.DataFrame | None = None, **params) -> "TimeIndexTransformer":
+        """Fit the transformer by storing the reference time.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            Feature time series with ``"time"`` column.
+        y : pl.DataFrame, optional
+            Target time series (unused, for API compatibility).
+        **params : dict
+            Metadata routing parameters.
+
+        Returns
+        -------
+        self
+
+        """
+        X = validate_transformer_data(self, X=X, reset=True)
+        BaseTransformer.fit(self, X, y, **params)
+
+        self.first_time_ = X["time"][0]
+        self.n_steps_ = len(X)
+
+        generated_names = []
+        for d in range(1, self.degree + 1):
+            col_name = self._PREFIX if d == 1 else f"{self._PREFIX}_{d}"
+            generated_names.append(col_name)
+        existing = set(X.columns) - {"time"}
+        conflicts = set(generated_names) & existing
+        if conflicts:
+            raise ValueError(f"Generated column names {sorted(conflicts)} conflict with existing columns in X.")
+
+        return self
+
+    def _compute_index(self, X: pl.DataFrame) -> np.ndarray:
+        """Compute the numeric time index for the given data.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            DataFrame with ``"time"`` column.
+
+        Returns
+        -------
+        np.ndarray
+            Numeric time index array.
+
+        """
+        interval = self.interval_
+        time_diff = X["time"] - self.first_time_
+
+        if interval.endswith("mo") or interval.endswith("y") or interval.endswith("q"):
+            first_time = self.first_time_
+            months = (
+                ((X["time"].dt.year() - first_time.year) * 12 + (X["time"].dt.month() - first_time.month))
+                .to_numpy()
+                .astype(np.float64)
+            )
+            if interval.endswith("y"):
+                t = months / 12.0
+            elif interval.endswith("q"):
+                t = months / 3.0
+            else:
+                mo_count = int(interval.replace("mo", ""))
+                t = months / mo_count
+        else:
+            t = time_diff.dt.total_seconds().to_numpy().astype(np.float64)
+            if len(X) > 1:
+                first_diff = (X["time"][1] - X["time"][0]).total_seconds()
+                if first_diff != 0:
+                    t = t / first_diff
+
+        return t
+
+    def transform(self, X: pl.DataFrame, **params) -> pl.DataFrame:
+        """Generate time index features from the time column.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            Feature time series with ``"time"`` column.
+        **params : dict
+            Metadata routing parameters.
+
+        Returns
+        -------
+        pl.DataFrame
+            DataFrame with ``"time"`` column and time index features.
+
+        """
+        check_is_fitted(self, ["first_time_", "n_steps_"])
+        X = validate_transformer_data(self, X=X, reset=False, check_continuity=False)
+
+        t = self._compute_index(X)
+
+        feature_cols = []
+        for d in range(1, self.degree + 1):
+            col_name = self._PREFIX if d == 1 else f"{self._PREFIX}_{d}"
+            if d == 1 and not self.normalize:
+                values = t.astype(np.int64)
+                feature_cols.append(pl.Series(col_name, values, dtype=pl.Int64))
+            elif d == 1 and self.normalize:
+                denom = max(self.n_steps_ - 1, 1)
+                values = t / denom
+                feature_cols.append(pl.Series(col_name, values, dtype=pl.Float64))
+            else:
+                if self.normalize:
+                    denom = max(self.n_steps_ - 1, 1)
+                    base = t / denom
+                else:
+                    base = t
+                values = base**d
+                feature_cols.append(pl.Series(col_name, values, dtype=pl.Float64))
+
+        return X.select(pl.col("time")).with_columns(*feature_cols)
+
+    def get_feature_names_out(self, input_features=None) -> list[str]:
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input feature names (unused, for API compatibility).
+
+        Returns
+        -------
+        list of str
+            Generated time index feature column names.
+
+        """
+        check_is_fitted(self, ["first_time_"])
+        generated = []
+        for d in range(1, self.degree + 1):
+            col_name = self._PREFIX if d == 1 else f"{self._PREFIX}_{d}"
+            generated.append(col_name)
+        return generated

--- a/src/yohou/preprocessing/time_features.py
+++ b/src/yohou/preprocessing/time_features.py
@@ -164,7 +164,7 @@ class FourierFeatureTransformer(BaseTransformer):
 
         interval = self.interval_
         time_diff = X["time"] - self.first_time_
-        if interval.endswith("mo") or interval.endswith("y") or interval.endswith("q"):
+        if interval.endswith("mo") or interval.endswith("y"):
             t = np.arange(len(X), dtype=np.float64)
         else:
             t = time_diff.dt.total_seconds().to_numpy().astype(np.float64)
@@ -338,7 +338,7 @@ class TimeIndexTransformer(BaseTransformer):
         interval = self.interval_
         time_diff = X["time"] - self.first_time_
 
-        if interval.endswith("mo") or interval.endswith("y") or interval.endswith("q"):
+        if interval.endswith("mo") or interval.endswith("y"):
             first_time = self.first_time_
             months = (
                 ((X["time"].dt.year() - first_time.year) * 12 + (X["time"].dt.month() - first_time.month))
@@ -347,8 +347,6 @@ class TimeIndexTransformer(BaseTransformer):
             )
             if interval.endswith("y"):
                 t = months / 12.0
-            elif interval.endswith("q"):
-                t = months / 3.0
             else:
                 mo_count = int(interval.replace("mo", ""))
                 t = months / mo_count

--- a/tests/preprocessing/test_calendar.py
+++ b/tests/preprocessing/test_calendar.py
@@ -306,6 +306,25 @@ class TestHolidayFeatureTransformerBasic:
         with pytest.raises(ValueError, match="polars DataFrame"):
             transformer.fit(X)
 
+    def test_none_holidays_raises(self):
+        """Test ValueError when holidays is None."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 10), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = HolidayFeatureTransformer()
+        with pytest.raises(ValueError, match="holidays must be provided"):
+            transformer.fit(X)
+
+    def test_wrong_date_dtype_raises(self):
+        """Test ValueError when date column has wrong dtype."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 10), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": ["2020-01-05"]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays)
+        with pytest.raises(ValueError, match="Date or Datetime type"):
+            transformer.fit(X)
+
 
 class TestHolidayFeatureTransformerProximity:
     """Tests for proximity feature output."""
@@ -344,6 +363,34 @@ class TestHolidayFeatureTransformerProximity:
         since_last = X_t["holiday_days_since_last"].to_list()
         assert since_last[0] == 1  # Dec 26.
 
+    def test_days_to_next_only(self):
+        """Test days_to_next=True without days_since_last."""
+        time = pl.datetime_range(start=datetime(2020, 12, 23), end=datetime(2020, 12, 27), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": [date(2020, 12, 25)]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays, days_to_next=True)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "holiday_days_to_next" in X_t.columns
+        assert "holiday_days_since_last" not in X_t.columns
+        assert X_t["holiday_days_to_next"][0] == 2
+
+    def test_days_since_last_only(self):
+        """Test days_since_last=True without days_to_next."""
+        time = pl.datetime_range(start=datetime(2020, 12, 26), end=datetime(2020, 12, 28), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": [date(2020, 12, 25)]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays, days_since_last=True)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "holiday_days_since_last" in X_t.columns
+        assert "holiday_days_to_next" not in X_t.columns
+        assert X_t["holiday_days_since_last"][0] == 1
+
 
 class TestHolidayFeatureTransformerEdgeCases:
     """Edge case tests for HolidayFeatureTransformer."""
@@ -371,6 +418,34 @@ class TestHolidayFeatureTransformerEdgeCases:
         X_t = transformer.transform(X)
 
         assert all(v is None for v in X_t["holiday_days_to_next"].to_list())
+        assert all(v is None for v in X_t["holiday_days_since_last"].to_list())
+
+    def test_empty_holidays_days_to_next_only(self):
+        """Test empty holidays with only days_to_next produces nulls."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 5), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": pl.Series([], dtype=pl.Date)})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays, days_to_next=True)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "holiday_days_to_next" in X_t.columns
+        assert "holiday_days_since_last" not in X_t.columns
+        assert all(v is None for v in X_t["holiday_days_to_next"].to_list())
+
+    def test_empty_holidays_days_since_last_only(self):
+        """Test empty holidays with only days_since_last produces nulls."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 5), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": pl.Series([], dtype=pl.Date)})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays, days_since_last=True)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "holiday_days_since_last" in X_t.columns
+        assert "holiday_days_to_next" not in X_t.columns
         assert all(v is None for v in X_t["holiday_days_since_last"].to_list())
 
     def test_all_dates_are_holidays(self):

--- a/tests/preprocessing/test_calendar.py
+++ b/tests/preprocessing/test_calendar.py
@@ -1,0 +1,434 @@
+"""Tests for calendar and holiday feature transformers.
+
+Tests CalendarFeatureTransformer and HolidayFeatureTransformer using both
+the systematic check generator pattern and transformer-specific tests.
+"""
+
+from datetime import date, datetime
+
+import polars as pl
+import pytest
+from sklearn.base import clone
+
+from conftest import run_checks
+from yohou.preprocessing.calendar import CalendarFeatureTransformer, HolidayFeatureTransformer
+from yohou.testing import _yield_yohou_transformer_checks
+
+
+class TestCalendarFeatureTransformerSystematic:
+    """Systematic check generator tests for CalendarFeatureTransformer."""
+
+    @pytest.mark.parametrize(
+        "transformer,expected_failures",
+        [
+            (CalendarFeatureTransformer(), []),
+            (CalendarFeatureTransformer(features=["month", "day_of_week"]), []),
+        ],
+        ids=["default", "specific_features"],
+    )
+    def test_systematic_checks(
+        self,
+        transformer,
+        expected_failures,
+        time_series_train_test_factory,
+    ):
+        """Run all applicable checks for CalendarFeatureTransformer."""
+        X_train, X_test = time_series_train_test_factory(
+            train_length=60,
+            test_length=30,
+        )
+
+        transformer_fitted = clone(transformer)
+        transformer_fitted.fit(X_train)
+
+        run_checks(
+            transformer_fitted,
+            _yield_yohou_transformer_checks(transformer_fitted, X_train, None, X_test),
+            expected_failures=set(expected_failures),
+        )
+
+
+class TestCalendarFeatureTransformerFeatures:
+    """Tests for CalendarFeatureTransformer feature selection and values."""
+
+    def test_auto_select_daily_data(self):
+        """Test auto-selection excludes hour/minute for daily data."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 3, 1), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = CalendarFeatureTransformer()
+        transformer.fit(X)
+
+        assert "hour" not in transformer.applicable_features_
+        assert "minute" not in transformer.applicable_features_
+        assert "month" in transformer.applicable_features_
+        assert "day_of_week" in transformer.applicable_features_
+
+    def test_auto_select_hourly_data(self):
+        """Test auto-selection includes hour for hourly data."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 5), interval="1h", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = CalendarFeatureTransformer()
+        transformer.fit(X)
+
+        assert "hour" in transformer.applicable_features_
+        assert "month" in transformer.applicable_features_
+
+    def test_specific_features(self):
+        """Test extracting specific features produces correct columns."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 3, 1), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = CalendarFeatureTransformer(features=["month", "day_of_week"])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "cal_month" in X_t.columns
+        assert "cal_day_of_week" in X_t.columns
+        assert "cal_year" not in X_t.columns
+
+    def test_invalid_feature_raises(self):
+        """Test unknown feature raises ValueError."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 31), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = CalendarFeatureTransformer(features=["month", "nonexistent"])
+        with pytest.raises(ValueError, match="Unknown features"):
+            transformer.fit(X)
+
+    def test_incompatible_feature_raises(self):
+        """Test hourly feature on daily data raises ValueError."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 3, 1), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = CalendarFeatureTransformer(features=["hour"])
+        with pytest.raises(ValueError, match="not applicable"):
+            transformer.fit(X)
+
+    def test_correct_month_values(self):
+        """Test month values are 1-12."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2021, 1, 1), interval="1mo", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = CalendarFeatureTransformer(features=["month"])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        months = X_t["cal_month"].to_list()
+        assert months[0] == 1
+        assert months[5] == 6
+        assert months[11] == 12
+
+    def test_correct_day_of_week_values(self):
+        """Test day_of_week uses polars convention (1=Monday to 7=Sunday)."""
+        time = pl.datetime_range(
+            start=datetime(2020, 1, 6),
+            end=datetime(2020, 1, 13),
+            interval="1d",
+            eager=True,
+        )
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = CalendarFeatureTransformer(features=["day_of_week"])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        dow = X_t["cal_day_of_week"].to_list()
+        assert dow[0] == 1  # Monday
+
+    def test_is_weekend_values(self):
+        """Test is_weekend produces 0/1 for weekday/weekend."""
+        time = pl.datetime_range(
+            start=datetime(2020, 1, 6),
+            end=datetime(2020, 1, 13),
+            interval="1d",
+            eager=True,
+        )
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = CalendarFeatureTransformer(features=["is_weekend"])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        weekend = X_t["cal_is_weekend"].to_list()
+        assert all(v in (0, 1) for v in weekend)
+        assert weekend[5] == 1  # Saturday
+        assert weekend[6] == 1  # Sunday
+        assert weekend[0] == 0  # Monday
+
+    def test_column_name_conflict_raises(self):
+        """Test that conflicting column names raise ValueError."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 31), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "cal_month": range(len(time))})
+
+        transformer = CalendarFeatureTransformer(features=["month"])
+        with pytest.raises(ValueError, match="conflict"):
+            transformer.fit(X)
+
+
+class TestCalendarFeatureTransformerPanel:
+    """Tests for panel data support."""
+
+    def test_panel_data_support(self, panel_time_series_factory):
+        """Test transformer handles panel data (prefixed columns)."""
+        X = panel_time_series_factory(length=50, n_series=2, n_groups=2)
+
+        transformer = CalendarFeatureTransformer(features=["month", "day_of_week"])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "time" in X_t.columns
+        assert "cal_month" in X_t.columns
+        assert "cal_day_of_week" in X_t.columns
+
+
+class TestCalendarFeatureTransformerEdgeCases:
+    """Edge case tests for CalendarFeatureTransformer."""
+
+    def test_single_row(self):
+        """Test transformer works with two-row DataFrame (minimum for interval detection)."""
+        X = pl.DataFrame({
+            "time": [datetime(2020, 6, 15), datetime(2020, 6, 16)],
+            "value": [1.0, 2.0],
+        })
+
+        transformer = CalendarFeatureTransformer(features=["month", "quarter"])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert X_t["cal_month"][0] == 6
+        assert X_t["cal_quarter"][0] == 2
+
+    def test_get_feature_names_out(self):
+        """Test get_feature_names_out matches transform output."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 31), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = CalendarFeatureTransformer(features=["month", "is_weekend"])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        feature_names = transformer.get_feature_names_out()
+        assert feature_names == ["cal_month", "cal_is_weekend"]
+        for name in feature_names:
+            assert name in X_t.columns
+
+
+class TestHolidayFeatureTransformerSystematic:
+    """Systematic check generator tests for HolidayFeatureTransformer."""
+
+    @pytest.fixture()
+    def holidays_df(self):
+        """Create a sample holidays DataFrame."""
+        return pl.DataFrame({
+            "date": [date(2021, 1, 1), date(2021, 12, 25), date(2021, 7, 4)],
+        })
+
+    @pytest.mark.parametrize(
+        "days_to_next,days_since_last,expected_failures",
+        [
+            (False, False, []),
+            (True, True, []),
+        ],
+        ids=["binary_only", "with_proximity"],
+    )
+    def test_systematic_checks(
+        self,
+        holidays_df,
+        days_to_next,
+        days_since_last,
+        expected_failures,
+        time_series_train_test_factory,
+    ):
+        """Run all applicable checks for HolidayFeatureTransformer."""
+        X_train, X_test = time_series_train_test_factory(
+            train_length=60,
+            test_length=30,
+        )
+
+        transformer = HolidayFeatureTransformer(
+            holidays=holidays_df, days_to_next=days_to_next, days_since_last=days_since_last
+        )
+        transformer_fitted = clone(transformer)
+        transformer_fitted.fit(X_train)
+
+        run_checks(
+            transformer_fitted,
+            _yield_yohou_transformer_checks(transformer_fitted, X_train, None, X_test),
+            expected_failures=set(expected_failures),
+        )
+
+
+class TestHolidayFeatureTransformerBasic:
+    """Basic functionality tests for HolidayFeatureTransformer."""
+
+    def test_binary_output(self):
+        """Test correct binary output for known holidays."""
+        time = pl.datetime_range(start=datetime(2020, 12, 23), end=datetime(2020, 12, 27), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": [date(2020, 12, 25)]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert X_t["holiday_indicator"].to_list() == [0, 0, 1, 0, 0]
+
+    def test_no_holidays_match(self):
+        """Test all zeros when no holidays match."""
+        time = pl.datetime_range(start=datetime(2020, 6, 1), end=datetime(2020, 6, 5), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": [date(2020, 12, 25)]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert all(v == 0 for v in X_t["holiday_indicator"].to_list())
+
+    def test_missing_date_column_raises(self):
+        """Test ValueError for missing date column."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 10), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"holiday_date": [date(2020, 1, 5)]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays)
+        with pytest.raises(ValueError, match="'date' column"):
+            transformer.fit(X)
+
+    def test_invalid_holidays_type_raises(self):
+        """Test ValueError for non-DataFrame holidays."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 10), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = HolidayFeatureTransformer(holidays="not_a_df")
+        with pytest.raises(ValueError, match="polars DataFrame"):
+            transformer.fit(X)
+
+
+class TestHolidayFeatureTransformerProximity:
+    """Tests for proximity feature output."""
+
+    def test_proximity_columns(self):
+        """Test days_to_next/days_since_last produce distance columns."""
+        time = pl.datetime_range(start=datetime(2020, 12, 23), end=datetime(2020, 12, 27), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": [date(2020, 12, 25)]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays, days_to_next=True, days_since_last=True)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "holiday_days_to_next" in X_t.columns
+        assert "holiday_days_since_last" in X_t.columns
+
+        to_next = X_t["holiday_days_to_next"].to_list()
+        assert to_next[0] == 2  # Dec 23 -> Dec 25
+        assert to_next[1] == 1  # Dec 24 -> Dec 25
+        assert to_next[2] == 0  # Dec 25 -> Dec 25
+
+    def test_proximity_null_at_boundary(self):
+        """Test null when no next/previous holiday exists."""
+        time = pl.datetime_range(start=datetime(2020, 12, 26), end=datetime(2020, 12, 28), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": [date(2020, 12, 25)]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays, days_to_next=True, days_since_last=True)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        to_next = X_t["holiday_days_to_next"].to_list()
+        assert all(v is None for v in to_next)
+
+        since_last = X_t["holiday_days_since_last"].to_list()
+        assert since_last[0] == 1  # Dec 26.
+
+
+class TestHolidayFeatureTransformerEdgeCases:
+    """Edge case tests for HolidayFeatureTransformer."""
+
+    def test_empty_holiday_list(self):
+        """Test with empty holidays DataFrame."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 5), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": pl.Series([], dtype=pl.Date)})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert all(v == 0 for v in X_t["holiday_indicator"].to_list())
+
+    def test_empty_holidays_with_proximity(self):
+        """Test proximity with empty holidays produces all nulls."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 5), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": pl.Series([], dtype=pl.Date)})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays, days_to_next=True, days_since_last=True)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert all(v is None for v in X_t["holiday_days_to_next"].to_list())
+        assert all(v is None for v in X_t["holiday_days_since_last"].to_list())
+
+    def test_all_dates_are_holidays(self):
+        """Test when every date in data is a holiday."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 3), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({
+            "date": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)],
+        })
+
+        transformer = HolidayFeatureTransformer(holidays=holidays)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert all(v == 1 for v in X_t["holiday_indicator"].to_list())
+
+    def test_datetime_holidays_column(self):
+        """Test holidays with Datetime column type works."""
+        time = pl.datetime_range(start=datetime(2020, 12, 24), end=datetime(2020, 12, 26), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": [datetime(2020, 12, 25)]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert X_t["holiday_indicator"].to_list() == [0, 1, 0]
+
+    def test_column_name_conflict_raises(self):
+        """Test that conflicting column names raise ValueError."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 5), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "holiday_indicator": range(len(time))})
+        holidays = pl.DataFrame({"date": [date(2020, 1, 3)]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays)
+        with pytest.raises(ValueError, match="conflict"):
+            transformer.fit(X)
+
+    def test_get_feature_names_out(self):
+        """Test get_feature_names_out returns correct names."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 5), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": [date(2020, 1, 3)]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays, days_to_next=True, days_since_last=True)
+        transformer.fit(X)
+
+        names = transformer.get_feature_names_out()
+        assert names == ["holiday_indicator", "holiday_days_to_next", "holiday_days_since_last"]
+
+    def test_get_feature_names_out_no_proximity(self):
+        """Test get_feature_names_out without proximity."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 5), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+        holidays = pl.DataFrame({"date": [date(2020, 1, 3)]})
+
+        transformer = HolidayFeatureTransformer(holidays=holidays)
+        transformer.fit(X)
+
+        names = transformer.get_feature_names_out()
+        assert names == ["holiday_indicator"]

--- a/tests/preprocessing/test_time_features.py
+++ b/tests/preprocessing/test_time_features.py
@@ -1,0 +1,450 @@
+"""Tests for Fourier and time index feature transformers.
+
+Tests FourierFeatureTransformer and TimeIndexTransformer using both
+the systematic check generator pattern and transformer-specific tests.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import polars as pl
+import pytest
+from sklearn.base import clone
+
+from conftest import run_checks
+from yohou.preprocessing.time_features import FourierFeatureTransformer, TimeIndexTransformer
+from yohou.testing import _yield_yohou_transformer_checks
+
+
+class TestFourierFeatureTransformerSystematic:
+    """Systematic check generator tests for FourierFeatureTransformer."""
+
+    @pytest.mark.parametrize(
+        "transformer,expected_failures",
+        [
+            (FourierFeatureTransformer(seasonality=7.0), []),
+            (FourierFeatureTransformer(seasonality=7.0, harmonics=[1, 2, 3]), []),
+        ],
+        ids=["default_harmonic", "multi_harmonic"],
+    )
+    def test_systematic_checks(
+        self,
+        transformer,
+        expected_failures,
+        time_series_train_test_factory,
+    ):
+        """Run all applicable checks for FourierFeatureTransformer."""
+        X_train, X_test = time_series_train_test_factory(
+            train_length=60,
+            test_length=30,
+        )
+
+        transformer_fitted = clone(transformer)
+        transformer_fitted.fit(X_train)
+
+        run_checks(
+            transformer_fitted,
+            _yield_yohou_transformer_checks(transformer_fitted, X_train, None, X_test),
+            expected_failures=set(expected_failures),
+        )
+
+
+class TestFourierFeatureTransformerBasic:
+    """Basic functionality tests for FourierFeatureTransformer."""
+
+    def test_correct_column_count(self):
+        """Test output has 2 * len(harmonics) new columns."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 15), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=7.0, harmonics=[1, 2, 3])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        fourier_cols = [c for c in X_t.columns if c.startswith("fourier_")]
+        assert len(fourier_cols) == 6  # 3 harmonics * 2 (sin + cos)
+
+    def test_values_in_range(self):
+        """Test sin/cos values are in [-1, 1]."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 2, 1), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=7.0, harmonics=[1, 2])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        for col in X_t.columns:
+            if col.startswith("fourier_"):
+                values = X_t[col].to_numpy()
+                assert np.all(values >= -1.0 - 1e-10)
+                assert np.all(values <= 1.0 + 1e-10)
+
+    def test_column_names(self):
+        """Test column naming convention."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 15), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=7.0, harmonics=[1, 2])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "fourier_7.0_sin_1" in X_t.columns
+        assert "fourier_7.0_cos_1" in X_t.columns
+        assert "fourier_7.0_sin_2" in X_t.columns
+        assert "fourier_7.0_cos_2" in X_t.columns
+
+    def test_preserves_time_and_original(self):
+        """Test time column preserved and original features dropped."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 15), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=7.0)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "time" in X_t.columns
+        assert "value" not in X_t.columns
+
+
+class TestFourierFeatureTransformerHarmonics:
+    """Tests for harmonic parameter behavior."""
+
+    def test_default_single_harmonic(self):
+        """Test default harmonics=[1] produces 2 columns."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 15), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=7.0)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        fourier_cols = [c for c in X_t.columns if c.startswith("fourier_")]
+        assert len(fourier_cols) == 2
+
+    def test_empty_harmonics_raises(self):
+        """Test empty harmonics list raises ValueError."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 15), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=7.0, harmonics=[])
+        with pytest.raises(ValueError, match="cannot be empty"):
+            transformer.fit(X)
+
+    def test_negative_harmonic_raises(self):
+        """Test negative harmonic raises ValueError."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 15), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=7.0, harmonics=[-1])
+        with pytest.raises(ValueError, match="positive integers"):
+            transformer.fit(X)
+
+    def test_nyquist_limit_raises(self):
+        """Test harmonic exceeding Nyquist limit raises ValueError."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 15), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=7.0, harmonics=[4])
+        with pytest.raises(ValueError, match="Nyquist"):
+            transformer.fit(X)
+
+
+class TestFourierFeatureTransformerNonIntegerSeasonality:
+    """Tests for non-integer seasonality periods."""
+
+    def test_non_integer_period(self):
+        """Test non-integer seasonality works correctly."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2021, 1, 1), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=365.25, harmonics=[1])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "fourier_365.25_sin_1" in X_t.columns
+        assert "fourier_365.25_cos_1" in X_t.columns
+        assert len(X_t) == len(X)
+
+
+class TestFourierFeatureTransformerContinuity:
+    """Tests for boundary continuity of Fourier features."""
+
+    def test_periodicity(self):
+        """Test that values repeat approximately after one full period."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 22), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=7.0, harmonics=[1])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        sin_vals = X_t["fourier_7.0_sin_1"].to_numpy()
+        np.testing.assert_allclose(sin_vals[0], sin_vals[7], atol=1e-10)
+        np.testing.assert_allclose(sin_vals[0], sin_vals[14], atol=1e-10)
+
+
+class TestFourierFeatureTransformerEdgeCases:
+    """Edge case tests for FourierFeatureTransformer."""
+
+    def test_single_row(self):
+        """Test transformer works with two-row DataFrame (minimum for interval detection)."""
+        X = pl.DataFrame({
+            "time": [datetime(2020, 1, 1), datetime(2020, 1, 2)],
+            "value": [1.0, 2.0],
+        })
+
+        transformer = FourierFeatureTransformer(seasonality=7.0)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert len(X_t) == 2
+        assert "fourier_7.0_sin_1" in X_t.columns
+
+    def test_get_feature_names_out(self):
+        """Test get_feature_names_out returns correct names."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 15), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=7.0, harmonics=[1, 2])
+        transformer.fit(X)
+
+        names = transformer.get_feature_names_out()
+        assert names == [
+            "fourier_7.0_sin_1",
+            "fourier_7.0_cos_1",
+            "fourier_7.0_sin_2",
+            "fourier_7.0_cos_2",
+        ]
+
+    def test_column_name_conflict_raises(self):
+        """Test that conflicting column names raise ValueError."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 15), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "fourier_7.0_sin_1": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=7.0, harmonics=[1])
+        with pytest.raises(ValueError, match="conflict"):
+            transformer.fit(X)
+
+
+class TestTimeIndexTransformerSystematic:
+    """Systematic check generator tests for TimeIndexTransformer."""
+
+    @pytest.mark.parametrize(
+        "transformer,expected_failures",
+        [
+            (TimeIndexTransformer(), []),
+            (TimeIndexTransformer(normalize=True), []),
+            (TimeIndexTransformer(degree=3), []),
+            (TimeIndexTransformer(normalize=True, degree=2), []),
+        ],
+        ids=["default", "normalized", "polynomial", "normalized_polynomial"],
+    )
+    def test_systematic_checks(
+        self,
+        transformer,
+        expected_failures,
+        time_series_train_test_factory,
+    ):
+        """Run all applicable checks for TimeIndexTransformer."""
+        X_train, X_test = time_series_train_test_factory(
+            train_length=60,
+            test_length=30,
+        )
+
+        transformer_fitted = clone(transformer)
+        transformer_fitted.fit(X_train)
+
+        run_checks(
+            transformer_fitted,
+            _yield_yohou_transformer_checks(transformer_fitted, X_train, None, X_test),
+            expected_failures=set(expected_failures),
+        )
+
+
+class TestTimeIndexTransformerBasic:
+    """Basic functionality tests for TimeIndexTransformer."""
+
+    def test_sequential_integer_index(self):
+        """Test produces sequential integer index starting at 0."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer()
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        indices = X_t["time_index"].to_list()
+        assert indices == list(range(len(time)))
+
+    def test_preserves_time_and_original(self):
+        """Test time column preserved and original features dropped."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer()
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "time" in X_t.columns
+        assert "value" not in X_t.columns
+        assert "time_index" in X_t.columns
+
+    def test_integer_dtype_default(self):
+        """Test default output dtype is Int64."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer()
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert X_t["time_index"].dtype == pl.Int64
+
+
+class TestTimeIndexTransformerNormalized:
+    """Tests for normalized index output."""
+
+    def test_normalized_range(self):
+        """Test normalized values span [0, 1] for fit data."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer(normalize=True)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        values = X_t["time_index"].to_numpy()
+        np.testing.assert_allclose(values[0], 0.0)
+        np.testing.assert_allclose(values[-1], 1.0)
+
+    def test_normalized_exceeds_range_on_new_data(self):
+        """Test normalized values can exceed [0, 1] on future data."""
+        time_train = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True)
+        time_test = pl.datetime_range(start=datetime(2020, 1, 11), end=datetime(2020, 1, 21), interval="1d", eager=True)
+        X_train = pl.DataFrame({"time": time_train, "value": range(len(time_train))})
+        X_test = pl.DataFrame({"time": time_test, "value": range(len(time_test))})
+
+        transformer = TimeIndexTransformer(normalize=True)
+        transformer.fit(X_train)
+        X_t = transformer.transform(X_test)
+
+        values = X_t["time_index"].to_numpy()
+        assert values[-1] > 1.0
+
+    def test_float_dtype_when_normalized(self):
+        """Test normalized output dtype is Float64."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer(normalize=True)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert X_t["time_index"].dtype == pl.Float64
+
+
+class TestTimeIndexTransformerPolynomial:
+    """Tests for polynomial degree output."""
+
+    def test_degree_2_produces_2_columns(self):
+        """Test degree=2 produces time_index and time_index_2."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer(degree=2)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "time_index" in X_t.columns
+        assert "time_index_2" in X_t.columns
+
+    def test_degree_3_produces_3_columns(self):
+        """Test degree=3 produces 3 index columns."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer(degree=3)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "time_index" in X_t.columns
+        assert "time_index_2" in X_t.columns
+        assert "time_index_3" in X_t.columns
+
+    def test_polynomial_values_correct(self):
+        """Test polynomial column values are correct powers."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 6), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer(degree=3)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        t = X_t["time_index"].to_numpy().astype(np.float64)
+        t2 = X_t["time_index_2"].to_numpy()
+        t3 = X_t["time_index_3"].to_numpy()
+
+        np.testing.assert_allclose(t2, t**2)
+        np.testing.assert_allclose(t3, t**3)
+
+    def test_polynomial_float_dtype(self):
+        """Test polynomial columns are Float64."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer(degree=2)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert X_t["time_index_2"].dtype == pl.Float64
+
+
+class TestTimeIndexTransformerEdgeCases:
+    """Edge case tests for TimeIndexTransformer."""
+
+    def test_single_row(self):
+        """Test transformer works with two-row DataFrame (minimum for interval detection)."""
+        X = pl.DataFrame({
+            "time": [datetime(2020, 1, 1), datetime(2020, 1, 2)],
+            "value": [1.0, 2.0],
+        })
+
+        transformer = TimeIndexTransformer()
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert X_t["time_index"][0] == 0
+
+    def test_single_row_normalized(self):
+        """Test normalized two-row produces 0 and 1."""
+        X = pl.DataFrame({
+            "time": [datetime(2020, 1, 1), datetime(2020, 1, 2)],
+            "value": [1.0, 2.0],
+        })
+
+        transformer = TimeIndexTransformer(normalize=True)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert X_t["time_index"][0] == 0.0
+        assert X_t["time_index"][1] == 1.0
+
+    def test_get_feature_names_out(self):
+        """Test get_feature_names_out returns correct names."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer(degree=3)
+        transformer.fit(X)
+
+        names = transformer.get_feature_names_out()
+        assert names == ["time_index", "time_index_2", "time_index_3"]
+
+    def test_column_name_conflict_raises(self):
+        """Test that conflicting column names raise ValueError."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 11), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "time_index": range(len(time))})
+
+        transformer = TimeIndexTransformer()
+        with pytest.raises(ValueError, match="conflict"):
+            transformer.fit(X)

--- a/tests/preprocessing/test_time_features.py
+++ b/tests/preprocessing/test_time_features.py
@@ -166,6 +166,23 @@ class TestFourierFeatureTransformerNonIntegerSeasonality:
         assert len(X_t) == len(X)
 
 
+class TestFourierFeatureTransformerMonthlyData:
+    """Tests for Fourier features on monthly/quarterly/yearly data."""
+
+    def test_monthly_data(self):
+        """Test Fourier features with monthly time interval."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2022, 1, 1), interval="1mo", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=12.0, harmonics=[1])
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        assert "fourier_12.0_sin_1" in X_t.columns
+        sin_vals = X_t["fourier_12.0_sin_1"].to_numpy()
+        np.testing.assert_allclose(sin_vals[0], sin_vals[12], atol=1e-10)
+
+
 class TestFourierFeatureTransformerContinuity:
     """Tests for boundary continuity of Fourier features."""
 
@@ -397,6 +414,47 @@ class TestTimeIndexTransformerPolynomial:
         X_t = transformer.transform(X)
 
         assert X_t["time_index_2"].dtype == pl.Float64
+
+
+class TestTimeIndexTransformerMonthlyData:
+    """Tests for TimeIndexTransformer on monthly/quarterly/yearly data."""
+
+    def test_monthly_data_index(self):
+        """Test time index with monthly interval."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2022, 1, 1), interval="1mo", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer()
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        indices = X_t["time_index"].to_list()
+        assert indices[0] == 0
+        assert indices[12] == 12
+
+    def test_quarterly_data_index(self):
+        """Test time index with quarterly interval."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2022, 1, 1), interval="1q", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer()
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        indices = X_t["time_index"].to_list()
+        assert indices[0] == 0
+
+    def test_yearly_data_index(self):
+        """Test time index with yearly interval."""
+        time = pl.datetime_range(start=datetime(2015, 1, 1), end=datetime(2025, 1, 1), interval="1y", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = TimeIndexTransformer()
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        indices = X_t["time_index"].to_list()
+        assert indices[0] == 0
 
 
 class TestTimeIndexTransformerEdgeCases:

--- a/tests/utils/test_discovery.py
+++ b/tests/utils/test_discovery.py
@@ -18,7 +18,7 @@ class TestAllEstimators:
     def test_all_estimators_total_count(self):
         """Test all_estimators returns correct total count."""
         estimators = all_estimators()
-        assert len(estimators) == 75
+        assert len(estimators) == 79
 
     def test_all_estimators_forecaster_filter(self):
         """Test forecaster type filter (matches estimator_type == 'forecaster')."""
@@ -43,7 +43,7 @@ class TestAllEstimators:
     def test_all_estimators_transformer_filter(self):
         """Test transformer type filter."""
         transformers = all_estimators(type_filter="transformer")
-        assert len(transformers) == 29
+        assert len(transformers) == 33
 
     def test_all_estimators_splitter_filter(self):
         """Test splitter type filter."""
@@ -53,7 +53,7 @@ class TestAllEstimators:
     def test_all_estimators_multiple_filters(self):
         """Test multiple type filters combined."""
         multi = all_estimators(type_filter=["forecaster", "transformer"])
-        assert len(multi) == 36  # 7 forecasters + 29 transformers  (class_proba scorers not included)
+        assert len(multi) == 40  # 7 forecasters + 33 transformers  (class_proba scorers not included)
 
     def test_all_estimators_invalid_filter(self):
         """Test invalid filter raises error with proper message."""


### PR DESCRIPTION
## Description

Add four stateless time-derived feature transformers for extracting features from the `"time"` column:

- `CalendarFeatureTransformer`: extract calendar features (month, day_of_week, etc.) with auto-detection based on time interval
- `HolidayFeatureTransformer`: binary holiday indicator with optional `days_to_next`/`days_since_last` proximity features
- `FourierFeatureTransformer`: sin/cos harmonics at a specified seasonal period with Nyquist validation
- `TimeIndexTransformer`: numeric time index with optional normalization and polynomial terms

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

These transformers fill the gap for time-derived feature engineering in yohou. Calendar, holiday, Fourier, and trend index features are fundamental inputs for reduction forecasters and were previously only achievable via `FunctionTransformer`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

- Also adds `statsmodels>=0.14` to the `examples` dependency group and PEP 723 metadata for 4 existing notebooks that use PACF/STL plotting functions.
