### PR TITLE
fix(interval): detect LightGBM quantile alpha parameter

### DIFF
--- a/src/yohou/interval/reduction.py
+++ b/src/yohou/interval/reduction.py
@@ -185,6 +185,32 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
                 return param_name
         return None
 
+    def _detect_lgbm_quantile_alpha(self) -> list[str]:
+        """Detect LightGBM-style quantile regression via ``objective="quantile"``.
+
+        LightGBM uses ``objective="quantile"`` with ``alpha`` as the
+        quantile level parameter, rather than a single ``quantile`` param.
+        This method detects that pattern and returns the ``alpha``
+        parameter path so that it can be used the same way as a native
+        ``quantile`` parameter.
+
+        Returns
+        -------
+        list[str]
+            A list with the ``alpha`` parameter path (e.g. ``["alpha"]``
+            or ``["estimator__alpha"]``) if the pattern is detected,
+            otherwise an empty list.
+
+        """
+        params = self.estimator.get_params(deep=True)
+        for param_name, value in params.items():
+            if param_name.split("__")[-1] == "objective" and value == "quantile":
+                # Derive the ``alpha`` parameter path from the ``objective``
+                # path (e.g. ``"estimator__objective"`` -> ``"estimator__alpha"``).
+                prefix = param_name.rsplit("objective", 1)[0]
+                return [f"{prefix}alpha"]
+        return []
+
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(
         self,
@@ -278,6 +304,12 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
                 param_name for param_name in estimator_param_names if param_name.split("__")[-1] == "quantile"
             ]
 
+            # LightGBM uses ``objective="quantile"`` with ``alpha`` as the
+            # quantile parameter (instead of a param named ``quantile``).
+            # Detect this pattern when no ``quantile`` param was found.
+            if len(quantile_param_names) == 0:
+                quantile_param_names = self._detect_lgbm_quantile_alpha()
+
             if len(quantile_param_names) > 1:
                 raise ValueError(
                     f"Found multiple quantile parameters in estimator: {quantile_param_names}. "
@@ -289,7 +321,9 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
                 raise ValueError(
                     f"No quantile parameter found in estimator. "
                     f"IntervalReductionForecaster requires an estimator with a 'quantile' "
-                    f"parameter (e.g., QuantileRegressor) or a multi-quantile loss function "
+                    f"parameter (e.g., QuantileRegressor), a 'quantile' objective with an "
+                    f"'alpha' parameter (e.g., LGBMRegressor with ``objective='quantile'``), "
+                    f"or a multi-quantile loss function "
                     f"(e.g., CatBoost ``loss_function='MultiQuantile:alpha=...'``). "
                     f"Available parameters: {estimator_param_names}"
                 )

--- a/tests/interval/test_reduction.py
+++ b/tests/interval/test_reduction.py
@@ -556,6 +556,106 @@ class TestMultiQuantile:
                 assert f"{col}_upper_{cr}" in y_pred.columns
 
 
+class _MockLGBMQuantileRegressor(BaseEstimator, RegressorMixin):
+    """Lightweight stand-in for LGBMRegressor with ``objective="quantile"``.
+
+    Mimics the LightGBM pattern where the quantile level is controlled
+    by an ``alpha`` parameter rather than a ``quantile`` parameter.
+    """
+
+    def __init__(self, objective="quantile", alpha=0.5):
+        self.objective = objective
+        self.alpha = alpha
+
+    def fit(self, X, y, **kwargs):
+        y = np.asarray(y)
+        if y.ndim == 2:
+            y = y[:, 0]
+        self.intercept_ = np.quantile(y, self.alpha)
+        return self
+
+    def predict(self, X):
+        return np.full(X.shape[0], self.intercept_)
+
+
+class TestLGBMQuantileAlpha:
+    """Tests for LightGBM-style ``objective='quantile'`` + ``alpha`` detection."""
+
+    def test_detect_lgbm_quantile_alpha(self):
+        """_detect_lgbm_quantile_alpha returns alpha param for LGBM-style estimators."""
+        est = _MockLGBMQuantileRegressor()
+        forecaster = IntervalReductionForecaster(estimator=est)
+        assert forecaster._detect_lgbm_quantile_alpha() == ["alpha"]
+
+    def test_detect_lgbm_quantile_alpha_nested(self):
+        """_detect_lgbm_quantile_alpha resolves nested alpha param path."""
+        from sklearn.multioutput import MultiOutputRegressor
+
+        est = MultiOutputRegressor(_MockLGBMQuantileRegressor())
+        forecaster = IntervalReductionForecaster(estimator=est)
+        assert forecaster._detect_lgbm_quantile_alpha() == ["estimator__alpha"]
+
+    def test_detect_lgbm_quantile_alpha_absent(self):
+        """_detect_lgbm_quantile_alpha returns empty list for standard estimators."""
+        forecaster = IntervalReductionForecaster()
+        assert forecaster._detect_lgbm_quantile_alpha() == []
+
+    @pytest.mark.slow
+    def test_fit_predict_direct(self, standard_splits):
+        """LGBM-style alpha detection produces correct interval columns (direct)."""
+        y_train, y_test, X_train, X_test = standard_splits
+        coverage_rates = [0.5, 0.9]
+        est = _MockLGBMQuantileRegressor()
+        forecaster = IntervalReductionForecaster(
+            estimator=est,
+            reduction_strategy="direct",
+        )
+
+        forecaster.fit(
+            y=y_train,
+            X=X_train,
+            forecasting_horizon=2,
+            coverage_rates=coverage_rates,
+        )
+
+        y_pred = forecaster.predict_interval(
+            forecasting_horizon=2,
+            X=X_test,
+            coverage_rates=coverage_rates,
+        )
+
+        y_cols = [c for c in y_train.columns if c != "time"]
+        for col in y_cols:
+            for cr in coverage_rates:
+                assert f"{col}_lower_{cr}" in y_pred.columns
+                assert f"{col}_upper_{cr}" in y_pred.columns
+                assert all(y_pred[f"{col}_upper_{cr}"] + 1e-14 >= y_pred[f"{col}_lower_{cr}"])
+
+    def test_no_quantile_param_raises(self):
+        """Estimator without quantile or alpha raises ValueError."""
+
+        class _NoQuantileEstimator(BaseEstimator, RegressorMixin):
+            def fit(self, X, y):
+                return self
+
+            def predict(self, X):
+                return np.zeros(X.shape[0])
+
+        forecaster = IntervalReductionForecaster(estimator=_NoQuantileEstimator())
+        y = pl.DataFrame({
+            "time": pl.datetime_range(
+                start=datetime(2021, 1, 1),
+                end=datetime(2021, 1, 1, 0, 0, 9),
+                interval="1s",
+                eager=True,
+            ),
+            "value": list(range(10)),
+        }).cast({"value": pl.Float64})
+
+        with pytest.raises(ValueError, match="No quantile parameter found"):
+            forecaster.fit(y=y, forecasting_horizon=1, coverage_rates=[0.9])
+
+
 class TestIntervalReductionWithFeaturesSystematicChecks:
     """Systematic checks for IntervalReductionForecaster with exogenous features."""
 


### PR DESCRIPTION
## Description

`IntervalReductionForecaster` only recognized estimators with a parameter literally named `quantile` (e.g. `QuantileRegressor`). LightGBM uses `objective="quantile"` with `alpha` as the quantile level parameter, which was not detected, causing a `ValueError` on fit.

This adds `_detect_lgbm_quantile_alpha()` to recognize the `objective="quantile"` + `alpha` pattern, including nested estimators (e.g. `MultiOutputRegressor(LGBMRegressor(...))`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Using `LGBMRegressor(objective="quantile")` with `IntervalReductionForecaster` raised a `ValueError` because the validation logic could not find a `quantile` parameter in the estimator's params.

## Checklist

- [x] My code follows the code style of this project
- [ ] I have run `just fix` to format my code
- [ ] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] My changes generate no new warnings

## Additional Notes

