### PR TITLE
feat(point,preprocessing): add MeanSeasonalNaive and MeanLagTransformer

### DIFF
--- a/src/yohou/point/__init__.py
+++ b/src/yohou/point/__init__.py
@@ -1,11 +1,12 @@
 """Point forecasters for generating single-valued predictions."""
 
 from .base import BasePointForecaster
-from .naive import SeasonalNaive
+from .naive import MeanSeasonalNaive, SeasonalNaive
 from .reduction import PointReductionForecaster
 
 __all__ = [
     "BasePointForecaster",
+    "MeanSeasonalNaive",
     "PointReductionForecaster",
     "SeasonalNaive",
 ]

--- a/src/yohou/point/naive.py
+++ b/src/yohou/point/naive.py
@@ -1,4 +1,4 @@
-"""Implementation of seasonal naive forecaster."""
+"""Implementation of seasonal naive forecasters."""
 
 import numbers
 from typing import Literal
@@ -12,7 +12,7 @@ from yohou.utils._compat import Interval, _fit_context
 from ..utils.tags import Tags
 from .base import BasePointForecaster
 
-__all__ = ["SeasonalNaive"]
+__all__ = ["MeanSeasonalNaive", "SeasonalNaive"]
 
 
 class SeasonalNaive(BasePointForecaster):
@@ -61,6 +61,7 @@ class SeasonalNaive(BasePointForecaster):
 
     See Also
     --------
+    `MeanSeasonalNaive` : Averages multiple past seasonal cycles.
     `PointReductionForecaster` : ML-based point forecaster.
 
     """
@@ -185,6 +186,242 @@ class SeasonalNaive(BasePointForecaster):
 
                 if self.fit_forecasting_horizon_ > self.seasonality:
                     # Number of full repetitions needed
+                    n_repeats = (self.fit_forecasting_horizon_ + self.seasonality - 1) // self.seasonality
+                    y_pred_group = pl.concat([y_pred_group] * n_repeats)
+
+                y_pred_group = y_pred_group.head(self.fit_forecasting_horizon_)
+
+                # Rename columns to add panel prefix
+                y_pred_group = y_pred_group.rename({col: f"{panel_group_name}__{col}" for col in y_pred_group.columns})
+
+                y_pred.append(y_pred_group)
+
+            # Concatenate horizontally (side by side)
+            y_pred = pl.concat(y_pred, how="horizontal")
+
+        y_pred = self._add_time_columns(y_pred)
+
+        return y_pred
+
+
+class MeanSeasonalNaive(BasePointForecaster):
+    """Seasonal naive forecaster that averages values across past seasons.
+
+    Instead of repeating only the last seasonal cycle (as ``SeasonalNaive``
+    does), this forecaster averages the same position across ``n_seasons``
+    past cycles.  For example, with ``seasonality=7`` and ``n_seasons=3``,
+    the forecast for Monday is the mean of the last three observed Mondays.
+
+    Parameters
+    ----------
+    seasonality : int, default=1
+        The seasonal period length. For example, 7 for weekly seasonality
+        in daily data, or 12 for monthly seasonality in monthly data.
+    n_seasons : int, default=1
+        Number of past seasonal cycles to average over. When set to 1, the
+        behaviour is identical to ``SeasonalNaive``.
+    panel_strategy : {"global", "multivariate"}, default="global"
+        How to handle panel data. See ``BaseForecaster`` for details.
+
+    Attributes
+    ----------
+    interval_ : str
+        Detected time interval of the training data.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from datetime import datetime
+    >>> from yohou.point import MeanSeasonalNaive
+    >>>
+    >>> df = pl.DataFrame({
+    ...     "time": pl.datetime_range(
+    ...         start=datetime(2021, 1, 1),
+    ...         end=datetime(2021, 1, 12),
+    ...         interval="1d",
+    ...         eager=True,
+    ...     ),
+    ...     "value": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+    ... })
+    >>> forecaster = MeanSeasonalNaive(seasonality=3, n_seasons=2)
+    >>> _ = forecaster.fit(y=df, forecasting_horizon=3)
+    >>> y_pred = forecaster.predict(forecasting_horizon=3)
+    >>> len(y_pred)
+    3
+
+    Notes
+    -----
+    The forecaster stores the last ``seasonality * n_seasons`` observations.
+    These are reshaped into ``n_seasons`` groups of ``seasonality`` values
+    and the arithmetic mean is computed per position.  The resulting pattern
+    is repeated cyclically to fill the forecasting horizon.
+
+    When ``n_seasons=1`` the output is identical to ``SeasonalNaive`` and
+    the original column dtype is preserved.  When ``n_seasons > 1`` the
+    averaging produces ``Float64`` columns.
+
+    See Also
+    --------
+    `SeasonalNaive` : Repeats the last seasonal cycle without averaging.
+    `PointReductionForecaster` : ML-based point forecaster.
+
+    """
+
+    _parameter_constraints: dict = {
+        **BasePointForecaster._parameter_constraints,
+        "seasonality": [Interval(numbers.Integral, 1, None, closed="left")],
+        "n_seasons": [Interval(numbers.Integral, 1, None, closed="left")],
+    }
+
+    def __init__(
+        self,
+        seasonality: StrictInt = 1,
+        n_seasons: StrictInt = 1,
+        panel_strategy: Literal["global", "multivariate"] = "global",
+    ):
+        BasePointForecaster.__init__(
+            self,
+            feature_transformer=None,
+            target_transformer=None,
+            target_as_feature=None,
+            panel_strategy=panel_strategy,
+        )
+
+        self.seasonality = seasonality
+        self.n_seasons = n_seasons
+
+    def __sklearn_tags__(self) -> Tags:
+        """Get estimator tags.
+
+        Returns
+        -------
+        Tags
+            Estimator tags with yohou-specific attributes.
+
+        """
+        tags = super().__sklearn_tags__()
+        assert tags.forecaster_tags is not None
+        tags.forecaster_tags.ignores_exogenous = True
+        tags.forecaster_tags.stateful = True
+        return tags
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(
+        self,
+        y: pl.DataFrame,
+        X: pl.DataFrame | None = None,
+        forecasting_horizon: StrictInt = 1,
+        **params,
+    ) -> "BasePointForecaster":
+        """Fit the forecaster to historical data.
+
+        Stores the last ``seasonality * n_seasons`` observations for
+        averaging across seasonal cycles.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            Target time series with a ``"time"`` column (datetime) and one
+            or more numeric value columns.
+        X : pl.DataFrame or None, default=None
+            Exogenous features with a ``"time"`` column matching ``y``.
+            If ``None``, no exogenous features are used.
+        forecasting_horizon : int, default=1
+            Number of time steps to forecast into the future.
+        **params : dict
+            Metadata to route to nested estimators.
+
+        Returns
+        -------
+        self
+            The fitted forecaster instance.
+
+        Raises
+        ------
+        ValueError
+            If ``y`` has fewer rows than ``seasonality * n_seasons``.
+
+        """
+        self._observation_horizon = self.seasonality * self.n_seasons
+
+        BasePointForecaster.fit(
+            self,
+            y=y,
+            X=X,
+            forecasting_horizon=forecasting_horizon,
+            **params,
+        )
+
+        return self
+
+    def _compute_mean_pattern(self, y_values: pl.DataFrame) -> pl.DataFrame:
+        """Compute the mean seasonal pattern from observed values.
+
+        Parameters
+        ----------
+        y_values : pl.DataFrame
+            Observed values (excluding the "time" column) with exactly
+            ``seasonality * n_seasons`` rows.
+
+        Returns
+        -------
+        pl.DataFrame
+            DataFrame with ``seasonality`` rows containing the averaged
+            pattern.
+
+        """
+        if self.n_seasons == 1:
+            return y_values
+
+        result = {}
+        for col in y_values.columns:
+            values = y_values[col].to_numpy().reshape(self.n_seasons, self.seasonality)
+            result[col] = values.mean(axis=0).tolist()
+        return pl.DataFrame(result)
+
+    def _predict_one(
+        self,
+        groups: list[str],
+        **params,
+    ) -> pl.DataFrame:
+        """Predict ``fit_forecasting_horizon_`` steps from the observation horizon.
+
+        Parameters
+        ----------
+        groups : list of str
+            Panel group names to predict for.
+        **params : dict
+            Metadata to route to nested estimators.
+
+        Returns
+        -------
+        pl.DataFrame
+            Predicted time series.
+
+        """
+        # Non-panel data
+        if self.groups_ is None:
+            assert isinstance(self._y_observed, pl.DataFrame)
+            y_values = self._y_observed.select(~cs.by_name("time"))
+            y_pred = self._compute_mean_pattern(y_values)
+
+            if self.fit_forecasting_horizon_ > self.seasonality:
+                n_repeats = int((self.fit_forecasting_horizon_ + self.seasonality - 1) // self.seasonality)
+                y_pred = pl.concat([y_pred] * n_repeats)
+
+            y_pred = y_pred.head(self.fit_forecasting_horizon_)
+
+        # Panel data
+        else:
+            assert isinstance(self._y_observed, dict)
+            y_pred = []
+            for panel_group_name in groups:
+                y_group = self._y_observed[panel_group_name]
+                assert isinstance(y_group, pl.DataFrame)
+                y_values = y_group.select(~cs.by_name("time"))
+                y_pred_group = self._compute_mean_pattern(y_values)
+
+                if self.fit_forecasting_horizon_ > self.seasonality:
                     n_repeats = (self.fit_forecasting_horizon_ + self.seasonality - 1) // self.seasonality
                     y_pred_group = pl.concat([y_pred_group] * n_repeats)
 

--- a/src/yohou/preprocessing/__init__.py
+++ b/src/yohou/preprocessing/__init__.py
@@ -40,6 +40,7 @@ from .time_features import FourierFeatureTransformer, TimeIndexTransformer
 from .window import (
     ExponentialMovingAverage,
     LagTransformer,
+    MeanLagTransformer,
     RollingStatisticsTransformer,
     SlidingWindowFunctionTransformer,
 )
@@ -59,6 +60,7 @@ __all__ = [
     "Upsampler",
     # Windowing
     "LagTransformer",
+    "MeanLagTransformer",
     # Sklearn scalers
     "SklearnScaler",
     "StandardScaler",

--- a/src/yohou/preprocessing/window.py
+++ b/src/yohou/preprocessing/window.py
@@ -16,6 +16,7 @@ from yohou.utils.tags import Tags
 __all__ = [
     "ExponentialMovingAverage",
     "LagTransformer",
+    "MeanLagTransformer",
     "RollingStatisticsTransformer",
     "SlidingWindowFunctionTransformer",
 ]
@@ -63,6 +64,7 @@ class LagTransformer(BaseTransformer):
 
     See Also
     --------
+    `MeanLagTransformer` : Averages multiple lag multiples into a single feature.
     `RollingStatisticsTransformer` : Compute rolling statistics (mean, std, etc.).
     `SlidingWindowFunctionTransformer` : Apply custom functions to sliding windows.
     `tabularize` : Underlying tabularization function.
@@ -175,6 +177,194 @@ class LagTransformer(BaseTransformer):
         """
         input_features = _check_feature_names_in(self, input_features)
         feature_names = [f"{col}_lag_{lag}" for col in input_features for lag in self.lags_]
+
+        arr: list[str] = np.asarray(feature_names, dtype=object).tolist()
+        return arr
+
+
+class MeanLagTransformer(BaseTransformer):
+    """Create mean-lagged features by averaging across lag multiples.
+
+    For each input column and each base lag ``k``, this transformer computes
+    the arithmetic mean of the column shifted by ``k, 2k, ..., n_lags * k``
+    time steps.  This captures averaged seasonal patterns as features for
+    supervised learning.
+
+    Parameters
+    ----------
+    lag : int >= 1 or list of ints >= 1, default=1
+        Base lag(s) to create. Can be a single integer or a list of integers.
+        Each lag value must be >= 1.
+    n_lags : int >= 1, default=1
+        Number of lag multiples to average. For a base lag ``k`` the shifts
+        ``k, 2k, ..., n_lags * k`` are averaged. When ``n_lags=1`` the output
+        is a single shift (equivalent to ``LagTransformer``).
+
+    Attributes
+    ----------
+    lags_ : list of int
+        Effective list of base lags used for transformation.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from datetime import datetime
+    >>> from yohou.preprocessing import MeanLagTransformer
+
+    >>> # Create sample data
+    >>> X = pl.DataFrame({
+    ...     "time": [datetime(2020, 1, i) for i in range(1, 13)],
+    ...     "value": list(range(12)),
+    ... })
+
+    >>> # Average lag-3 and lag-6 into a single feature
+    >>> transformer = MeanLagTransformer(lag=3, n_lags=2)
+    >>> transformer.fit(X)  # doctest: +ELLIPSIS
+    MeanLagTransformer(...)
+    >>> X_t = transformer.transform(X)
+    >>> X_t.columns
+    ['time', 'value_mean_lag_3']
+    >>> len(X_t)  # First 6 rows dropped (max(lag) * n_lags = 6)
+    6
+
+    See Also
+    --------
+    `LagTransformer` : Creates individual lag features without averaging.
+    `RollingStatisticsTransformer` : Compute rolling statistics over consecutive windows.
+
+    Notes
+    -----
+    For a base lag ``k`` and ``n_lags=3``, the output at time ``t`` is
+    ``mean(x[t-k], x[t-2k], x[t-3k])``.  This differs from
+    ``RollingStatisticsTransformer`` which uses consecutive time steps
+    rather than seasonal multiples.
+
+    The first ``max(lags) * n_lags`` rows are dropped because they contain
+    incomplete lookback windows, setting
+    ``observation_horizon = max(lags) * n_lags``.
+
+    When ``n_lags=1`` the output values are identical to ``LagTransformer``
+    and the original column dtype is preserved.  When ``n_lags > 1`` the
+    averaging produces ``Float64`` columns.
+
+    Output column names follow the pattern ``{input_col}_mean_lag_{k}``.
+
+    """
+
+    _parameter_constraints: dict = {
+        **BaseTransformer._parameter_constraints,
+        "lag": [Interval(numbers.Integral, 1, None, closed="left"), list],
+        "n_lags": [Interval(numbers.Integral, 1, None, closed="left")],
+    }
+
+    def __init__(self, lag: StrictInt | list[StrictInt] = 1, n_lags: StrictInt = 1):
+        self.lag = lag
+        self.n_lags = n_lags
+
+    def __sklearn_tags__(self) -> Tags:
+        """Get estimator tags.
+
+        Returns
+        -------
+        Tags
+            Estimator tags with yohou-specific attributes.
+
+        """
+        tags = super().__sklearn_tags__()
+        assert tags.transformer_tags is not None
+        tags.transformer_tags.stateful = True
+        return tags
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X: pl.DataFrame, y: pl.DataFrame | None = None, **params) -> "MeanLagTransformer":
+        """Fit the transformer to input data.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            Input time series with a ``"time"`` column (datetime) and one or
+            more numeric columns.
+
+        y : pl.DataFrame or None, default=None
+            Ignored.  Present for API compatibility with yohou pipelines.
+
+        **params : dict
+            Metadata to route to nested estimators.
+
+        Returns
+        -------
+        self
+            The fitted transformer instance.
+
+        Raises
+        ------
+        ValueError
+            If ``X`` has fewer rows than ``max(lags) * n_lags``.
+
+        """
+        self.lags_: list[int] = self.lag if isinstance(self.lag, list) else [self.lag]
+
+        self._observation_horizon = max(self.lags_) * self.n_lags
+        X = validate_transformer_data(self, X=X, reset=True)
+
+        BaseTransformer.fit(self, X, y, **params)
+
+        return self
+
+    def transform(self, X: pl.DataFrame, **params) -> pl.DataFrame:
+        """Transform the input time series.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            Input time series with a ``"time"`` column (datetime) and one or
+            more numeric columns.
+        **params : dict
+            Metadata to route to nested estimators.
+
+        Returns
+        -------
+        pl.DataFrame
+            Transformed time series with a ``"time"`` column and
+            ``{col}_mean_lag_{k}`` columns.
+
+        """
+        check_is_fitted(self, ["X_schema_", "feature_names_in_", "n_features_in_"])
+        X = validate_transformer_data(self, X=X, reset=False, check_continuity=False)
+
+        data_cols = [c for c in X.columns if c != "time"]
+
+        exprs: list[pl.Expr] = [pl.col("time")]
+        for col in data_cols:
+            for lag in self.lags_:
+                if self.n_lags == 1:
+                    exprs.append(pl.col(col).shift(lag).alias(f"{col}_mean_lag_{lag}"))
+                else:
+                    shifted = [pl.col(col).shift(lag * j) for j in range(1, self.n_lags + 1)]
+                    exprs.append(pl.mean_horizontal(*shifted).alias(f"{col}_mean_lag_{lag}"))
+
+        X_t = X.select(exprs)
+        X_t = X_t[self._observation_horizon :]
+
+        return X_t
+
+    def get_feature_names_out(self, input_features: list[str] | None = None) -> list[str]:
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Column names of the input features.  If ``None``, uses the
+            feature names seen during ``fit``.
+
+        Returns
+        -------
+        list of str
+            Output feature names after transformation.
+
+        """
+        input_features = _check_feature_names_in(self, input_features)
+        feature_names = [f"{col}_mean_lag_{lag}" for col in input_features for lag in self.lags_]
 
         arr: list[str] = np.asarray(feature_names, dtype=object).tolist()
         return arr

--- a/tests/point/test_naive.py
+++ b/tests/point/test_naive.py
@@ -8,7 +8,7 @@ from sklearn.base import clone
 from sklearn.model_selection import train_test_split
 
 from conftest import run_checks
-from yohou.point import SeasonalNaive
+from yohou.point import MeanSeasonalNaive, SeasonalNaive
 from yohou.testing import _yield_yohou_forecaster_checks
 
 
@@ -146,5 +146,168 @@ class TestSeasonalNaiveWithoutExogenous:
     def test_ignores_exogenous_tag(self):
         """SeasonalNaive should have ignores_exogenous=True tag."""
         forecaster = SeasonalNaive(seasonality=3)
+        tags = forecaster.__sklearn_tags__()
+        assert tags.forecaster_tags.ignores_exogenous is True
+
+
+@pytest.fixture(scope="module")
+def mean_naive_data():
+    """Deterministic data shared by MeanSeasonalNaive tests (longer than naive_data)."""
+    length = 50
+    y = pl.DataFrame({
+        "time": pl.datetime_range(
+            start=datetime(2021, 12, 16),
+            end=datetime(2021, 12, 16, 0, 0, length - 1),
+            interval="1s",
+            eager=True,
+        ),
+        "a": [float(i) for i in range(length)],
+        "b": [float(i) for i in range(10, length + 10)],
+    })
+    X = pl.DataFrame({
+        "time": pl.datetime_range(
+            start=datetime(2021, 12, 16),
+            end=datetime(2021, 12, 16, 0, 0, length - 1),
+            interval="1s",
+            eager=True,
+        ),
+        "c": range(length),
+        "d": range(10, length + 10),
+        "e": range(20, length + 20),
+    })
+    return y, X
+
+
+class TestMeanSeasonalNaive:
+    @pytest.mark.parametrize(
+        "forecaster,expected_failures",
+        [
+            (
+                MeanSeasonalNaive(seasonality=1, n_seasons=1),
+                [],
+            ),
+            (
+                MeanSeasonalNaive(seasonality=3, n_seasons=3),
+                [],
+            ),
+        ],
+    )
+    def test_mean_seasonal_naive_checks(self, forecaster, expected_failures, y_X_factory):
+        """Run systematic checks on MeanSeasonalNaive forecaster."""
+        y, X = y_X_factory(length=200, seed=42)
+        y_train, y_test = y[:160], y[160:]
+        X_train, X_test = (X[:160], X[160:]) if X is not None else (None, None)
+
+        forecaster_fitted = clone(forecaster)
+        forecaster_fitted.fit(y_train, X_train, forecasting_horizon=3)
+
+        run_checks(
+            forecaster_fitted,
+            _yield_yohou_forecaster_checks(forecaster_fitted, y_train, X_train, y_test, X_test),
+            expected_failures=set(expected_failures),
+        )
+
+    @pytest.mark.parametrize(
+        "seasonality, n_seasons, fit_fh, predict_fh, expected_a",
+        [
+            # n_seasons=1 should match SeasonalNaive exactly (dtype preserved)
+            # train has 40 rows (a=0.0..39.0), last 1 value = [39.0]
+            (1, 1, 5, 5, [39.0, 39.0, 39.0, 39.0, 39.0]),
+            # seasonality=2, n_seasons=1: last 2 = [38.0, 39.0]
+            (2, 1, 5, 5, [38.0, 39.0, 38.0, 39.0, 38.0]),
+            # seasonality=2, n_seasons=2: last 4 = [36.0,37.0,38.0,39.0]
+            #   reshape [[36,37],[38,39]], mean = [37.0, 38.0]
+            (2, 2, 5, 5, [37.0, 38.0, 37.0, 38.0, 37.0]),
+            # seasonality=3, n_seasons=2: last 6 = [34.0,35.0,36.0,37.0,38.0,39.0]
+            #   reshape [[34,35,36],[37,38,39]], mean = [35.5, 36.5, 37.5]
+            (3, 2, 5, 5, [35.5, 36.5, 37.5, 35.5, 36.5]),
+            # seasonality=3, n_seasons=3: last 9 = [31.0..39.0]
+            #   reshape [[31,32,33],[34,35,36],[37,38,39]], mean = [34.0, 35.0, 36.0]
+            (3, 3, 3, 3, [34.0, 35.0, 36.0]),
+            # predict_fh < seasonality
+            (3, 2, 3, 2, [35.5, 36.5]),
+        ],
+    )
+    def test_predict(self, seasonality, n_seasons, fit_fh, predict_fh, expected_a, mean_naive_data):
+        """Test specific prediction behavior of MeanSeasonalNaive."""
+        y, X = mean_naive_data
+        y_train, y_test, X_train, X_test = train_test_split(y, X, test_size=0.2, shuffle=False)
+        forecaster = MeanSeasonalNaive(seasonality=seasonality, n_seasons=n_seasons)
+
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=fit_fh)
+
+        y_pred = forecaster.predict(forecasting_horizon=predict_fh)
+
+        expected_b = [a + 10 for a in expected_a]
+
+        expected_y_pred = pl.DataFrame({
+            "vintage_time": [y_train["time"][-1]] * predict_fh,
+            "time": pl.datetime_range(
+                start=datetime(2021, 12, 16, 0, 0, len(y_train)),
+                end=datetime(2021, 12, 16, 0, 0, len(y_train) + predict_fh - 1),
+                interval="1s",
+                eager=True,
+            ),
+            "a": expected_a,
+            "b": expected_b,
+        })
+        pl.testing.assert_frame_equal(y_pred, expected_y_pred)
+
+    def test_n_seasons_1_matches_seasonal_naive(self, mean_naive_data):
+        """MeanSeasonalNaive(n_seasons=1) should produce identical output to SeasonalNaive."""
+        y, X = mean_naive_data
+        y_train, _, X_train, _ = train_test_split(y, X, test_size=0.2, shuffle=False)
+
+        for seasonality in [1, 3, 7]:
+            naive = SeasonalNaive(seasonality=seasonality)
+            naive.fit(y=y_train, X=X_train, forecasting_horizon=5)
+            y_naive = naive.predict(forecasting_horizon=5)
+
+            mean_naive = MeanSeasonalNaive(seasonality=seasonality, n_seasons=1)
+            mean_naive.fit(y=y_train, X=X_train, forecasting_horizon=5)
+            y_mean = mean_naive.predict(forecasting_horizon=5)
+
+            pl.testing.assert_frame_equal(y_mean, y_naive)
+
+
+class TestMeanSeasonalNaiveWithoutExogenous:
+    """Tests for MeanSeasonalNaive with X=None throughout the lifecycle."""
+
+    def test_fit_predict_without_exogenous(self, mean_naive_data):
+        """MeanSeasonalNaive should work without exogenous features."""
+        y, _ = mean_naive_data
+        forecaster = MeanSeasonalNaive(seasonality=3, n_seasons=2)
+        forecaster.fit(y[:40], X=None, forecasting_horizon=3)
+        y_pred = forecaster.predict(forecasting_horizon=3)
+
+        assert isinstance(y_pred, pl.DataFrame)
+        assert "time" in y_pred.columns
+        assert len(y_pred) == 3
+
+    def test_observe_predict_without_exogenous(self, mean_naive_data):
+        """MeanSeasonalNaive observe_predict should work without exogenous features."""
+        y, _ = mean_naive_data
+        forecaster = MeanSeasonalNaive(seasonality=3, n_seasons=2)
+        forecaster.fit(y[:40], X=None, forecasting_horizon=3)
+        y_pred = forecaster.observe_predict(y[40:42], X=None)
+
+        assert isinstance(y_pred, pl.DataFrame)
+        assert "time" in y_pred.columns
+
+    def test_rewind_without_exogenous(self, mean_naive_data):
+        """MeanSeasonalNaive rewind should work without exogenous features."""
+        y, _ = mean_naive_data
+        forecaster = MeanSeasonalNaive(seasonality=3, n_seasons=2)
+        forecaster.fit(y[:40], X=None, forecasting_horizon=3)
+        forecaster.observe(y[40:42], X=None)
+        forecaster.rewind(y[:40], X=None)
+        y_pred = forecaster.predict(forecasting_horizon=3)
+
+        assert isinstance(y_pred, pl.DataFrame)
+        assert len(y_pred) == 3
+
+    def test_ignores_exogenous_tag(self):
+        """MeanSeasonalNaive should have ignores_exogenous=True tag."""
+        forecaster = MeanSeasonalNaive(seasonality=3, n_seasons=2)
         tags = forecaster.__sklearn_tags__()
         assert tags.forecaster_tags.ignores_exogenous is True

--- a/tests/point/test_naive.py
+++ b/tests/point/test_naive.py
@@ -150,6 +150,53 @@ class TestSeasonalNaiveWithoutExogenous:
         assert tags.forecaster_tags.ignores_exogenous is True
 
 
+class TestSeasonalNaivePanel:
+    """Tests for SeasonalNaive with panel data."""
+
+    def test_panel_predict(self):
+        """Panel predict produces correct columns and repeats seasonal pattern."""
+        length = 20
+        y = pl.DataFrame({
+            "time": pl.datetime_range(
+                start=datetime(2021, 1, 1),
+                end=datetime(2021, 1, 1, 0, 0, length - 1),
+                interval="1s",
+                eager=True,
+            ),
+            "grp__a": list(range(length)),
+            "grp__b": list(range(10, length + 10)),
+        })
+        forecaster = SeasonalNaive(seasonality=3)
+        forecaster.fit(y=y[:15], forecasting_horizon=5)
+        y_pred = forecaster.predict(forecasting_horizon=5)
+
+        assert "grp__a" in y_pred.columns
+        assert "grp__b" in y_pred.columns
+        assert len(y_pred) == 5
+        # Last 3 values: [12, 13, 14], repeated => [12, 13, 14, 12, 13]
+        assert y_pred["grp__a"].to_list() == [12, 13, 14, 12, 13]
+
+    def test_panel_predict_fh_less_than_seasonality(self):
+        """Panel predict works when fh <= seasonality (no repetition needed)."""
+        length = 20
+        y = pl.DataFrame({
+            "time": pl.datetime_range(
+                start=datetime(2021, 1, 1),
+                end=datetime(2021, 1, 1, 0, 0, length - 1),
+                interval="1s",
+                eager=True,
+            ),
+            "grp__a": list(range(length)),
+        })
+        forecaster = SeasonalNaive(seasonality=5)
+        forecaster.fit(y=y[:15], forecasting_horizon=3)
+        y_pred = forecaster.predict(forecasting_horizon=3)
+
+        assert len(y_pred) == 3
+        # Last 5 values: [10, 11, 12, 13, 14], take first 3 => [10, 11, 12]
+        assert y_pred["grp__a"].to_list() == [10, 11, 12]
+
+
 @pytest.fixture(scope="module")
 def mean_naive_data():
     """Deterministic data shared by MeanSeasonalNaive tests (longer than naive_data)."""
@@ -311,3 +358,53 @@ class TestMeanSeasonalNaiveWithoutExogenous:
         forecaster = MeanSeasonalNaive(seasonality=3, n_seasons=2)
         tags = forecaster.__sklearn_tags__()
         assert tags.forecaster_tags.ignores_exogenous is True
+
+
+class TestMeanSeasonalNaivePanel:
+    """Tests for MeanSeasonalNaive with panel data."""
+
+    @pytest.fixture()
+    def panel_y(self):
+        """Panel y with two groups, each with two series."""
+        length = 30
+        return pl.DataFrame({
+            "time": pl.datetime_range(
+                start=datetime(2021, 1, 1),
+                end=datetime(2021, 1, 1, 0, 0, length - 1),
+                interval="1s",
+                eager=True,
+            ),
+            "grp__a": [float(i) for i in range(length)],
+            "grp__b": [float(i + 10) for i in range(length)],
+        })
+
+    def test_panel_predict(self, panel_y):
+        """Panel predict produces correct columns and length."""
+        forecaster = MeanSeasonalNaive(seasonality=3, n_seasons=2)
+        forecaster.fit(y=panel_y[:24], forecasting_horizon=3)
+        y_pred = forecaster.predict(forecasting_horizon=3)
+
+        assert "grp__a" in y_pred.columns
+        assert "grp__b" in y_pred.columns
+        assert len(y_pred) == 3
+
+    def test_panel_predict_with_repeat(self, panel_y):
+        """Panel predict repeats the seasonal pattern when fh > seasonality."""
+        forecaster = MeanSeasonalNaive(seasonality=2, n_seasons=2)
+        forecaster.fit(y=panel_y[:24], forecasting_horizon=5)
+        y_pred = forecaster.predict(forecasting_horizon=5)
+
+        assert len(y_pred) == 5
+        assert "grp__a" in y_pred.columns
+        # Last 4 values: [20,21,22,23], reshape [[20,21],[22,23]], mean=[21,22]
+        # Repeated: [21,22,21,22,21]
+        assert y_pred["grp__a"].to_list() == [21.0, 22.0, 21.0, 22.0, 21.0]
+
+    def test_panel_observe_predict(self, panel_y):
+        """Panel observe_predict works correctly."""
+        forecaster = MeanSeasonalNaive(seasonality=3, n_seasons=2)
+        forecaster.fit(y=panel_y[:24], forecasting_horizon=3)
+        y_pred = forecaster.observe_predict(panel_y[24:26])
+
+        assert isinstance(y_pred, pl.DataFrame)
+        assert "grp__a" in y_pred.columns

--- a/tests/preprocessing/test_window.py
+++ b/tests/preprocessing/test_window.py
@@ -14,6 +14,7 @@ from sklearn.base import clone
 from conftest import run_checks
 from yohou.preprocessing.window import (
     LagTransformer,
+    MeanLagTransformer,
     RollingStatisticsTransformer,
     SlidingWindowFunctionTransformer,
 )
@@ -496,6 +497,146 @@ class TestRollingStatisticsTransformerSklearn:
 
         assert cloned.window_size == transformer.window_size
         assert cloned.statistics == transformer.statistics
+
+
+class TestMeanLagTransformerSystematic:
+    """Systematic checks for MeanLagTransformer."""
+
+    @pytest.mark.parametrize(
+        "lag,n_lags",
+        [([1], 2), ([1, 2], 3)],
+        ids=["lag_1_nlags_2", "lag_1_2_nlags_3"],
+    )
+    def test_systematic_checks(self, lag, n_lags, time_series_train_test_factory):
+        """Run all checks for MeanLagTransformer with different configurations."""
+        transformer = MeanLagTransformer(lag=lag, n_lags=n_lags)
+        expected_failures = []
+
+        min_horizon = max(lag) * n_lags + 10
+        X_train, X_test = time_series_train_test_factory(train_length=min_horizon + 50, test_length=min_horizon + 20)
+
+        transformer_fitted = clone(transformer)
+        transformer_fitted.fit(X_train)
+
+        run_checks(
+            transformer_fitted,
+            _yield_yohou_transformer_checks(transformer_fitted, X_train, None, X_test),
+            expected_failures=set(expected_failures),
+        )
+
+
+class TestMeanLagTransformer:
+    """Functional tests for MeanLagTransformer."""
+
+    def test_feature_names(self, time_series_factory):
+        """Test MeanLagTransformer generates correct feature names."""
+        X = time_series_factory(length=50, n_components=2)
+        transformer = MeanLagTransformer(lag=[1, 2], n_lags=2)
+        transformer.fit(X)
+
+        transformer.transform(X)
+        feature_names = transformer.get_feature_names_out()
+
+        # Should have mean_lag_1 and mean_lag_2 for each input feature
+        expected_n_features = 2 * 2  # 2 features * 2 lags
+        assert len(feature_names) == expected_n_features
+
+        # Check feature naming pattern
+        assert all("mean_lag" in name for name in feature_names)
+
+    def test_observation_horizon(self, time_series_factory):
+        """Test observation_horizon equals max(lag) * n_lags."""
+        X = time_series_factory(length=100)
+
+        for lag, n_lags in [([1], 1), ([1, 2], 3), ([1, 5, 10], 2)]:
+            transformer = MeanLagTransformer(lag=lag, n_lags=n_lags)
+            transformer.fit(X)
+
+            expected_horizon = max(lag) * n_lags
+            assert transformer.observation_horizon == expected_horizon, (
+                f"For lag={lag}, n_lags={n_lags}, expected horizon={expected_horizon}, got {transformer.observation_horizon}"
+            )
+
+    def test_output_length(self, time_series_factory):
+        """Test output length drops max(lag) * n_lags rows."""
+        X = time_series_factory(length=50)
+        transformer = MeanLagTransformer(lag=[1, 2, 3], n_lags=2)
+        transformer.fit(X)
+
+        X_trans = transformer.transform(X)
+
+        expected_length = len(X) - max([1, 2, 3]) * 2
+        assert len(X_trans) == expected_length
+
+    def test_n_lags_1_equivalence(self, time_series_factory):
+        """With n_lags=1, values should match LagTransformer (different column names, same dtype)."""
+        X = time_series_factory(length=50, n_components=2)
+
+        for lag in [[1], [1, 2], [3]]:
+            lag_t = LagTransformer(lag=lag)
+            lag_t.fit(X)
+            X_lag = lag_t.transform(X)
+
+            mean_t = MeanLagTransformer(lag=lag, n_lags=1)
+            mean_t.fit(X)
+            X_mean = mean_t.transform(X)
+
+            # Same number of rows and columns (excluding time)
+            assert len(X_mean) == len(X_lag)
+            lag_cols = [c for c in X_lag.columns if c != "time"]
+            mean_cols = [c for c in X_mean.columns if c != "time"]
+            assert len(lag_cols) == len(mean_cols)
+
+            # Values should match (compare column by column, names differ)
+            for lag_col, mean_col in zip(lag_cols, mean_cols, strict=True):
+                assert X_lag[lag_col].to_list() == X_mean[mean_col].to_list()
+                assert X_lag[lag_col].dtype == X_mean[mean_col].dtype
+
+    def test_mean_values(self):
+        """Test that averaging produces correct values with known data."""
+        time = [datetime(2021, 1, 1) + timedelta(days=i) for i in range(20)]
+        X = pl.DataFrame({
+            "time": time,
+            "x": list(range(20)),
+        })
+
+        # lag=3, n_lags=2: mean of shift(3) and shift(6)
+        transformer = MeanLagTransformer(lag=3, n_lags=2)
+        transformer.fit(X)
+        X_t = transformer.transform(X)
+
+        # observation_horizon = 3*2 = 6, output starts at row 6
+        assert len(X_t) == 14
+        # row 6 (x=6): mean(x[3], x[0]) = mean(3, 0) = 1.5
+        # row 7 (x=7): mean(x[4], x[1]) = mean(4, 1) = 2.5
+        # row 8 (x=8): mean(x[5], x[2]) = mean(5, 2) = 3.5
+        expected = [1.5, 2.5, 3.5, 4.5, 5.5]
+        assert X_t["x_mean_lag_3"][:5].to_list() == expected
+
+    def test_with_panel_data(self, panel_time_series_factory):
+        """Test MeanLagTransformer handles panel data."""
+        X_panel = panel_time_series_factory(length=50, n_series=3, n_global=2)
+        transformer = MeanLagTransformer(lag=[1, 2], n_lags=2)
+
+        transformer.fit(X_panel)
+        X_trans = transformer.transform(X_panel)
+
+        assert "time" in X_trans.columns
+        expected_length = len(X_panel) - max([1, 2]) * 2
+        assert len(X_trans) == expected_length
+
+    def test_insufficient_data_raises(self):
+        """Test that fitting with insufficient data raises ValueError."""
+        time = [datetime(2021, 1, 1) + timedelta(days=i) for i in range(5)]
+        X = pl.DataFrame({
+            "time": time,
+            "x": list(range(5)),
+        })
+
+        # observation_horizon = 3*3 = 9 > 5 rows
+        transformer = MeanLagTransformer(lag=3, n_lags=3)
+        with pytest.raises(ValueError):
+            transformer.fit(X)
 
 
 class TestWindowTransformersIntegration:

--- a/tests/utils/test_discovery.py
+++ b/tests/utils/test_discovery.py
@@ -18,17 +18,17 @@ class TestAllEstimators:
     def test_all_estimators_total_count(self):
         """Test all_estimators returns correct total count."""
         estimators = all_estimators()
-        assert len(estimators) == 82
+        assert len(estimators) == 84
 
     def test_all_estimators_forecaster_filter(self):
         """Test forecaster type filter (matches estimator_type == 'forecaster')."""
         forecasters = all_estimators(type_filter="forecaster")
-        assert len(forecasters) == 7
+        assert len(forecasters) == 8
 
     def test_all_estimators_point_filter(self):
         """Test point forecaster sub-type filter."""
         points = all_estimators(type_filter="point")
-        assert len(points) == 5
+        assert len(points) == 6
 
     def test_all_estimators_interval_filter(self):
         """Test interval forecaster sub-type filter."""
@@ -43,7 +43,7 @@ class TestAllEstimators:
     def test_all_estimators_transformer_filter(self):
         """Test transformer type filter."""
         transformers = all_estimators(type_filter="transformer")
-        assert len(transformers) == 33
+        assert len(transformers) == 34
 
     def test_all_estimators_splitter_filter(self):
         """Test splitter type filter."""
@@ -53,7 +53,7 @@ class TestAllEstimators:
     def test_all_estimators_multiple_filters(self):
         """Test multiple type filters combined."""
         multi = all_estimators(type_filter=["forecaster", "transformer"])
-        assert len(multi) == 40  # 7 forecasters + 33 transformers  (class_proba scorers not included)
+        assert len(multi) == 42  # 8 forecasters + 34 transformers  (class_proba scorers not included)
 
     def test_all_estimators_invalid_filter(self):
         """Test invalid filter raises error with proper message."""


### PR DESCRIPTION
## Description

Add `MeanSeasonalNaive` point forecaster and `MeanLagTransformer` preprocessing transformer.

`MeanSeasonalNaive` averages values across multiple past seasonal cycles instead of repeating only the last cycle (as `SeasonalNaive` does). `MeanLagTransformer` averages multiple lag multiples into a single feature per base lag.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Seasonal averaging produces more robust forecasts and features than single-cycle repetition, especially in noisy data.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings