### PR TITLE
refactor!: remove gap parameter from splitters

### DIFF
--- a/examples/model_selection/cv_splitters.py
+++ b/examples/model_selection/cv_splitters.py
@@ -34,7 +34,6 @@ def _(mo):
 
     - [`ExpandingWindowSplitter`](/pages/api/generated/yohou.model_selection.split.ExpandingWindowSplitter/): Growing training window
     - [`SlidingWindowSplitter`](/pages/api/generated/yohou.model_selection.split.SlidingWindowSplitter/): Fixed-size sliding window
-    - Controlling `gap` between train and test
     - Visualizing splits with [`plot_splits`](/pages/api/generated/yohou.plotting.model_selection.plot_splits/)
 
     ## Prerequisites
@@ -152,27 +151,7 @@ def _(plot_splits, sliding, y):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## 4. Using `gap` to Simulate Forecast Delay
-
-    In practice, there's often a gap between the last known observation and when
-    forecasts are needed. The `gap` parameter simulates this.
-    """)
-
-
-@app.cell
-def _(ExpandingWindowSplitter, plot_splits, y):
-    expanding_gap = ExpandingWindowSplitter(n_splits=3, test_size=12, gap=6)
-
-    for _i, (_train_idx, _test_idx) in enumerate(expanding_gap.split(y)):
-        print(f"  Split {_i}: train ends at {_train_idx[-1]}, test starts at {_test_idx[0]} (gap=6)")
-
-    plot_splits(y, expanding_gap, title="Expanding Window with gap=6")
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 5. Controlling Window Size
+    ## 4. Controlling Window Size
 
     `max_train_size` on [`ExpandingWindowSplitter`](/pages/api/generated/yohou.model_selection.split.ExpandingWindowSplitter/) limits growth, effectively
     becoming a sliding window that fills up from the expanding start.
@@ -192,7 +171,7 @@ def _(ExpandingWindowSplitter, plot_splits, y):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## 6. SlidingWindowSplitter with Stride
+    ## 5. SlidingWindowSplitter with Stride
 
     `stride` controls how many observations the window advances between splits.
     Default is `test_size` (non-overlapping test sets).
@@ -214,7 +193,6 @@ def _(mo):
 
     - [`ExpandingWindowSplitter`](/pages/api/generated/yohou.model_selection.split.ExpandingWindowSplitter/): Training window grows: uses all historical data
     - [`SlidingWindowSplitter`](/pages/api/generated/yohou.model_selection.split.SlidingWindowSplitter/): Fixed training window: focuses on recent data
-    - `gap`: Simulates forecast delay between train and test periods
     - `max_train_size`: Caps expanding window growth
     - `stride`: Controls step size between splits (for overlapping test sets)
     - [`plot_splits`](/pages/api/generated/yohou.plotting.model_selection.plot_splits/) visualizes the temporal structure of CV splits

--- a/examples/plotting/model_selection.py
+++ b/examples/plotting/model_selection.py
@@ -56,7 +56,6 @@ def _(mo):
 
     - Visualizing train/test CV splits with [`plot_splits`](/pages/api/generated/yohou.plotting.model_selection.plot_splits/)
     - Comparing expanding vs sliding window strategies
-    - Using gap periods to prevent data leakage
     - Plotting hyperparameter search results with [`plot_cv_results_scatter`](/pages/api/generated/yohou.plotting.model_selection.plot_cv_results_scatter/)
 
     ## Prerequisites
@@ -135,11 +134,10 @@ def _(SlidingWindowSplitter, plot_splits, tourism):
 def _(ExpandingWindowSplitter, plot_splits, tourism):
     plot_splits(
         tourism,
-        ExpandingWindowSplitter(n_splits=3, test_size=12, gap=6),
+        ExpandingWindowSplitter(n_splits=3, test_size=12),
         train_color="#059669",
         test_color="#dc2626",
-        gap_color="#fbbf24",
-        title="Expanding Window - Gap=6, Custom Colours",
+        title="Expanding Window - Custom Colours",
     )
 
 
@@ -147,8 +145,8 @@ def _(ExpandingWindowSplitter, plot_splits, tourism):
 def _(SlidingWindowSplitter, plot_splits, tourism):
     plot_splits(
         tourism,
-        SlidingWindowSplitter(n_splits=3, test_size=12, gap=3),
-        title="Sliding Window - Gap=3",
+        SlidingWindowSplitter(n_splits=3, test_size=12),
+        title="Sliding Window - 3 Folds",
     )
 
 

--- a/src/yohou/model_selection/split.py
+++ b/src/yohou/model_selection/split.py
@@ -191,6 +191,7 @@ class ExpandingWindowSplitter(BaseSplitter):
     >>> len(train), len(test)
     (80, 10)
     >>>
+
     Notes
     -----
     - Training sets grow with each split (expanding window)

--- a/src/yohou/model_selection/split.py
+++ b/src/yohou/model_selection/split.py
@@ -164,10 +164,6 @@ class ExpandingWindowSplitter(BaseSplitter):
         Used to limit the size of the test set. Defaults to
         ``n_samples // (n_splits + 1)``, which is the maximum allowed
         value with no overlap between test sets.
-    gap : int, default=0
-        Number of time steps to skip between the end of the training set
-        and the start of the test set. Must be non-negative.
-        Use gap > 0 to simulate forecasting lag or prevent data leakage.
 
     Examples
     --------
@@ -195,12 +191,6 @@ class ExpandingWindowSplitter(BaseSplitter):
     >>> len(train), len(test)
     (80, 10)
     >>>
-    >>> # With 5-day gap between train and test
-    >>> splitter_gap = ExpandingWindowSplitter(n_splits=3, test_size=10, gap=5)
-    >>> train, test = list(splitter_gap.split(y))[0]
-    >>> bool(test[0] - train[-1] == 6)  # 5-day gap + 1 for next index
-    True
-
     Notes
     -----
     - Training sets grow with each split (expanding window)
@@ -219,7 +209,6 @@ class ExpandingWindowSplitter(BaseSplitter):
         "n_splits": [Interval(numbers.Integral, 2, None, closed="left")],
         "max_train_size": [Interval(numbers.Integral, 1, None, closed="left"), None],
         "test_size": [Interval(numbers.Integral, 1, None, closed="left"), None],
-        "gap": [Interval(numbers.Integral, 0, None, closed="left")],
     }
 
     def __init__(
@@ -228,12 +217,10 @@ class ExpandingWindowSplitter(BaseSplitter):
         *,
         max_train_size: int | None = None,
         test_size: int | None = None,
-        gap: int = 0,
     ) -> None:
         self.n_splits = n_splits
         self.max_train_size = max_train_size
         self.test_size = test_size
-        self.gap = gap
 
         # Validate parameters
         self._validate_params()
@@ -268,13 +255,10 @@ class ExpandingWindowSplitter(BaseSplitter):
         n_samples = len(y)
         indices = np.arange(n_samples)
         max_train_size = self.max_train_size
-        gap = self.gap
 
         # Delegate to concrete implementation
         for test_index in self._iter_test_indices(y, X):
-            # test_index already has gap incorporated from _iter_test_indices
-            # Train indices are all samples before (test_start - gap)
-            train_end = test_index[0] - gap
+            train_end = test_index[0]
             train_index = indices[indices < train_end]
 
             # Apply max_train_size if specified
@@ -307,7 +291,6 @@ class ExpandingWindowSplitter(BaseSplitter):
         n_splits = self.n_splits
         n_folds = n_splits + 1
         test_size = self.test_size if self.test_size is not None else n_samples // n_folds
-        gap = self.gap
 
         if n_folds > n_samples:
             raise ValueError(f"Cannot have number of folds={n_folds} greater than the number of samples={n_samples}.")
@@ -315,17 +298,12 @@ class ExpandingWindowSplitter(BaseSplitter):
         if test_size >= n_samples:
             raise ValueError(f"test_size={test_size} should be less than the number of samples={n_samples}.")
 
-        # Calculate test start positions accounting for gap
-        # The last test must end at n_samples, working backwards n_splits times
-        # Each test is test_size long, and we need gap between train and test
-        # So test positions are shifted by gap compared to no-gap case
-        test_starts = range(n_samples - gap - n_splits * test_size, n_samples - gap, test_size)
+        test_starts = range(n_samples - n_splits * test_size, n_samples, test_size)
 
         for test_start in test_starts:
-            # Add gap to shift test forward (train ends gap samples before test)
-            if test_start + gap < 0:
+            if test_start < 0:
                 continue
-            yield np.arange(test_start + gap, test_start + gap + test_size, dtype=np.intp)
+            yield np.arange(test_start, test_start + test_size, dtype=np.intp)
 
     def get_n_splits(
         self,
@@ -379,7 +357,7 @@ class SlidingWindowSplitter(BaseSplitter):
         Number of samples in each training window.  When ``None``
         (default), the training size is computed automatically so that
         exactly ``n_splits`` folds fit the data:
-        ``train_size = n_samples - gap - test_size - (n_splits - 1) * stride``.
+        ``train_size = n_samples - test_size - (n_splits - 1) * stride``.
         When both ``n_splits`` and ``train_size`` are provided explicitly,
         they must be consistent with the data length; otherwise a
         ``ValueError`` is raised during ``split()``.
@@ -388,10 +366,6 @@ class SlidingWindowSplitter(BaseSplitter):
     stride : int, default=None
         Number of samples to move forward between splits. If None,
         defaults to `test_size` (non-overlapping windows).
-    gap : int, default=0
-        Number of time steps to skip between the end of the training set
-        and the start of the test set. Must be non-negative.
-        Use gap > 0 to simulate forecasting lag or prevent data leakage.
 
     Attributes
     ----------
@@ -424,12 +398,6 @@ class SlidingWindowSplitter(BaseSplitter):
     >>> # All training windows have the same size
     >>> all(len(tr) == len(splits[0][0]) for tr, _ in splits)
     True
-    >>>
-    >>> # With explicit train_size and gap
-    >>> splitter_gap = SlidingWindowSplitter(n_splits=6, train_size=30, test_size=10, gap=3)
-    >>> train, test = list(splitter_gap.split(y))[0]
-    >>> bool(test[0] - train[-1] == 4)  # 3-day gap + 1 for next index
-    True
 
     Notes
     -----
@@ -451,7 +419,6 @@ class SlidingWindowSplitter(BaseSplitter):
         "train_size": [Interval(numbers.Integral, 1, None, closed="left"), None],
         "test_size": [Interval(numbers.Integral, 1, None, closed="left")],
         "stride": [Interval(numbers.Integral, 1, None, closed="left"), None],
-        "gap": [Interval(numbers.Integral, 0, None, closed="left")],
     }
 
     def __init__(
@@ -461,13 +428,11 @@ class SlidingWindowSplitter(BaseSplitter):
         train_size: int | None = None,
         test_size: int = 10,
         stride: int | None = None,
-        gap: int = 0,
     ) -> None:
         self.n_splits = n_splits
         self.train_size = train_size
         self.test_size = test_size
         self.stride = stride
-        self.gap = gap
 
         # Validate parameters
         self._validate_params()
@@ -499,16 +464,14 @@ class SlidingWindowSplitter(BaseSplitter):
         # Validate data
         y, X = validate_splitter_data(self, y=y, X=X)
 
-        gap = self.gap
-
         # Resolve train_size (may compute from n_splits) and store as fitted attr
         self.train_size_ = self._resolve_train_size(len(y))
 
         # Delegate to concrete implementation for test indices
         for test_index in self._iter_test_indices(y, X):
             # For sliding window, train indices are the fixed-size window
-            # ending gap samples before the test set
-            train_end = test_index[0] - gap
+            # ending at the start of the test set
+            train_end = test_index[0]
             train_start = train_end - self.train_size_
 
             train_index = np.arange(train_start, train_end, dtype=np.intp)
@@ -538,7 +501,6 @@ class SlidingWindowSplitter(BaseSplitter):
         train_size = self._resolve_train_size(n_samples)
         test_size = self.test_size
         stride = self.stride if self.stride is not None else test_size
-        gap = self.gap
 
         if test_size % stride != 0:
             warnings.warn(
@@ -550,14 +512,14 @@ class SlidingWindowSplitter(BaseSplitter):
                 stacklevel=3,
             )
 
-        if train_size + gap + test_size > n_samples:
+        if train_size + test_size > n_samples:
             raise ValueError(
-                f"train_size ({train_size}) + gap ({gap}) + test_size ({test_size}) = "
-                f"{train_size + gap + test_size} is greater than n_samples ({n_samples})."
+                f"train_size ({train_size}) + test_size ({test_size}) = "
+                f"{train_size + test_size} is greater than n_samples ({n_samples})."
             )
 
         # Fixed iteration: produce exactly n_splits test windows
-        test_start = train_size + gap
+        test_start = train_size
         for _ in range(self.n_splits):
             if test_start + test_size > n_samples:
                 break
@@ -586,16 +548,15 @@ class SlidingWindowSplitter(BaseSplitter):
         """
         test_size = self.test_size
         stride = self.stride if self.stride is not None else test_size
-        gap = self.gap
         n_splits = self.n_splits
 
         if self.train_size is None:
             # Compute train_size from n_splits
-            train_size = n_samples - gap - test_size - (n_splits - 1) * stride
+            train_size = n_samples - test_size - (n_splits - 1) * stride
             if train_size < 1:
                 raise ValueError(
                     f"Not enough data for n_splits={n_splits} with "
-                    f"test_size={test_size}, stride={stride}, gap={gap}: "
+                    f"test_size={test_size}, stride={stride}: "
                     f"computed train_size={train_size} (must be >= 1). "
                     f"Reduce n_splits or provide more data."
                 )
@@ -603,19 +564,19 @@ class SlidingWindowSplitter(BaseSplitter):
 
         # Both n_splits and train_size are explicit; check consistency
         train_size = self.train_size
-        if train_size + gap + test_size > n_samples:
+        if train_size + test_size > n_samples:
             raise ValueError(
-                f"train_size ({train_size}) + gap ({gap}) + test_size ({test_size}) = "
-                f"{train_size + gap + test_size} is greater than n_samples ({n_samples})."
+                f"train_size ({train_size}) + test_size ({test_size}) = "
+                f"{train_size + test_size} is greater than n_samples ({n_samples})."
             )
 
-        available = n_samples - train_size - gap - test_size
+        available = n_samples - train_size - test_size
         max_splits = (available // stride) + 1
         if n_splits > max_splits:
             raise ValueError(
                 f"Inconsistent parameters: n_splits={n_splits} but the data "
                 f"(n_samples={n_samples}) with train_size={train_size}, "
-                f"test_size={test_size}, stride={stride}, gap={gap} supports "
+                f"test_size={test_size}, stride={stride} supports "
                 f"at most {max_splits} splits. Set train_size=None to "
                 f"auto-compute or reduce n_splits to at most {max_splits}."
             )

--- a/src/yohou/model_selection/split.py
+++ b/src/yohou/model_selection/split.py
@@ -513,12 +513,6 @@ class SlidingWindowSplitter(BaseSplitter):
                 stacklevel=3,
             )
 
-        if train_size + test_size > n_samples:
-            raise ValueError(
-                f"train_size ({train_size}) + test_size ({test_size}) = "
-                f"{train_size + test_size} is greater than n_samples ({n_samples})."
-            )
-
         # Fixed iteration: produce exactly n_splits test windows
         test_start = train_size
         for _ in range(self.n_splits):

--- a/src/yohou/plotting/model_selection.py
+++ b/src/yohou/plotting/model_selection.py
@@ -24,7 +24,6 @@ def plot_splits(
     X: pl.DataFrame | None = None,
     train_color: str | None = None,
     test_color: str | None = None,
-    gap_color: str = "#9ca3af",
     show_legend: bool = True,
     title: str | None = None,
     x_label: str | None = None,
@@ -33,7 +32,6 @@ def plot_splits(
     height: int | None = None,
     resampler: bool | Literal["widget"] | None = None,
     line_width: float = 10.0,
-    gap_opacity: float = 0.5,
 ) -> go.Figure:
     """
     Plot cross-validation splits as a timeline visualization.
@@ -53,8 +51,6 @@ def plot_splits(
         Color for train segments. If None, uses first color from yohou palette.
     test_color : str | None, default=None
         Color for test segments. If None, uses second color from yohou palette.
-    gap_color : str, default="#9ca3af"
-        Color for gap segments (if splitter has gap > 0).
     show_legend : bool, default=True
         Whether to show the legend.
     title : str | None, default=None
@@ -72,9 +68,7 @@ def plot_splits(
         ``"widget"`` creates a ``FigureWidgetResampler``; ``False`` or
         ``None`` uses a plain ``go.Figure``.
     line_width : float, default=10.0
-        Width of the train/test/gap bars.
-    gap_opacity : float, default=0.5
-        Opacity for gap segments.
+        Width of the train/test bars.
 
     Returns
     -------
@@ -135,9 +129,6 @@ def plot_splits(
     # Get time column
     times = y["time"]
 
-    # Check if splitter has gap
-    gap = getattr(splitter, "gap", None) or 0
-
     # Plot each split
     for i, (train_idx, test_idx) in enumerate(splits):
         fold_label = f"Fold {i + 1}"
@@ -163,22 +154,6 @@ def plot_splits(
                 hovertemplate=f"Train<br>Start: %{{x}}<br>Fold: {fold_label}<extra></extra>",
             )
         )
-
-        # Plot gap if present
-        if gap > 0:
-            fig.add_trace(
-                go.Scatter(
-                    x=[t_train_end, t_test_start],
-                    y=[fold_label, fold_label],
-                    mode="lines",
-                    line={"color": gap_color, "width": line_width},
-                    name="Gap" if i == 0 else None,
-                    showlegend=(i == 0),
-                    legendgroup="gap",
-                    opacity=gap_opacity,
-                    hovertemplate=f"Gap<br>Fold: {fold_label}<extra></extra>",
-                )
-            )
 
         # Plot test segment
         fig.add_trace(

--- a/tests/model_selection/test_split.py
+++ b/tests/model_selection/test_split.py
@@ -117,62 +117,6 @@ class TestExpandingWindowBasic:
         assert train_sizes[0] < train_sizes[1] < train_sizes[2]
 
 
-class TestExpandingWindowGap:
-    """Tests for ExpandingWindowSplitter with gap parameter."""
-
-    def test_expanding_window_gap_insertion(self, y_X_factory):
-        """Test gap parameter inserts gap between train and test."""
-        y, X = y_X_factory(length=100, n_targets=1, n_features=2, seed=42)
-
-        splitter = ExpandingWindowSplitter(n_splits=3, test_size=10, gap=5)
-        splits = list(splitter.split(y, X))
-
-        for train_idx, test_idx in splits:
-            gap_size = test_idx[0] - train_idx[-1] - 1
-            assert gap_size == 5
-
-    def test_expanding_window_gap_preserves_split_count(self, y_X_factory):
-        """Test gap doesn't change number of splits, only index positions."""
-        y, _ = y_X_factory(length=100, n_targets=1, n_features=0, seed=42)
-
-        splitter = ExpandingWindowSplitter(n_splits=5, test_size=10, gap=10)
-        base_splitter = ExpandingWindowSplitter(n_splits=5, test_size=10)
-
-        splits = list(splitter.split(y))
-        base_splits = list(base_splitter.split(y))
-
-        assert len(splits) == len(base_splits) == 5
-
-        for (train_gap, test_gap), (train_base, test_base) in zip(splits, base_splits, strict=False):
-            assert test_gap[0] == test_base[0]
-            assert train_gap[-1] == train_base[-1] - 10
-
-    def test_expanding_window_gap_zero_equivalent_to_none(self, y_X_factory):
-        """Test gap=0 produces same result as no gap argument."""
-        y, _ = y_X_factory(length=100, n_targets=1, n_features=0, seed=42)
-
-        splitter_gap_zero = ExpandingWindowSplitter(n_splits=3, test_size=10, gap=0)
-        splitter_no_gap = ExpandingWindowSplitter(n_splits=3, test_size=10)
-
-        splits_zero = list(splitter_gap_zero.split(y))
-        splits_no_gap = list(splitter_no_gap.split(y))
-
-        for (t1, te1), (t2, te2) in zip(splits_zero, splits_no_gap, strict=False):
-            assert np.array_equal(t1, t2)
-            assert np.array_equal(te1, te2)
-
-    def test_expanding_window_gap_get_n_splits_no_data_required(self, y_X_factory):
-        """Test get_n_splits works without y even when gap > 0."""
-        y, _ = y_X_factory(length=100, n_targets=1, n_features=0, seed=42)
-
-        splitter = ExpandingWindowSplitter(n_splits=3, test_size=10, gap=5)
-
-        n_splits_no_y = splitter.get_n_splits(y=None)
-        n_splits_with_y = splitter.get_n_splits(y)
-
-        assert n_splits_no_y == n_splits_with_y == 3
-
-
 class TestSlidingWindowBasic:
     """Tests for basic SlidingWindowSplitter functionality."""
 
@@ -269,60 +213,6 @@ class TestSlidingWindowBasic:
             list(splitter.split(y))
 
 
-class TestSlidingWindowGap:
-    """Tests for SlidingWindowSplitter with gap parameter."""
-
-    def test_sliding_window_gap_insertion(self, y_X_factory):
-        """Test gap parameter inserts gap between train and test."""
-        y, X = y_X_factory(length=100, n_targets=1, n_features=2, seed=42)
-
-        splitter = SlidingWindowSplitter(n_splits=6, train_size=30, test_size=10, gap=5)
-        splits = list(splitter.split(y, X))
-
-        train_sizes = [len(train) for train, _ in splits]
-        assert all(size == 30 for size in train_sizes)
-
-        for train_idx, test_idx in splits:
-            assert test_idx[0] - train_idx[-1] == 6  # gap + 1
-
-    def test_sliding_window_gap_with_stride(self, y_X_factory):
-        """Test gap and stride work independently."""
-        y, _ = y_X_factory(length=100, n_targets=1, n_features=0, seed=42)
-
-        splitter = SlidingWindowSplitter(n_splits=3, train_size=30, test_size=10, stride=20, gap=5)
-        splits = list(splitter.split(y))
-
-        assert len(splits) == 3
-
-        train_sizes = [len(train) for train, _ in splits]
-        assert all(size == 30 for size in train_sizes)
-
-        for train_idx, test_idx in splits:
-            assert test_idx[0] - train_idx[-1] == 6  # gap + 1
-
-    def test_sliding_window_gap_zero_equivalent_to_none(self, y_X_factory):
-        """Test gap=0 produces same result as no gap argument."""
-        y, _ = y_X_factory(length=100, n_targets=1, n_features=0, seed=42)
-
-        splitter_gap_zero = SlidingWindowSplitter(n_splits=7, train_size=30, test_size=10, gap=0)
-        splitter_no_gap = SlidingWindowSplitter(n_splits=7, train_size=30, test_size=10)
-
-        splits_zero = list(splitter_gap_zero.split(y))
-        splits_no_gap = list(splitter_no_gap.split(y))
-
-        for (t1, te1), (t2, te2) in zip(splits_zero, splits_no_gap, strict=False):
-            assert np.array_equal(t1, t2)
-            assert np.array_equal(te1, te2)
-
-    def test_sliding_window_gap_insufficient_data(self, y_X_factory):
-        """Test error when gap + train + test exceeds data."""
-        y, _ = y_X_factory(length=40, n_targets=1, n_features=0, seed=42)
-
-        splitter = SlidingWindowSplitter(n_splits=2, train_size=30, test_size=10, gap=5)
-        with pytest.raises(ValueError, match="train_size.*gap.*test_size.*greater than n_samples"):
-            list(splitter.split(y))
-
-
 class TestSplitterIntegration:
     """Integration tests for splitters with forecasters."""
 
@@ -375,13 +265,3 @@ class TestSplitterIntegration:
 
         assert len(scores) >= 1
         assert all(score >= 0 for score in scores)
-
-    def test_gap_prevents_leakage(self, y_X_factory):
-        """Test gap parameter prevents data leakage."""
-        y, X = y_X_factory(length=100, n_targets=1, n_features=2, seed=42)
-
-        splitter = ExpandingWindowSplitter(n_splits=3, test_size=10, gap=5)
-
-        for train_idx, test_idx in splitter.split(y, X):
-            gap_size = test_idx[0] - train_idx[-1] - 1
-            assert gap_size == 5

--- a/tests/plotting/test_model_selection.py
+++ b/tests/plotting/test_model_selection.py
@@ -257,19 +257,3 @@ class TestPlotCvResultsScatter:
         scatter_y = list(fig.data[0].y)
         assert scatter_y == [-0.5, -0.3, -0.2]
         assert len(fig.data) > 0
-
-
-class TestPlotSplitsGap:
-    """Test gap rendering in plot_splits (line 164)."""
-
-    def test_gap_renders_extra_traces(self, sample_y):
-        """Splitter with gap > 0 adds gap traces between train and test."""
-        splitter = SlidingWindowSplitter(n_splits=3, test_size=30, gap=10)
-        fig = plot_splits(sample_y, splitter)
-        assert_figure_valid(fig)
-        # With gap > 0, each fold gets 3 traces (train + gap + test)
-        # 3 folds x 3 traces = 9 minimum
-        assert len(fig.data) >= 9
-        # At least one trace should belong to the "gap" legendgroup
-        gap_traces = [t for t in fig.data if getattr(t, "legendgroup", None) == "gap"]
-        assert len(gap_traces) >= 1

--- a/tests/testing/test_splitter.py
+++ b/tests/testing/test_splitter.py
@@ -37,7 +37,6 @@ def splitters():
     return [
         ExpandingWindowSplitter(n_splits=3, test_size=10),
         SlidingWindowSplitter(n_splits=3, test_size=10),
-        ExpandingWindowSplitter(n_splits=3, test_size=10, gap=2),
     ]
 
 
@@ -48,7 +47,6 @@ class TestSplitterChecks:
         """Test that tags are accessible on splitter instances."""
         check_splitter_tags_accessible_before_fit(ExpandingWindowSplitter(n_splits=3, test_size=10))
         check_splitter_tags_accessible_before_fit(SlidingWindowSplitter(n_splits=3, test_size=10))
-        check_splitter_tags_accessible_before_fit(ExpandingWindowSplitter(n_splits=3, test_size=10, gap=2))
 
     def test_tags_static_after_fit(self, splitters, y_data):
         """Test that tags don't change after split()."""
@@ -69,13 +67,6 @@ class TestSplitterChecks:
             splitters[1],
             y_data,
             expected_tags={"splitter_type": "sliding"},
-        )
-
-        # Test ExpandingWindowSplitter with gap
-        check_splitter_tags_match_capabilities(
-            splitters[2],
-            y_data,
-            expected_tags={"splitter_type": "expanding"},
         )
 
     def test_tags_match_capabilities_without_expected_tags(self, y_data):
@@ -103,10 +94,8 @@ class TestSplitterChecks:
         [
             (ExpandingWindowSplitter, "n_splits", [1, 0, -1]),
             (ExpandingWindowSplitter, "test_size", [0, -1]),
-            (ExpandingWindowSplitter, "gap", [-1]),
             (SlidingWindowSplitter, "n_splits", [1, 0, -1]),
             (SlidingWindowSplitter, "test_size", [0, -1]),
-            (SlidingWindowSplitter, "gap", [-1]),
         ],
     )
     def test_parameter_constraints(self, splitter_class, param_name, invalid_values):
@@ -139,15 +128,6 @@ class TestSplitterChecks:
     def test_systematic_sliding_window_checks(self, y_data):
         """Systematic test using generator for SlidingWindowSplitter."""
         splitter = SlidingWindowSplitter(n_splits=3, test_size=10)
-
-        run_checks(
-            splitter,
-            _yield_yohou_splitter_checks(splitter, y_data),
-        )
-
-    def test_systematic_expanding_with_gap_checks(self, y_data):
-        """Systematic test using generator for ExpandingWindowSplitter with gap."""
-        splitter = ExpandingWindowSplitter(n_splits=3, test_size=10, gap=5)
 
         run_checks(
             splitter,


### PR DESCRIPTION
## Description

Remove the `gap` parameter from `ExpandingWindowSplitter`, `SlidingWindowSplitter`, and `plot_splits`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Simplify the splitter API by removing the `gap` parameter.

## Checklist

- [x] My code follows the code style of this project
- [ ] I have run `just fix` to format my code
- [ ] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

