### PR TITLE
fix: sync observed_time_ in SplitConformalForecaster observe and rewind

### DIFF
--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -10,6 +10,8 @@ from sklearn.base import clone
 from sklearn.model_selection import train_test_split
 from sklearn.utils.validation import check_is_fitted
 
+from yohou.base.panel import BasePanelForecaster
+from yohou.base.standard import BaseStandardForecaster
 from yohou.metrics import AbsoluteResidual, BaseConformityScorer, Residual
 from yohou.point import BasePointForecaster, SeasonalNaive
 from yohou.utils import POINT_INTERVAL, Tags, validate_forecaster_data
@@ -262,6 +264,10 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         y, X, groups = validate_forecaster_data(self, y, X, reset=False, groups=groups)
 
         self.point_forecaster_.observe(y=y, X=X, groups=groups)
+        if self.groups_ is None:
+            self._observe_standard(y, X)
+        else:
+            BasePanelForecaster._observe_panel(self, y, X, groups)
         return self
 
     def rewind(
@@ -301,6 +307,10 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         y, X, groups = validate_forecaster_data(self, y, X, reset=False, groups=groups)
 
         self.point_forecaster_.rewind(y=y, X=X, groups=groups)
+        if self.groups_ is None:
+            self._rewind_standard(y, X)
+        else:
+            BasePanelForecaster._rewind_panel(self, y, X, groups)
         return self
 
     def predict(

--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -11,7 +11,6 @@ from sklearn.model_selection import train_test_split
 from sklearn.utils.validation import check_is_fitted
 
 from yohou.base.panel import BasePanelForecaster
-from yohou.base.standard import BaseStandardForecaster
 from yohou.metrics import AbsoluteResidual, BaseConformityScorer, Residual
 from yohou.point import BasePointForecaster, SeasonalNaive
 from yohou.utils import POINT_INTERVAL, Tags, validate_forecaster_data

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -231,6 +231,33 @@ class TestSplitConformalObserveRewind:
         assert isinstance(y_pred, pl.DataFrame)
         assert len(y_pred) == 1
 
+    def test_observe_syncs_observed_time(self, conformal_data):
+        """Test that observe updates observed_time_ on the outer forecaster."""
+        scf = SplitConformalForecaster(calibration_size=50)
+        scf.fit(conformal_data[:200], forecasting_horizon=1)
+
+        fit_time = scf.observed_time_
+
+        y_update = conformal_data[200:210]
+        scf.observe(y_update)
+
+        assert scf.observed_time_ == scf.point_forecaster_.observed_time_
+        assert scf.observed_time_ != fit_time
+        assert scf.observed_time_ == y_update["time"][-1]
+
+    def test_rewind_syncs_observed_time(self, conformal_data):
+        """Test that rewind updates observed_time_ on the outer forecaster."""
+        scf = SplitConformalForecaster(calibration_size=50)
+        scf.fit(conformal_data[:200], forecasting_horizon=1)
+
+        y_update = conformal_data[200:210]
+        scf.observe(y_update)
+
+        scf.rewind(conformal_data[190:200])
+
+        assert scf.observed_time_ == scf.point_forecaster_.observed_time_
+        assert scf.observed_time_ == conformal_data[199]["time"][0]
+
     def test_observe_not_fitted(self):
         """Test observe raises error when not fitted."""
         scf = SplitConformalForecaster()
@@ -342,8 +369,5 @@ class TestSplitConformalSystematicChecks:
         run_checks(
             forecaster,
             _yield_yohou_forecaster_checks(forecaster, y_train, None, y_test, None),
-            expected_failures={
-                # observation_horizon=0 means rewind does not update observed_time_
-                "check_rewind_replaces_observations",
-            },
+            expected_failures=set(),
         )

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -258,6 +258,41 @@ class TestSplitConformalObserveRewind:
         assert scf.observed_time_ == scf.point_forecaster_.observed_time_
         assert scf.observed_time_ == conformal_data[199]["time"][0]
 
+    def test_observe_syncs_observed_time_panel(self, y_X_factory):
+        """Test that observe updates observed_time_ on panel data."""
+        y, _ = y_X_factory(length=250, n_targets=1, n_features=0, seed=42, panel=True, n_groups=2)
+
+        scf = SplitConformalForecaster(calibration_size=50)
+        scf.fit(y[:200], forecasting_horizon=1)
+
+        fit_time = scf.observed_time_
+
+        y_update = y[200:210]
+        scf.observe(y_update)
+
+        assert scf.observed_time_ == scf.point_forecaster_.observed_time_
+        assert scf.observed_time_ != fit_time
+        expected_time = y_update["time"][-1]
+        for group_time in scf.observed_time_.values():
+            assert group_time == expected_time
+
+    def test_rewind_syncs_observed_time_panel(self, y_X_factory):
+        """Test that rewind updates observed_time_ on panel data."""
+        y, _ = y_X_factory(length=250, n_targets=1, n_features=0, seed=42, panel=True, n_groups=2)
+
+        scf = SplitConformalForecaster(calibration_size=50)
+        scf.fit(y[:200], forecasting_horizon=1)
+
+        y_update = y[200:210]
+        scf.observe(y_update)
+
+        scf.rewind(y[190:200])
+
+        assert scf.observed_time_ == scf.point_forecaster_.observed_time_
+        expected_time = y[199]["time"][0]
+        for group_time in scf.observed_time_.values():
+            assert group_time == expected_time
+
     def test_observe_not_fitted(self):
         """Test observe raises error when not fitted."""
         scf = SplitConformalForecaster()

--- a/tests/model_selection/test_search.py
+++ b/tests/model_selection/test_search.py
@@ -114,7 +114,7 @@ class TestSystematicChecks:
                     "refit": True,
                 },
                 {"search_type": "grid", "refit": True, "multimetric": False, "interval_scoring": True},
-                ["check_search_observe_delegates", "check_search_rewind_delegates"],
+                [],
             ),
             # GridSearchCV with list-of-dicts param_grid (multiple grid search spaces)
             (


### PR DESCRIPTION
## Description

`SplitConformalForecaster.observe()` and `rewind()` only delegated to the inner `point_forecaster_`, leaving the outer forecaster's `observed_time_` stale. This propagates state changes to the outer forecaster as well.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

After calling `observe()`, `self.observed_time_` did not match `self.point_forecaster_.observed_time_`, causing incorrect behavior on subsequent `predict()` calls and after pickle round trips.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed