### PR TITLE
feat(interval): allow coverage_rate=0 for point forecasts

### DIFF
--- a/src/yohou/ensemble/voting_interval.py
+++ b/src/yohou/ensemble/voting_interval.py
@@ -242,8 +242,8 @@ class VotingIntervalForecaster(_BaseEnsembleForecaster, BaseIntervalForecaster, 
 
         if coverage_rates is not None:
             for rate in coverage_rates:
-                if rate <= 0 or rate > 1:
-                    raise ValueError(f"All coverage_rates must be in (0, 1], got {rate}")
+                if rate < 0 or rate > 1:
+                    raise ValueError(f"All coverage_rates must be in [0, 1], got {rate}")
 
         extra_fit_kwargs = {"coverage_rates": coverage_rates} if coverage_rates is not None else None
 

--- a/src/yohou/interval/base.py
+++ b/src/yohou/interval/base.py
@@ -243,7 +243,7 @@ class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         Raises
         ------
         ValueError
-            If ``forecasting_horizon`` < 1, ``coverage_rates`` not in (0, 1],
+            If ``forecasting_horizon`` < 1, ``coverage_rates`` not in [0, 1],
             or if ``y`` / ``X`` have invalid structure.
 
         """
@@ -270,7 +270,7 @@ class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         Raises
         ------
         ValueError
-            If forecasting_horizon < 1 or coverage_rates not in (0, 1].
+            If forecasting_horizon < 1 or coverage_rates not in [0, 1].
 
         """
         if forecasting_horizon < 1:
@@ -281,8 +281,8 @@ class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         # Validate coverage rates
         for rate in coverage_rates:
-            if not (0 < rate <= 1):
-                raise ValueError(f"All coverage_rates must be in (0, 1], got {rate}")
+            if not (0 <= rate <= 1):
+                raise ValueError(f"All coverage_rates must be in [0, 1], got {rate}")
 
         return forecasting_horizon, coverage_rates
 
@@ -368,7 +368,7 @@ class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         sklearn.exceptions.NotFittedError
             If the forecaster has not been fitted yet.
         ValueError
-            If ``X`` has invalid structure, ``coverage_rates`` not in (0, 1],
+            If ``X`` has invalid structure, ``coverage_rates`` not in [0, 1],
             or ``groups`` contains names not seen during fit.
 
         """

--- a/src/yohou/metrics/base.py
+++ b/src/yohou/metrics/base.py
@@ -1272,8 +1272,8 @@ class BaseIntervalScorer(BaseScorer, metaclass=abc.ABCMeta):
 
             # Check range
             for rate in coverage_filter:
-                if not 0 < rate < 1:
-                    raise ValueError(f"All coverage rates must be between 0 and 1 (exclusive), got {rate}")
+                if not 0 <= rate <= 1:
+                    raise ValueError(f"All coverage rates must be between 0 and 1 (inclusive), got {rate}")
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, y_train: pl.DataFrame, *, forecaster=None, **params) -> BaseIntervalScorer:

--- a/src/yohou/metrics/conformity_base.py
+++ b/src/yohou/metrics/conformity_base.py
@@ -84,6 +84,11 @@ class BaseConformityScorer(BaseScorer, metaclass=abc.ABCMeta):
             )
 
         alpha = 1.0 - coverage_rate
+
+        if coverage_rate == 0:
+            median_val: float = np.quantile(scores_array, 0.5, method="lower")
+            return median_val, median_val
+
         lower_quantile: float = np.quantile(scores_array, alpha / 2.0, method="lower")
 
         upper_quantile: float = np.quantile(scores_array, 1.0 - alpha / 2.0, method="higher")

--- a/src/yohou/metrics/interval.py
+++ b/src/yohou/metrics/interval.py
@@ -335,6 +335,11 @@ class IntervalScore(BaseIntervalScorer):
         """Compute per-row interval score values."""
         frames = []
         for rate in coverage_rates:
+            if rate == 0:
+                raise ValueError(
+                    "IntervalScore is undefined for coverage_rate=0 "
+                    "(the penalty term requires division by the coverage rate)."
+                )
             rate_data = {}
             for col in target_columns:
                 lower_col = f"{col}_lower_{rate}"

--- a/src/yohou/plotting/forecasting.py
+++ b/src/yohou/plotting/forecasting.py
@@ -374,28 +374,43 @@ def plot_forecast(
                 lower_col = f"{interval_base}_lower_{rate}"
                 upper_col = f"{interval_base}_upper_{rate}"
                 if lower_col in y_pred.columns and upper_col in y_pred.columns:
-                    rate_opacity = band_opacity * (1.0 - 0.45 * sort_idx / max(1, n_rates - 1))
-                    rgba = f"rgba({rgb[0]}, {rgb[1]}, {rgb[2]}, {rate_opacity:.3f})"
                     t = y_pred["time"].to_list()
                     y_upper = y_pred[upper_col].to_list()
                     y_lower = y_pred[lower_col].to_list()
-                    x_band = t + t[::-1]
-                    y_band = y_upper + y_lower[::-1]
-                    ctx.fig.add_trace(
-                        go.Scatter(
-                            x=x_band,
-                            y=y_band,
-                            fill="toself",
-                            fillcolor=rgba,
-                            mode="lines",
-                            line={"width": 0, "color": rgba},
-                            name=f"{col} ({rate:.0%} PI)",
-                            legendrank=11 + sort_idx,
-                            hoverinfo="skip",
-                        ),
-                        row=ctx.row,
-                        col=ctx.col,
-                    )
+                    if rate == 0:
+                        ctx.fig.add_trace(
+                            go.Scatter(
+                                x=t,
+                                y=y_upper,
+                                mode="lines",
+                                line={"dash": "dash", "width": line_width * 0.75, "color": forecast_color},
+                                name=f"{col} (Median)",
+                                legendrank=11 + sort_idx,
+                                hoverinfo="skip",
+                            ),
+                            row=ctx.row,
+                            col=ctx.col,
+                        )
+                    else:
+                        rate_opacity = band_opacity * (1.0 - 0.45 * sort_idx / max(1, n_rates - 1))
+                        rgba = f"rgba({rgb[0]}, {rgb[1]}, {rgb[2]}, {rate_opacity:.3f})"
+                        x_band = t + t[::-1]
+                        y_band = y_upper + y_lower[::-1]
+                        ctx.fig.add_trace(
+                            go.Scatter(
+                                x=x_band,
+                                y=y_band,
+                                fill="toself",
+                                fillcolor=rgba,
+                                mode="lines",
+                                line={"width": 0, "color": rgba},
+                                name=f"{col} ({rate:.0%} PI)",
+                                legendrank=11 + sort_idx,
+                                hoverinfo="skip",
+                            ),
+                            row=ctx.row,
+                            col=ctx.col,
+                        )
 
         # Actual test data (prepend last train point to close the gap)
         _x_actual = y_test["time"]
@@ -1112,28 +1127,44 @@ def _plot_forecast_multi_model(
                 upper_col = f"{interval_base}_upper_{rate}"
                 if lower_col in y_pred.columns and upper_col in y_pred.columns:
                     rgb = tuple(int(model_color[i : i + 2], 16) for i in (1, 3, 5))
-                    rgba = f"rgba({rgb[0]}, {rgb[1]}, {rgb[2]}, {band_opacity})"
                     t = y_pred["time"].to_list()
                     y_upper = y_pred[upper_col].to_list()
                     y_lower = y_pred[lower_col].to_list()
-                    x_band = t + t[::-1]
-                    y_band = y_upper + y_lower[::-1]
-                    ctx.fig.add_trace(
-                        go.Scatter(
-                            x=x_band,
-                            y=y_band,
-                            fill="toself",
-                            fillcolor=rgba,
-                            mode="lines",
-                            line={"width": 0, "color": rgba},
-                            name=f"{model_name} ({rate:.0%} PI)",
-                            legendgroup=model_name,
-                            legendrank=10 + model_idx * 100 + sort_idx + 1,
-                            hoverinfo="skip",
-                        ),
-                        row=ctx.row,
-                        col=ctx.col,
-                    )
+                    if rate == 0:
+                        ctx.fig.add_trace(
+                            go.Scatter(
+                                x=t,
+                                y=y_upper,
+                                mode="lines",
+                                line={"dash": "dash", "width": line_width * 0.75, "color": model_color},
+                                name=f"{model_name} (Median)",
+                                legendgroup=model_name,
+                                legendrank=10 + model_idx * 100 + sort_idx + 1,
+                                hoverinfo="skip",
+                            ),
+                            row=ctx.row,
+                            col=ctx.col,
+                        )
+                    else:
+                        rgba = f"rgba({rgb[0]}, {rgb[1]}, {rgb[2]}, {band_opacity})"
+                        x_band = t + t[::-1]
+                        y_band = y_upper + y_lower[::-1]
+                        ctx.fig.add_trace(
+                            go.Scatter(
+                                x=x_band,
+                                y=y_band,
+                                fill="toself",
+                                fillcolor=rgba,
+                                mode="lines",
+                                line={"width": 0, "color": rgba},
+                                name=f"{model_name} ({rate:.0%} PI)",
+                                legendgroup=model_name,
+                                legendrank=10 + model_idx * 100 + sort_idx + 1,
+                                hoverinfo="skip",
+                            ),
+                            row=ctx.row,
+                            col=ctx.col,
+                        )
 
         # Actual test data (prepend last train point to close the gap)
         _x_actual = y_test["time"]
@@ -1216,6 +1247,7 @@ def _render_interval_bands(
     base_color,
     member,
     band_opacity,
+    line_width,
     legend_tracker,
     group_title,
     row,
@@ -1238,16 +1270,17 @@ def _render_interval_bands(
             lower_c = f"{interval_base}_lower_{rate}"
             upper_c = f"{interval_base}_upper_{rate}"
             if lower_c in m_pred.columns and upper_c in m_pred.columns:
-                rgba = f"rgba({rgb[0]}, {rgb[1]}, {rgb[2]}, {band_opacity})"
                 t = m_pred["time"].to_list()
                 y_upper = m_pred[upper_c].to_list()
                 y_lower = m_pred[lower_c].to_list()
-                x_band = t + t[::-1]
-                y_band = y_upper + y_lower[::-1]
                 if multi_member:
-                    pi_entry = f"{m_name} ({rate:.0%} PI)" if is_multi_model else f"{rate:.0%} PI"
+                    pi_entry = f"{m_name} (Median)" if rate == 0 else f"{m_name} ({rate:.0%} PI)"
+                    if not is_multi_model:
+                        pi_entry = "Median" if rate == 0 else f"{rate:.0%} PI"
+                elif is_multi_model:
+                    pi_entry = f"{m_name} (Median)" if rate == 0 else f"{m_name} ({rate:.0%} PI)"
                 else:
-                    pi_entry = f"{rate:.0%} PI" if not is_multi_model else f"{m_name} ({rate:.0%} PI)"
+                    pi_entry = "Median" if rate == 0 else f"{rate:.0%} PI"
 
                 if group_title is not None:
                     legend_kw = grouped_legend_kwargs(group_title, pi_entry, legend_tracker, is_first_in_group=False)
@@ -1258,22 +1291,40 @@ def _render_interval_bands(
                         "legendgroup": m_name,
                     }
 
-                fig.add_trace(
-                    go.Scatter(
-                        x=x_band,
-                        y=y_band,
-                        fill="toself",
-                        fillcolor=rgba,
-                        mode="lines",
-                        line={"width": 0, "color": rgba},
-                        **legend_kw,
-                        legendrank=10 + m_idx * 100 + sort_idx + 1,
-                        hoverinfo="skip",
-                    ),
-                    row=row,
-                    col=col_grid,
-                    **_fill_trace_kwargs(fig),
-                )
+                if rate == 0:
+                    fig.add_trace(
+                        go.Scatter(
+                            x=t,
+                            y=y_upper,
+                            mode="lines",
+                            line={"dash": "dash", "width": line_width * 0.75, "color": band_c},
+                            **legend_kw,
+                            legendrank=10 + m_idx * 100 + sort_idx + 1,
+                            hoverinfo="skip",
+                        ),
+                        row=row,
+                        col=col_grid,
+                    )
+                else:
+                    rgba = f"rgba({rgb[0]}, {rgb[1]}, {rgb[2]}, {band_opacity})"
+                    x_band = t + t[::-1]
+                    y_band = y_upper + y_lower[::-1]
+                    fig.add_trace(
+                        go.Scatter(
+                            x=x_band,
+                            y=y_band,
+                            fill="toself",
+                            fillcolor=rgba,
+                            mode="lines",
+                            line={"width": 0, "color": rgba},
+                            **legend_kw,
+                            legendrank=10 + m_idx * 100 + sort_idx + 1,
+                            hoverinfo="skip",
+                        ),
+                        row=row,
+                        col=col_grid,
+                        **_fill_trace_kwargs(fig),
+                    )
 
 
 def _render_forecast_trace(
@@ -1868,6 +1919,7 @@ def _plot_forecast_panel(
                 base_color=base_color if multi_sub else None,
                 member=sub_name,
                 band_opacity=band_opacity,
+                line_width=line_width,
                 legend_tracker=legend_tracker,
                 group_title=group_title,
                 row=row,

--- a/src/yohou/testing/generators.py
+++ b/src/yohou/testing/generators.py
@@ -834,7 +834,7 @@ def _yield_yohou_scorer_checks(
     if tags.get("prediction_type") == "interval":
         validation_test_cases.extend([
             ("coverage_rates", [1.5], "coverage"),  # Out of range
-            ("coverage_rates", [0.0], "coverage"),  # Out of range
+            ("coverage_rates", [-0.5], "coverage"),  # Negative
             ("coverage_rates", [[]], "coverage"),  # Invalid type (nested list)
         ])
 

--- a/src/yohou/testing/interval.py
+++ b/src/yohou/testing/interval.py
@@ -162,7 +162,7 @@ def check_interval_prediction_types(forecaster) -> None:
 
 
 def check_coverage_rates_parameter(forecaster) -> None:
-    """Check coverage_rates is list of floats in (0, 1).
+    """Check coverage_rates is list of floats in [0, 1].
 
     Parameters
     ----------
@@ -183,7 +183,7 @@ def check_coverage_rates_parameter(forecaster) -> None:
 
     for rate in coverage_rates:
         assert isinstance(rate, int | float), f"Each coverage rate should be numeric, got {type(rate)} for {rate}"
-        assert 0 < rate < 1, f"Coverage rates should be in (0, 1), got {rate}"
+        assert 0 <= rate <= 1, f"Coverage rates should be in [0, 1], got {rate}"
 
 
 def check_coverage_rates_validation(forecaster, y: pl.DataFrame, X: pl.DataFrame | None = None) -> None:
@@ -204,16 +204,6 @@ def check_coverage_rates_validation(forecaster, y: pl.DataFrame, X: pl.DataFrame
         If invalid coverage_rates don't raise ValueError
 
     """
-    # Test rate = 0 (boundary - invalid)
-    forecaster_clone = clone(forecaster)
-    try:
-        forecaster_clone.fit(y, X, forecasting_horizon=3, coverage_rates=[0.0])
-        raise AssertionError(f"{forecaster_clone.__class__.__name__} should raise ValueError for coverage_rates=[0.0]")
-    except ValueError as e:
-        assert "coverage" in str(e).lower() or "0" in str(e).lower(), (
-            f"ValueError should mention coverage_rates, got: {e}"
-        )
-
     # Test rate = 1.5 (above 1 - invalid)
     forecaster_clone = clone(forecaster)
     try:
@@ -239,9 +229,9 @@ def check_coverage_rates_validation(forecaster, y: pl.DataFrame, X: pl.DataFrame
     forecaster_clone.fit(y, X, forecasting_horizon=3, coverage_rates=[0.95])
 
     try:
-        forecaster_clone.predict_interval(forecasting_horizon=3, coverage_rates=[0.0])
+        forecaster_clone.predict_interval(forecasting_horizon=3, coverage_rates=[1.5])
         raise AssertionError(
-            f"{forecaster_clone.__class__.__name__}.predict_interval() should raise ValueError for coverage_rates=[0.0]"
+            f"{forecaster_clone.__class__.__name__}.predict_interval() should raise ValueError for coverage_rates=[1.5]"
         )
     except ValueError as e:
         assert "coverage" in str(e).lower(), f"ValueError should mention coverage_rates, got: {e}"

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -129,6 +129,22 @@ class TestSplitConformalFitPredict:
         assert isinstance(y_pred, pl.DataFrame)
         assert len(y_pred) == 3
 
+    def test_predict_interval_zero_coverage_rate(self, conformal_data):
+        """Test coverage_rate=0 produces zero-width intervals (lower == upper)."""
+        scf = SplitConformalForecaster(calibration_size=50)
+        scf.fit(conformal_data, forecasting_horizon=1, coverage_rates=[0.0])
+        y_pred = scf.predict_interval(coverage_rates=[0.0])
+        assert isinstance(y_pred, pl.DataFrame)
+        lower_cols = [c for c in y_pred.columns if "_lower_0.0" in c]
+        upper_cols = [c for c in y_pred.columns if "_upper_0.0" in c]
+        assert len(lower_cols) > 0
+        assert len(upper_cols) > 0
+        for lower_col, upper_col in zip(lower_cols, upper_cols, strict=True):
+            assert y_pred[lower_col].equals(y_pred[upper_col]), (
+                f"Expected lower == upper for coverage_rate=0, "
+                f"got lower={y_pred[lower_col].to_list()}, upper={y_pred[upper_col].to_list()}"
+            )
+
 
 class TestSplitConformalParameterValidation:
     """Test parameter validation."""

--- a/tests/metrics/test_interval.py
+++ b/tests/metrics/test_interval.py
@@ -302,6 +302,23 @@ class TestIntervalScore:
         assert "interval_score" in df.columns
         assert len(df) == 2
 
+    def test_interval_score_raises_for_zero_coverage_rate(self):
+        """Test IntervalScore raises ValueError for coverage_rate=0."""
+        y_true = pl.DataFrame({
+            "time": [datetime(2020, 1, 1)],
+            "value": [10.0],
+        })
+        y_pred = pl.DataFrame({
+            "vintage_time": [datetime(2019, 12, 31)],
+            "time": [datetime(2020, 1, 1)],
+            "value_lower_0.0": [10.0],
+            "value_upper_0.0": [10.0],
+        })
+        scorer = IntervalScore(coverage_rates=[0.0])
+        scorer.fit(y_true)
+        with pytest.raises(ValueError, match="coverage_rate=0"):
+            scorer.score(y_true, y_pred)
+
 
 class TestPinballLoss:
     def test_pinball_loss_perfect_predictions_zero_loss(self):

--- a/tests/metrics/test_parameter_validation.py
+++ b/tests/metrics/test_parameter_validation.py
@@ -300,18 +300,8 @@ class TestCoverageRates:
             scorer.fit(y)
 
     def test_coverage_rates_must_be_between_zero_and_one(self, y_X_factory):
-        """All coverage_rates must be between 0 and 1 (exclusive)."""
+        """All coverage_rates must be between 0 and 1 (inclusive)."""
         y, _ = y_X_factory(length=50, n_targets=1, seed=42)
-
-        # Test zero
-        scorer = EmpiricalCoverage(coverage_rates=[0.0, 0.9])
-        with pytest.raises(ValueError, match="All coverage rates must be between 0 and 1.*got 0.0"):
-            scorer.fit(y)
-
-        # Test one
-        scorer = EmpiricalCoverage(coverage_rates=[0.9, 1.0])
-        with pytest.raises(ValueError, match="All coverage rates must be between 0 and 1.*got 1.0"):
-            scorer.fit(y)
 
         # Test negative
         scorer = EmpiricalCoverage(coverage_rates=[-0.1, 0.9])
@@ -337,19 +327,17 @@ class TestCoverageRates:
         scorer = EmpiricalCoverage(coverage_rates=[0.5, 0.9])  # float
         scorer.fit(y)  # Should not raise
 
-    def test_coverage_rates_edge_case_boundary_values_excluded(self, y_X_factory):
-        """Boundary values 0 and 1 should be excluded."""
+    def test_coverage_rates_edge_case_boundary_values_included(self, y_X_factory):
+        """Boundary values 0 and 1 should be accepted."""
         y, _ = y_X_factory(length=50, n_targets=1, seed=42)
 
         # Test 0.0
         scorer = EmpiricalCoverage(coverage_rates=[0.0])
-        with pytest.raises(ValueError, match="must be between 0 and 1.*got 0.0"):
-            scorer.fit(y)
+        scorer.fit(y)  # Should not raise
 
         # Test 1.0
         scorer = EmpiricalCoverage(coverage_rates=[1.0])
-        with pytest.raises(ValueError, match="must be between 0 and 1.*got 1.0"):
-            scorer.fit(y)
+        scorer.fit(y)  # Should not raise
 
     def test_coverage_rates_edge_case_very_small_value(self, y_X_factory):
         """Very small valid coverage rates should be accepted."""

--- a/tests/plotting/test_forecasting.py
+++ b/tests/plotting/test_forecasting.py
@@ -70,6 +70,25 @@ class TestPlotForecast:
         fig = plot_forecast(y_test, y_pred, coverage_rates=[0.9])
         assert len(fig.data) > 0
 
+    def test_with_zero_coverage_rate_renders_dashed_median(self):
+        """Test coverage_rate=0 renders a dashed median line instead of a band."""
+        y_test = pl.DataFrame({
+            "time": pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 30), "1d", eager=True),
+            "y": [191 + i for i in range(30)],
+        })
+        median_vals = [190 + i for i in range(30)]
+        y_pred = pl.DataFrame({
+            "time": pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 30), "1d", eager=True),
+            "y": median_vals,
+            "y_lower_0.0": median_vals,
+            "y_upper_0.0": median_vals,
+        })
+        fig = plot_forecast(y_test, y_pred, coverage_rates=[0.0])
+        assert len(fig.data) > 0
+        median_traces = [t for t in fig.data if t.name is not None and "Median" in t.name]
+        assert len(median_traces) == 1
+        assert median_traces[0].line.dash == "dash"
+
     def test_groups(self):
         """Test forecast with groups parameter."""
         y_test = pl.DataFrame({
@@ -1076,6 +1095,31 @@ class TestPlotForecastMultiModelIntervals:
         assert any("M2" in n for n in names)
         assert any("PI" in n for n in names)
 
+    def test_multi_model_zero_coverage_rate_renders_dashed_median(self):
+        """Multi-model with coverage_rate=0 renders dashed median lines."""
+        dates = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 30), "1d", eager=True)
+        y_test = pl.DataFrame({"time": dates, "y": [191 + i for i in range(30)]})
+        median_a = [190 + i for i in range(30)]
+        median_b = [192 + i for i in range(30)]
+        y_pred_a = pl.DataFrame({
+            "time": dates,
+            "y": median_a,
+            "y_lower_0.0": median_a,
+            "y_upper_0.0": median_a,
+        })
+        y_pred_b = pl.DataFrame({
+            "time": dates,
+            "y": median_b,
+            "y_lower_0.0": median_b,
+            "y_upper_0.0": median_b,
+        })
+        fig = plot_forecast(y_test, {"M1": y_pred_a, "M2": y_pred_b}, coverage_rates=[0.0])
+        assert_figure_valid(fig)
+        median_traces = [t for t in fig.data if t.name is not None and "Median" in t.name]
+        assert len(median_traces) == 2
+        for trace in median_traces:
+            assert trace.line.dash == "dash"
+
 
 class TestPlotForecastPanelSingleMember:
     """Tests for panel forecast with single member per group."""
@@ -1145,6 +1189,32 @@ class TestPlotForecastPanelTrainAndIntervals:
         names = [t.name for t in fig.data if t.name is not None]
         assert any("Train" in n for n in names)
         assert any("PI" in n for n in names)
+
+    def test_panel_with_zero_coverage_rate_renders_dashed_median(self):
+        """Panel forecast with coverage_rate=0 renders dashed median lines."""
+        dates_test = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 30), "1d", eager=True)
+        y_test = pl.DataFrame({
+            "time": dates_test,
+            "y__a": [191 + i for i in range(30)],
+            "y__b": [291 + i for i in range(30)],
+        })
+        median_a = [190 + i for i in range(30)]
+        median_b = [289 + i for i in range(30)]
+        y_pred = pl.DataFrame({
+            "time": dates_test,
+            "y__a": median_a,
+            "y__b": median_b,
+            "y__a_lower_0.0": median_a,
+            "y__a_upper_0.0": median_a,
+            "y__b_lower_0.0": median_b,
+            "y__b_upper_0.0": median_b,
+        })
+        fig = plot_forecast(y_test, y_pred, coverage_rates=[0.0], groups=["y"])
+        assert_figure_valid(fig)
+        median_traces = [t for t in fig.data if t.name is not None and "Median" in t.name]
+        assert len(median_traces) > 0
+        for trace in median_traces:
+            assert trace.line.dash == "dash"
 
 
 class TestPlotForecastMultiModelTrainHistory:

--- a/tests/utils/test_parameter_validation.py
+++ b/tests/utils/test_parameter_validation.py
@@ -82,9 +82,6 @@ class TestCoverageRatesValidation:
 
         # Test invalid coverage_rates in predict_interval
         with pytest.raises(ValueError, match="coverage"):
-            forecaster.predict_interval(forecasting_horizon=3, coverage_rates=[0.0])
-
-        with pytest.raises(ValueError, match="coverage"):
             forecaster.predict_interval(forecasting_horizon=3, coverage_rates=[1.5])
 
         with pytest.raises(ValueError, match="coverage"):


### PR DESCRIPTION
## Description

Allow `coverage_rate=0` to produce degenerate intervals where lower == upper == median (0.5 quantile). Guard `IntervalScore` with `ValueError` for rate=0 (division by zero). Render a dashed median line in `plot_forecast` instead of an invisible zero-area polygon.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Setting `coverage_rate=0` is useful for producing point forecasts (median) through the interval API. Previously, rate=0 was rejected by validation. Now it produces a valid degenerate interval and plots correctly as a dashed line.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed (4439 passed)
- [x] My changes generate no new warnings