### PR TITLE
fix(reduction): pass Polars DataFrames to estimators instead of numpy arrays

### DIFF
--- a/src/yohou/base/reduction.py
+++ b/src/yohou/base/reduction.py
@@ -309,10 +309,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         X_t: pl.DataFrame,
         forecasting_horizon: int,
         y_columns: list[str] | None = None,
-    ) -> tuple[
-        np.ndarray[tuple[int, int], np.dtype[np.float64]],
-        np.ndarray[tuple[int, int], np.dtype[np.float64]],
-    ]:
+    ) -> tuple[pl.DataFrame, pl.DataFrame]:
         """Convert transformed time series to tabular supervised learning format.
 
         Creates feature matrix (X_tab) and target matrix (y_tab) suitable for training
@@ -332,10 +329,10 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         Returns
         -------
-        X_tab : np.ndarray of shape (n_samples, n_features)
+        X_tab : pl.DataFrame
             Feature matrix for supervised learning. Excludes "time" column and
             truncates last forecasting_horizon rows (no targets available).
-        y_tab : np.ndarray of shape (n_samples, forecasting_horizon * n_targets)
+        y_tab : pl.DataFrame
             Target matrix with columns for each (target, step) combination.
             Columns follow pattern: {target}_step_{1}, {target}_step_{2}, ...
 
@@ -371,7 +368,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             for col in y_columns
         })[[f"{col}_step_{step}" for step in range(1, 1 + forecasting_horizon) for col in y_columns]]
 
-        return X_tab.to_numpy(), y_tab.to_numpy()
+        return X_tab, y_tab
 
     def _estimator_fit_one(
         self,
@@ -460,7 +457,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         y_t: pl.DataFrame | dict[str, pl.DataFrame],
         X_t: pl.DataFrame | dict[str, pl.DataFrame] | None,
         forecasting_horizon: int,
-    ) -> tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[pl.DataFrame, pl.DataFrame]:
         """Tabularize and stack data for fitting (handles both standard and panel).
 
         Parameters
@@ -474,9 +471,9 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         Returns
         -------
-        X_tab : np.ndarray of shape (n_samples, n_features)
+        X_tab : pl.DataFrame
             Stacked feature matrix.
-        y_tab : np.ndarray of shape (n_samples, H * n_targets)
+        y_tab : pl.DataFrame
             Stacked target matrix with all horizon steps.
 
         """
@@ -500,11 +497,11 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             )
             X_tab_list.append(X_tab_local)
             y_tab_list.append(y_tab_local)
-        return np.vstack(X_tab_list), np.vstack(y_tab_list)
+        return pl.concat(X_tab_list), pl.concat(y_tab_list)
 
     def _validate_and_prepare_fit(
         self,
-        X_tab: np.ndarray,
+        X_tab: pl.DataFrame,
         y_t: pl.DataFrame | dict[str, pl.DataFrame],
         time_weight: Callable | pl.DataFrame | dict | None,
         sample_weight_alignment: str,
@@ -515,7 +512,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        X_tab : np.ndarray
+        X_tab : pl.DataFrame
             Feature matrix.
         y_t : pl.DataFrame or dict[str, pl.DataFrame]
             Transformed target (for weight computation).
@@ -556,8 +553,8 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
     def _fit_single_estimator(
         self,
-        X_tab: np.ndarray,
-        y_tab: np.ndarray,
+        X_tab: pl.DataFrame,
+        y_tab: pl.DataFrame | pl.Series,
         sample_weight: np.ndarray | None,
         estimator_params: dict[str, Any] | None = None,
         estimator_fit_params: dict[str, Any] | None = None,
@@ -566,10 +563,10 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        X_tab : np.ndarray
+        X_tab : pl.DataFrame
             Feature matrix.
-        y_tab : np.ndarray
-            Target matrix (single or multi-output).
+        y_tab : pl.DataFrame or pl.Series
+            Target (DataFrame for multi-output, Series for single-output).
         sample_weight : np.ndarray or None
             Sample weights.
         estimator_params : dict or None
@@ -727,12 +724,20 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             else len(self.local_y_t_schema_)
         )
 
+        y_columns = (
+            list(self.local_y_t_schema_.keys())
+            if self.groups_ is None
+            else [c for c in next(iter(y_t.values())).columns if c != "time"]
+            if isinstance(y_t, dict)
+            else list(self.local_y_t_schema_.keys())
+        )
+
         def _fit_step(step: int) -> BaseEstimator:
             """Fit a single estimator for horizon step."""
-            step_cols = [step + t * forecasting_horizon for t in range(n_targets)]
-            y_step = y_tab[:, step_cols]
+            step_col_names = [f"{col}_step_{step + 1}" for col in y_columns]
+            y_step: pl.DataFrame | pl.Series = y_tab.select(step_col_names)
             if y_step.shape[1] == 1:
-                y_step = y_step.ravel()
+                y_step = y_step.to_series()
             return self._fit_single_estimator(
                 X_tab,
                 y_step,
@@ -813,13 +818,21 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         self._dir_rec_n_original_features_ = X_tab.shape[1]
 
+        y_columns = (
+            list(self.local_y_t_schema_.keys())
+            if self.groups_ is None
+            else [c for c in next(iter(y_t.values())).columns if c != "time"]
+            if isinstance(y_t, dict)
+            else list(self.local_y_t_schema_.keys())
+        )
+
         estimators: list[BaseEstimator] = []
-        X_aug = X_tab.copy()  # Progressively augmented feature matrix
+        X_aug = X_tab.clone()  # Progressively augmented feature matrix
         for step in range(forecasting_horizon):
-            step_cols = [step + t * forecasting_horizon for t in range(n_targets)]
-            y_step = y_tab[:, step_cols]
+            step_col_names = [f"{col}_step_{step + 1}" for col in y_columns]
+            y_step: pl.DataFrame | pl.Series = y_tab.select(step_col_names)
             if y_step.shape[1] == 1:
-                y_step = y_step.ravel()
+                y_step = y_step.to_series()
             est = self._fit_single_estimator(
                 X_aug,
                 y_step,
@@ -834,7 +847,10 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
                 preds = est.predict(X_aug)  # ty: ignore[unresolved-attribute]
                 if preds.ndim == 1:
                     preds = preds.reshape(-1, 1)
-                X_aug = np.hstack([X_aug, preds])
+                X_aug = X_aug.with_columns([
+                    pl.Series(f"__aug_{step}_{j}", preds[:, j])
+                    for j in range(preds.shape[1])
+                ])
 
         return estimators
 
@@ -887,7 +903,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
     def _get_predict_features(
         self,
         panel_group_name: str | None = None,
-    ) -> np.ndarray:
+    ) -> pl.DataFrame:
         """Extract the last-row feature vector for prediction.
 
         Parameters
@@ -898,7 +914,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         Returns
         -------
-        np.ndarray of shape (1, n_features)
+        pl.DataFrame
             Feature row for prediction.
 
         """
@@ -911,7 +927,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             assert isinstance(self._X_t_observed, dict)
             X_t_dict = typing_cast(dict[str, pl.DataFrame], self._X_t_observed)
             X_t = X_t_dict[panel_group_name][[-1]].select(~cs.by_name("time"))
-        return X_t.select(list(self.local_X_t_schema_.keys())).to_numpy()
+        return X_t.select(list(self.local_X_t_schema_.keys()))
 
     def _reshape_predictions(
         self,
@@ -1003,7 +1019,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         y_cols = list(self.local_y_t_schema_.keys())
         n_targets = len(y_cols)
 
-        def _predict_step(est: BaseEstimator, X_tab: np.ndarray) -> np.ndarray:
+        def _predict_step(est: BaseEstimator, X_tab: pl.DataFrame) -> np.ndarray:
             """Predict a single horizon step."""
             pred = est.predict(X_tab)  # ty: ignore[unresolved-attribute]
             return np.atleast_1d(pred.ravel())[:n_targets]
@@ -1057,14 +1073,16 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         if self.groups_ is None:
             X_tab = self._get_predict_features()
-            X_aug = X_tab.copy()
+            X_aug = X_tab.clone()
             rows = []
-            for est in estimators:
+            for i, est in enumerate(estimators):
                 pred = est.predict(X_aug)  # ty: ignore[unresolved-attribute]
                 pred = np.atleast_1d(pred.ravel())
                 rows.append(pred[:n_targets])
                 # Augment features for next model
-                X_aug = np.hstack([X_aug, pred.reshape(1, -1)])
+                X_aug = X_aug.with_columns([
+                    pl.Series(f"__aug_{i}_{j}", [v]) for j, v in enumerate(pred)
+                ])
             y_pred_arr = np.vstack(rows)
             y_pred = pl.DataFrame(y_pred_arr, schema=y_cols)
             return cast(y_pred, self.local_y_t_schema_)
@@ -1072,13 +1090,15 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         y_pred_dict = {}
         for panel_group_name in groups:
             X_tab = self._get_predict_features(panel_group_name)
-            X_aug = X_tab.copy()
+            X_aug = X_tab.clone()
             rows = []
-            for est in estimators:
+            for i, est in enumerate(estimators):
                 pred = est.predict(X_aug)
                 pred = np.atleast_1d(pred.ravel())
                 rows.append(pred[:n_targets])
-                X_aug = np.hstack([X_aug, pred.reshape(1, -1)])
+                X_aug = X_aug.with_columns([
+                    pl.Series(f"__aug_{i}_{j}", [v]) for j, v in enumerate(pred)
+                ])
             y_pred_arr = np.vstack(rows)
             y_pred_local = pl.DataFrame(y_pred_arr, schema=y_cols)
             y_pred_local = cast(y_pred_local, self.local_y_t_schema_)

--- a/src/yohou/base/reduction.py
+++ b/src/yohou/base/reduction.py
@@ -716,14 +716,6 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             vintage_weight=vintage_weight,
         )
 
-        n_targets = (
-            len(self.local_y_t_schema_)
-            if self.groups_ is None
-            else len([c for c in next(iter(y_t.values())).columns if c != "time"])
-            if isinstance(y_t, dict)
-            else len(self.local_y_t_schema_)
-        )
-
         y_columns = (
             list(self.local_y_t_schema_.keys())
             if self.groups_ is None
@@ -808,14 +800,6 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             vintage_weight=vintage_weight,
         )
 
-        n_targets = (
-            len(self.local_y_t_schema_)
-            if self.groups_ is None
-            else len([c for c in next(iter(y_t.values())).columns if c != "time"])
-            if isinstance(y_t, dict)
-            else len(self.local_y_t_schema_)
-        )
-
         self._dir_rec_n_original_features_ = X_tab.shape[1]
 
         y_columns = (
@@ -847,10 +831,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
                 preds = est.predict(X_aug)  # ty: ignore[unresolved-attribute]
                 if preds.ndim == 1:
                     preds = preds.reshape(-1, 1)
-                X_aug = X_aug.with_columns([
-                    pl.Series(f"__aug_{step}_{j}", preds[:, j])
-                    for j in range(preds.shape[1])
-                ])
+                X_aug = X_aug.with_columns([pl.Series(f"__aug_{step}_{j}", preds[:, j]) for j in range(preds.shape[1])])
 
         return estimators
 
@@ -1080,9 +1061,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
                 pred = np.atleast_1d(pred.ravel())
                 rows.append(pred[:n_targets])
                 # Augment features for next model
-                X_aug = X_aug.with_columns([
-                    pl.Series(f"__aug_{i}_{j}", [v]) for j, v in enumerate(pred)
-                ])
+                X_aug = X_aug.with_columns([pl.Series(f"__aug_{i}_{j}", [v]) for j, v in enumerate(pred)])
             y_pred_arr = np.vstack(rows)
             y_pred = pl.DataFrame(y_pred_arr, schema=y_cols)
             return cast(y_pred, self.local_y_t_schema_)
@@ -1096,9 +1075,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
                 pred = est.predict(X_aug)
                 pred = np.atleast_1d(pred.ravel())
                 rows.append(pred[:n_targets])
-                X_aug = X_aug.with_columns([
-                    pl.Series(f"__aug_{i}_{j}", [v]) for j, v in enumerate(pred)
-                ])
+                X_aug = X_aug.with_columns([pl.Series(f"__aug_{i}_{j}", [v]) for j, v in enumerate(pred)])
             y_pred_arr = np.vstack(rows)
             y_pred_local = pl.DataFrame(y_pred_arr, schema=y_cols)
             y_pred_local = cast(y_pred_local, self.local_y_t_schema_)

--- a/src/yohou/class_proba/reduction.py
+++ b/src/yohou/class_proba/reduction.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Literal, cast
 
-import numpy as np
 import polars as pl
 from pydantic import StrictInt
 from sklearn.base import BaseEstimator
@@ -379,7 +378,7 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
     def _predict_proba_and_reshape(
         self,
         estimator: BaseEstimator,
-        X_tab: np.ndarray,
+        X_tab: pl.DataFrame,
         panel_group_name: str | None = None,
     ) -> pl.DataFrame:
         """Call predict_proba and reshape to probability DataFrame.
@@ -392,8 +391,8 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         ----------
         estimator : BaseEstimator
             Fitted classifier.
-        X_tab : np.ndarray
-            Feature array of shape ``(1, n_features)``.
+        X_tab : pl.DataFrame
+            Feature DataFrame of shape ``(1, n_features)``.
         panel_group_name : str or None
             Panel group prefix for column naming.
 
@@ -464,7 +463,7 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
     def _predict_proba_and_reshape_single_step(
         self,
         estimator: BaseEstimator,
-        X_tab: np.ndarray,
+        X_tab: pl.DataFrame,
         panel_group_name: str | None = None,
     ) -> pl.DataFrame:
         """Call predict_proba for a single-step direct estimator.
@@ -473,8 +472,8 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         ----------
         estimator : BaseEstimator
             Fitted single-step classifier.
-        X_tab : np.ndarray
-            Feature array of shape ``(1, n_features)``.
+        X_tab : pl.DataFrame
+            Feature DataFrame of shape ``(1, n_features)``.
         panel_group_name : str or None
             Panel group prefix for column naming.
 

--- a/tests/base/test_reduction_dataframe_pipeline.py
+++ b/tests/base/test_reduction_dataframe_pipeline.py
@@ -265,7 +265,9 @@ class TestYTabColumnNames:
         forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
 
         assert forecaster.estimator_.fit_y_columns == [
-            "value_step_1", "value_step_2", "value_step_3",
+            "value_step_1",
+            "value_step_2",
+            "value_step_3",
         ]
 
     def test_direct_y_has_step_column_per_estimator(self, reduction_data):
@@ -296,7 +298,10 @@ class TestYTabColumnNames:
         forecaster.fit(y=y_train, X=X_train, forecasting_horizon=2)
 
         assert forecaster.estimator_.fit_y_columns == [
-            "sales_step_1", "revenue_step_1", "sales_step_2", "revenue_step_2",
+            "sales_step_1",
+            "revenue_step_1",
+            "sales_step_2",
+            "revenue_step_2",
         ]
 
     def test_multi_target_direct_y_columns(self, multi_target_data):
@@ -325,11 +330,11 @@ class TestDirRecAugmentedFeatureNames:
         step2_cols = forecaster.estimator_[2].fit_X_columns
 
         # Step 1 has more columns than step 0
-        assert step1_cols[:len(base_cols)] == base_cols
+        assert step1_cols[: len(base_cols)] == base_cols
         assert len(step1_cols) > len(base_cols)
 
         # Step 2 has more columns than step 1
-        assert step2_cols[:len(base_cols)] == base_cols
+        assert step2_cols[: len(base_cols)] == base_cols
         assert len(step2_cols) > len(step1_cols)
 
         # All columns are strings (no integer indices)

--- a/tests/base/test_reduction_dataframe_pipeline.py
+++ b/tests/base/test_reduction_dataframe_pipeline.py
@@ -1,0 +1,537 @@
+"""Tests verifying that the reduction pipeline passes Polars DataFrames to sklearn estimators.
+
+The reduction pipeline passes Polars DataFrames (instead of numpy arrays) for
+both X and y to the underlying sklearn estimator. This ensures that estimators
+recording feature names during fit (e.g. LightGBM, XGBoost) see consistent
+names at predict time.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import polars as pl
+import pytest
+from sklearn.base import BaseEstimator, RegressorMixin
+from sklearn.linear_model import LinearRegression, Ridge
+
+from yohou.point import PointReductionForecaster
+
+LENGTH = 50
+
+
+@pytest.fixture(scope="module")
+def reduction_data():
+    """Single-target linear trend with exogenous features."""
+    time = pl.datetime_range(
+        start=datetime(2021, 1, 1),
+        end=datetime(2021, 1, 1, 0, 0, LENGTH - 1),
+        interval="1s",
+        eager=True,
+    )
+    y = pl.DataFrame({
+        "time": time,
+        "value": [2.0 * i + 10.0 for i in range(LENGTH)],
+    })
+    X = pl.DataFrame({
+        "time": time,
+        "feat_a": [float(i) for i in range(LENGTH)],
+        "feat_b": [float(i) + 100.0 for i in range(LENGTH)],
+    })
+    return y[:40], y[40:], X[:40], X[40:]
+
+
+@pytest.fixture(scope="module")
+def multi_target_data():
+    """Two-target dataset with exogenous features."""
+    time = pl.datetime_range(
+        start=datetime(2021, 1, 1),
+        end=datetime(2021, 1, 1, 0, 0, LENGTH - 1),
+        interval="1s",
+        eager=True,
+    )
+    y = pl.DataFrame({
+        "time": time,
+        "sales": [float(i) for i in range(LENGTH)],
+        "revenue": [float(i) * 2.5 for i in range(LENGTH)],
+    })
+    X = pl.DataFrame({
+        "time": time,
+        "promo": [float(i % 3) for i in range(LENGTH)],
+        "weekday": [float(i % 7) for i in range(LENGTH)],
+    })
+    return y[:40], y[40:], X[:40], X[40:]
+
+
+@pytest.fixture(scope="module")
+def panel_data():
+    """Two-group panel dataset."""
+    time = pl.datetime_range(
+        start=datetime(2021, 1, 1),
+        end=datetime(2021, 1, 1, 0, 0, LENGTH - 1),
+        interval="1s",
+        eager=True,
+    )
+    y = pl.DataFrame({
+        "time": time,
+        "store_a__sales": [float(i) for i in range(LENGTH)],
+        "store_b__sales": [float(i) + 5.0 for i in range(LENGTH)],
+    })
+    X = pl.DataFrame({
+        "time": time,
+        "store_a__promo": [float(i % 2) for i in range(LENGTH)],
+        "store_b__promo": [float(i % 3) for i in range(LENGTH)],
+        "weather": [float(i % 4) for i in range(LENGTH)],
+    })
+    return y[:40], y[40:], X[:40], X[40:]
+
+
+class _SpyEstimator(BaseEstimator, RegressorMixin):
+    """Estimator that records the types and column names of fit/predict inputs.
+
+    Uses a class-level list to track predict calls because the forecaster's
+    predict path deepcopies the forecaster (so instance state on the original
+    is not updated).
+    """
+
+    predict_calls: list[dict] = []
+
+    def __init__(self):
+        self.fit_X_type = None
+        self.fit_X_columns = None
+        self.fit_y_type = None
+        self.fit_y_columns = None
+        self._inner = Ridge()
+
+    @classmethod
+    def reset_predict_calls(cls):
+        cls.predict_calls = []
+
+    def fit(self, X, y, **fit_params):
+        self.fit_X_type = type(X)
+        self.fit_y_type = type(y)
+        self.fit_X_columns = list(X.columns) if hasattr(X, "columns") else None
+        if isinstance(y, pl.DataFrame):
+            self.fit_y_columns = list(y.columns)
+        elif isinstance(y, pl.Series):
+            self.fit_y_columns = [y.name]
+        else:
+            self.fit_y_columns = None
+        self._inner.fit(X, y)
+        return self
+
+    def predict(self, X):
+        _SpyEstimator.predict_calls.append({
+            "X_type": type(X),
+            "X_columns": list(X.columns) if hasattr(X, "columns") else None,
+        })
+        return self._inner.predict(X)
+
+
+def _get_fitted_estimator(forecaster):
+    """Return the first fitted estimator (handles both single and list)."""
+    est = forecaster.estimator_
+    return est[0] if isinstance(est, list) else est
+
+
+# ---------------------------------------------------------------------------
+# Type contract at fit boundary
+# ---------------------------------------------------------------------------
+
+
+class TestFitReceivesDataFrames:
+    """Verify that the estimator receives DataFrames at fit time."""
+
+    @pytest.mark.parametrize("strategy", ["multi-output", "direct", "dir-rec"])
+    def test_X_is_dataframe(self, reduction_data, strategy):
+        """The estimator's fit() receives a Polars DataFrame for X."""
+        y_train, _, X_train, _ = reduction_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy=strategy)
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        assert _get_fitted_estimator(forecaster).fit_X_type is pl.DataFrame
+
+    @pytest.mark.parametrize("strategy", ["multi-output", "direct", "dir-rec"])
+    def test_y_is_polars_type(self, reduction_data, strategy):
+        """The estimator's fit() receives a Polars DataFrame or Series for y."""
+        y_train, _, X_train, _ = reduction_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy=strategy)
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        assert _get_fitted_estimator(forecaster).fit_y_type in (pl.DataFrame, pl.Series)
+
+    def test_single_target_direct_y_is_series(self, reduction_data):
+        """Single-target direct passes a Series for y (not a 1-column DataFrame)."""
+        y_train, _, X_train, _ = reduction_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy="direct")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        for est in forecaster.estimator_:
+            assert est.fit_y_type is pl.Series
+
+    def test_single_target_dir_rec_y_is_series(self, reduction_data):
+        """Single-target dir-rec passes a Series for y."""
+        y_train, _, X_train, _ = reduction_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy="dir-rec")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        for est in forecaster.estimator_:
+            assert est.fit_y_type is pl.Series
+
+    def test_multi_target_multi_output_y_is_dataframe(self, multi_target_data):
+        """Multi-target multi-output passes a DataFrame for y."""
+        y_train, _, X_train, _ = multi_target_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy="multi-output")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        assert forecaster.estimator_.fit_y_type is pl.DataFrame
+
+
+# ---------------------------------------------------------------------------
+# Type contract at predict boundary
+# ---------------------------------------------------------------------------
+
+
+class TestPredictReceivesDataFrames:
+    """Verify that the estimator receives DataFrames at predict time."""
+
+    @pytest.mark.parametrize("strategy", ["multi-output", "direct", "dir-rec"])
+    def test_X_is_dataframe(self, reduction_data, strategy):
+        """The estimator's predict() receives a Polars DataFrame for X."""
+        y_train, _, X_train, X_test = reduction_data
+        spy = _SpyEstimator()
+        _SpyEstimator.reset_predict_calls()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy=strategy)
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+        forecaster.predict(X=X_test[:3], forecasting_horizon=3)
+
+        assert len(_SpyEstimator.predict_calls) > 0
+        for call in _SpyEstimator.predict_calls:
+            assert call["X_type"] is pl.DataFrame
+
+
+# ---------------------------------------------------------------------------
+# Feature name consistency between fit and predict
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureNamesConsistency:
+    """Verify that feature names are consistent between fit and predict."""
+
+    @pytest.mark.parametrize("strategy", ["multi-output", "direct", "dir-rec"])
+    def test_fit_predict_columns_match(self, reduction_data, strategy):
+        """Feature columns passed to fit and predict are identical."""
+        y_train, _, X_train, X_test = reduction_data
+        spy = _SpyEstimator()
+        _SpyEstimator.reset_predict_calls()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy=strategy)
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+        forecaster.predict(X=X_test[:3], forecasting_horizon=3)
+
+        fitted = _get_fitted_estimator(forecaster)
+        # The first predict call corresponds to the first estimator
+        assert _SpyEstimator.predict_calls[0]["X_columns"] == fitted.fit_X_columns
+
+    def test_columns_include_lagged_target(self, reduction_data):
+        """Feature columns include lagged target when target_as_feature is set."""
+        y_train, _, X_train, X_test = reduction_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, target_as_feature="transformed")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=2)
+
+        columns = forecaster.estimator_.fit_X_columns
+        assert any("value" in c for c in columns), f"Expected lagged target in columns: {columns}"
+
+    def test_columns_exclude_time(self, reduction_data):
+        """Feature columns never include the 'time' column."""
+        y_train, _, X_train, _ = reduction_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy)
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=2)
+
+        assert "time" not in _get_fitted_estimator(forecaster).fit_X_columns
+
+    @pytest.mark.parametrize("strategy", ["multi-output", "direct", "dir-rec"])
+    def test_panel_fit_predict_columns_match(self, panel_data, strategy):
+        """Panel data: feature columns match between fit and predict."""
+        y_train, _, X_train, X_test = panel_data
+        spy = _SpyEstimator()
+        _SpyEstimator.reset_predict_calls()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy=strategy)
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+        forecaster.predict(X=X_test[:3], forecasting_horizon=3)
+
+        fitted = _get_fitted_estimator(forecaster)
+        assert _SpyEstimator.predict_calls[0]["X_columns"] == fitted.fit_X_columns
+
+
+# ---------------------------------------------------------------------------
+# Target (y) column names
+# ---------------------------------------------------------------------------
+
+
+class TestYTabColumnNames:
+    """Verify that y passed to the estimator has meaningful column names."""
+
+    def test_multi_output_y_has_step_columns(self, reduction_data):
+        """Multi-output y has columns named {target}_step_{h}."""
+        y_train, _, X_train, _ = reduction_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy="multi-output")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        assert forecaster.estimator_.fit_y_columns == [
+            "value_step_1", "value_step_2", "value_step_3",
+        ]
+
+    def test_direct_y_has_step_column_per_estimator(self, reduction_data):
+        """Each direct estimator receives the column for its step."""
+        y_train, _, X_train, _ = reduction_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy="direct")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        for step, est in enumerate(forecaster.estimator_):
+            assert est.fit_y_columns == [f"value_step_{step + 1}"]
+
+    def test_dir_rec_y_has_step_column_per_estimator(self, reduction_data):
+        """Each dir-rec estimator receives the column for its step."""
+        y_train, _, X_train, _ = reduction_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy="dir-rec")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        for step, est in enumerate(forecaster.estimator_):
+            assert est.fit_y_columns == [f"value_step_{step + 1}"]
+
+    def test_multi_target_multi_output_y_columns(self, multi_target_data):
+        """Multi-target multi-output y has all target-step combinations."""
+        y_train, _, X_train, _ = multi_target_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy="multi-output")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=2)
+
+        assert forecaster.estimator_.fit_y_columns == [
+            "sales_step_1", "revenue_step_1", "sales_step_2", "revenue_step_2",
+        ]
+
+    def test_multi_target_direct_y_columns(self, multi_target_data):
+        """Multi-target direct: each estimator gets its step for all targets."""
+        y_train, _, X_train, _ = multi_target_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy="direct")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=2)
+
+        assert forecaster.estimator_[0].fit_y_columns == ["sales_step_1", "revenue_step_1"]
+        assert forecaster.estimator_[1].fit_y_columns == ["sales_step_2", "revenue_step_2"]
+
+
+# ---------------------------------------------------------------------------
+# Dir-rec augmented feature names
+# ---------------------------------------------------------------------------
+
+
+class TestDirRecAugmentedFeatureNames:
+    """Verify that dir-rec augmentation adds named columns progressively."""
+
+    def test_augmented_columns_are_named_and_progressive(self, reduction_data):
+        """Each subsequent dir-rec model has additional named columns."""
+        y_train, _, X_train, _ = reduction_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy="dir-rec")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        base_cols = forecaster.estimator_[0].fit_X_columns
+        step1_cols = forecaster.estimator_[1].fit_X_columns
+        step2_cols = forecaster.estimator_[2].fit_X_columns
+
+        # Step 1 has more columns than step 0
+        assert step1_cols[:len(base_cols)] == base_cols
+        assert len(step1_cols) > len(base_cols)
+
+        # Step 2 has more columns than step 1
+        assert step2_cols[:len(base_cols)] == base_cols
+        assert len(step2_cols) > len(step1_cols)
+
+        # All columns are strings (no integer indices)
+        for cols in [base_cols, step1_cols, step2_cols]:
+            assert all(isinstance(c, str) for c in cols)
+
+    def test_predict_passes_augmented_dataframe(self, reduction_data):
+        """Dir-rec predict passes DataFrames with augmented columns to later estimators."""
+        y_train, _, X_train, X_test = reduction_data
+        spy = _SpyEstimator()
+        _SpyEstimator.reset_predict_calls()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy="dir-rec")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+        forecaster.predict(X=X_test[:3], forecasting_horizon=3)
+
+        # All predict calls should receive DataFrames
+        assert all(c["X_type"] is pl.DataFrame for c in _SpyEstimator.predict_calls)
+        # The last estimator's predict call should have more columns than the first
+        first_call = _SpyEstimator.predict_calls[0]
+        last_call = _SpyEstimator.predict_calls[-1]
+        assert len(last_call["X_columns"]) > len(first_call["X_columns"])
+
+    def test_fit_predict_column_count_matches(self, reduction_data):
+        """The last dir-rec estimator sees the same number of columns at fit and predict."""
+        y_train, _, X_train, X_test = reduction_data
+        spy = _SpyEstimator()
+        _SpyEstimator.reset_predict_calls()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy="dir-rec")
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+        forecaster.predict(X=X_test[:3], forecasting_horizon=3)
+
+        last_est = forecaster.estimator_[-1]
+        last_predict_call = _SpyEstimator.predict_calls[-1]
+        assert len(last_predict_call["X_columns"]) == len(last_est.fit_X_columns)
+
+
+# ---------------------------------------------------------------------------
+# No sklearn feature-name warnings (regression test for the original bug)
+# ---------------------------------------------------------------------------
+
+
+class TestNoFeatureNameWarning:
+    """Verify no sklearn 'feature names' UserWarning is raised."""
+
+    @pytest.mark.parametrize("strategy", ["multi-output", "direct", "dir-rec"])
+    def test_no_warning_with_ridge(self, reduction_data, strategy):
+        """Ridge predict emits no 'feature names' warning for any strategy."""
+        import warnings
+
+        y_train, _, X_train, X_test = reduction_data
+        forecaster = PointReductionForecaster(estimator=Ridge(), reduction_strategy=strategy)
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            forecaster.predict(X=X_test[:3], forecasting_horizon=3)
+
+        feature_warnings = [w for w in record if "feature names" in str(w.message).lower()]
+        assert len(feature_warnings) == 0
+
+    def test_no_warning_with_linear_regression(self, reduction_data):
+        """LinearRegression predict emits no 'feature names' warning."""
+        import warnings
+
+        y_train, _, X_train, X_test = reduction_data
+        forecaster = PointReductionForecaster(estimator=LinearRegression())
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            forecaster.predict(X=X_test[:3], forecasting_horizon=3)
+
+        feature_warnings = [w for w in record if "feature names" in str(w.message).lower()]
+        assert len(feature_warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Panel data pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestPanelDataFramePipeline:
+    """Verify the DataFrame pipeline works with panel data."""
+
+    @pytest.mark.parametrize("strategy", ["multi-output", "direct", "dir-rec"])
+    def test_X_is_dataframe_at_fit(self, panel_data, strategy):
+        """Panel: estimator's fit() receives a Polars DataFrame for X."""
+        y_train, _, X_train, _ = panel_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy=strategy)
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        assert _get_fitted_estimator(forecaster).fit_X_type is pl.DataFrame
+
+    @pytest.mark.parametrize("strategy", ["multi-output", "direct", "dir-rec"])
+    def test_X_is_dataframe_at_predict(self, panel_data, strategy):
+        """Panel: estimator's predict() receives a Polars DataFrame for X."""
+        y_train, _, X_train, X_test = panel_data
+        spy = _SpyEstimator()
+        _SpyEstimator.reset_predict_calls()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy=strategy)
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+        forecaster.predict(X=X_test[:3], forecasting_horizon=3)
+
+        assert len(_SpyEstimator.predict_calls) > 0
+        for call in _SpyEstimator.predict_calls:
+            assert call["X_type"] is pl.DataFrame
+
+    @pytest.mark.parametrize("strategy", ["multi-output", "direct", "dir-rec"])
+    def test_y_is_polars_type_at_fit(self, panel_data, strategy):
+        """Panel: estimator's fit() receives a Polars DataFrame or Series for y."""
+        y_train, _, X_train, _ = panel_data
+        spy = _SpyEstimator()
+        forecaster = PointReductionForecaster(estimator=spy, reduction_strategy=strategy)
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+
+        assert _get_fitted_estimator(forecaster).fit_y_type in (pl.DataFrame, pl.Series)
+
+
+# ---------------------------------------------------------------------------
+# Prediction correctness (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+class TestPredictionCorrectness:
+    """Verify predictions remain numerically correct after the DataFrame change."""
+
+    @pytest.mark.parametrize("strategy", ["multi-output", "direct", "dir-rec"])
+    def test_linear_trend(self, strategy):
+        """All strategies produce exact predictions on a perfect linear trend."""
+        length = 60
+        time = pl.datetime_range(
+            start=datetime(2021, 1, 1),
+            end=datetime(2021, 1, 1, 0, 0, length - 1),
+            interval="1s",
+            eager=True,
+        )
+        y = pl.DataFrame({"time": time, "value": [3.0 * i + 7.0 for i in range(length)]})
+
+        forecaster = PointReductionForecaster(
+            estimator=LinearRegression(),
+            reduction_strategy=strategy,
+        )
+        forecaster.fit(y[:50], forecasting_horizon=3)
+        y_pred = forecaster.predict(forecasting_horizon=3)
+
+        expected = [3.0 * i + 7.0 for i in range(50, 53)]
+        np.testing.assert_allclose(y_pred["value"].to_numpy(), expected, atol=1e-8)
+
+    @pytest.mark.parametrize("strategy", ["multi-output", "direct", "dir-rec"])
+    def test_constant_series(self, strategy):
+        """All strategies predict the constant value for a constant series."""
+        length = 40
+        time = pl.datetime_range(
+            start=datetime(2021, 1, 1),
+            end=datetime(2021, 1, 1, 0, 0, length - 1),
+            interval="1s",
+            eager=True,
+        )
+        y = pl.DataFrame({"time": time, "value": [42.0] * length})
+
+        forecaster = PointReductionForecaster(
+            estimator=LinearRegression(),
+            reduction_strategy=strategy,
+        )
+        forecaster.fit(y[:30], forecasting_horizon=3)
+        y_pred = forecaster.predict(forecasting_horizon=3)
+
+        np.testing.assert_allclose(y_pred["value"].to_numpy(), [42.0, 42.0, 42.0], atol=1e-8)
+
+    def test_multi_target_shape_and_columns(self, multi_target_data):
+        """Multi-target predictions have correct shape and column names."""
+        y_train, _, X_train, X_test = multi_target_data
+        forecaster = PointReductionForecaster(estimator=LinearRegression())
+        forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
+        y_pred = forecaster.predict(X=X_test[:3], forecasting_horizon=3)
+
+        assert y_pred.shape[0] == 3
+        assert "sales" in y_pred.columns
+        assert "revenue" in y_pred.columns

--- a/tests/base/test_reduction_dataframe_pipeline.py
+++ b/tests/base/test_reduction_dataframe_pipeline.py
@@ -133,11 +133,6 @@ def _get_fitted_estimator(forecaster):
     return est[0] if isinstance(est, list) else est
 
 
-# ---------------------------------------------------------------------------
-# Type contract at fit boundary
-# ---------------------------------------------------------------------------
-
-
 class TestFitReceivesDataFrames:
     """Verify that the estimator receives DataFrames at fit time."""
 
@@ -191,11 +186,6 @@ class TestFitReceivesDataFrames:
         assert forecaster.estimator_.fit_y_type is pl.DataFrame
 
 
-# ---------------------------------------------------------------------------
-# Type contract at predict boundary
-# ---------------------------------------------------------------------------
-
-
 class TestPredictReceivesDataFrames:
     """Verify that the estimator receives DataFrames at predict time."""
 
@@ -212,11 +202,6 @@ class TestPredictReceivesDataFrames:
         assert len(_SpyEstimator.predict_calls) > 0
         for call in _SpyEstimator.predict_calls:
             assert call["X_type"] is pl.DataFrame
-
-
-# ---------------------------------------------------------------------------
-# Feature name consistency between fit and predict
-# ---------------------------------------------------------------------------
 
 
 class TestFeatureNamesConsistency:
@@ -267,11 +252,6 @@ class TestFeatureNamesConsistency:
 
         fitted = _get_fitted_estimator(forecaster)
         assert _SpyEstimator.predict_calls[0]["X_columns"] == fitted.fit_X_columns
-
-
-# ---------------------------------------------------------------------------
-# Target (y) column names
-# ---------------------------------------------------------------------------
 
 
 class TestYTabColumnNames:
@@ -330,11 +310,6 @@ class TestYTabColumnNames:
         assert forecaster.estimator_[1].fit_y_columns == ["sales_step_2", "revenue_step_2"]
 
 
-# ---------------------------------------------------------------------------
-# Dir-rec augmented feature names
-# ---------------------------------------------------------------------------
-
-
 class TestDirRecAugmentedFeatureNames:
     """Verify that dir-rec augmentation adds named columns progressively."""
 
@@ -391,11 +366,6 @@ class TestDirRecAugmentedFeatureNames:
         assert len(last_predict_call["X_columns"]) == len(last_est.fit_X_columns)
 
 
-# ---------------------------------------------------------------------------
-# No sklearn feature-name warnings (regression test for the original bug)
-# ---------------------------------------------------------------------------
-
-
 class TestNoFeatureNameWarning:
     """Verify no sklearn 'feature names' UserWarning is raised."""
 
@@ -429,11 +399,6 @@ class TestNoFeatureNameWarning:
 
         feature_warnings = [w for w in record if "feature names" in str(w.message).lower()]
         assert len(feature_warnings) == 0
-
-
-# ---------------------------------------------------------------------------
-# Panel data pipeline
-# ---------------------------------------------------------------------------
 
 
 class TestPanelDataFramePipeline:
@@ -472,11 +437,6 @@ class TestPanelDataFramePipeline:
         forecaster.fit(y=y_train, X=X_train, forecasting_horizon=3)
 
         assert _get_fitted_estimator(forecaster).fit_y_type in (pl.DataFrame, pl.Series)
-
-
-# ---------------------------------------------------------------------------
-# Prediction correctness (end-to-end)
-# ---------------------------------------------------------------------------
 
 
 class TestPredictionCorrectness:


### PR DESCRIPTION
## Description

Keep X_tab and y_tab as Polars DataFrames throughout the reduction pipeline so that estimators recording feature names during fit (e.g. LightGBM, XGBoost) see consistent column names at predict time, eliminating the sklearn "feature names" UserWarning.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Estimators like LGBMRegressor store `feature_names_in_` during fit. The reduction pipeline was calling `.to_numpy()` on X_tab and y_tab before passing them to the estimator, which dropped column names. At predict time, the estimator received a plain numpy array and sklearn's `_check_feature_names` raised a UserWarning.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings