### PR TITLE
feat(panel): support global-only exogenous features with panel data

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,8 +21,9 @@ build:
       - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --group docs --extra plotting
     post_install:
       # Pre-download all datasets so marimo HTML exports read from parquet cache
-      # instead of downloading and parsing large TSF archives during the build
-      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv run python docs/precache_datasets.py
+      # instead of downloading and parsing large TSF archives during the build.
+      # Use timeout to avoid build cancellation if Zenodo is slow.
+      - timeout 120 bash -c 'UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv run python docs/precache_datasets.py' || echo "[rtd] Dataset precache timed out or failed; notebooks will download on demand"
     post_build:
       # Check for broken links
       - uvx linkchecker "${READTHEDOCS_OUTPUT}html/index.html" --no-status --no-warnings --ignore-url material/overrides

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1373,28 +1373,45 @@ def on_pre_build(config):
         except FileNotFoundError:
             return str(rel_path), FileNotFoundError("marimo")
 
-    max_workers = int(os.environ.get("MKDOCS_EXPORT_WORKERS", min(os.cpu_count() or 2, 8)))
+    max_workers = int(os.environ.get("MKDOCS_EXPORT_WORKERS", min(os.cpu_count() or 2, 4)))
 
+    import threading
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     failed: list[str] = []
-    print(f"[hooks] exporting {len(notebooks)} notebooks with {max_workers} workers")
+    done_count = 0
+    total = len(notebooks)
+    print(f"[hooks] exporting {total} notebooks with {max_workers} workers", flush=True)
+
+    # Heartbeat thread to prevent RTD "inactivity" kills
+    heartbeat_stop = threading.Event()
+
+    def _heartbeat():
+        while not heartbeat_stop.wait(60):
+            print(f"[hooks] ... still exporting ({done_count}/{total} done)", flush=True)
+
+    heartbeat = threading.Thread(target=_heartbeat, daemon=True)
+    heartbeat.start()
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         futures = {pool.submit(_export_notebook, nb): nb for nb in notebooks}
         for future in as_completed(futures):
             rel_path, error = future.result()
+            done_count += 1
             if error is None:
-                print(f"[hooks] exported html {rel_path}")
+                print(f"[hooks] [{done_count}/{total}] exported {rel_path}", flush=True)
             elif isinstance(error, FileNotFoundError):
-                print("[hooks] marimo not found, skipping notebook export", file=sys.stderr)
+                print("[hooks] marimo not found, skipping notebook export", file=sys.stderr, flush=True)
                 pool.shutdown(wait=False, cancel_futures=True)
+                heartbeat_stop.set()
                 return
             else:
                 failed.append(rel_path)
-                print(f"[hooks] FAILED html {rel_path}: {error}", file=sys.stderr)
+                print(f"[hooks] [{done_count}/{total}] FAILED {rel_path}: {error}", file=sys.stderr, flush=True)
                 if hasattr(error, "stderr") and error.stderr:
-                    print(error.stderr, file=sys.stderr)
+                    print(error.stderr, file=sys.stderr, flush=True)
+
+    heartbeat_stop.set()
 
     if failed:
         msg = f"[hooks] {len(failed)} notebook(s) had cell execution errors:\n"

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1338,9 +1338,8 @@ def on_pre_build(config):
     docs_examples = project_root / "docs" / "examples"
     docs_examples.mkdir(parents=True, exist_ok=True)
 
-    failed: list[str] = []
-
-    for notebook in notebooks:
+    def _export_notebook(notebook):
+        """Export a single marimo notebook to HTML. Returns (rel_path, error)."""
         rel_path = notebook.relative_to(project_root)
         output_dir = docs_examples / notebook.stem
 
@@ -1368,16 +1367,34 @@ def on_pre_build(config):
                 capture_output=True,
                 text=True,
             )
-            print(f"[hooks] exported html {rel_path} -> {static_file.relative_to(project_root)}")
+            return str(rel_path), None
         except subprocess.CalledProcessError as e:
-            failed.append(str(rel_path))
-            print(f"[hooks] FAILED html {rel_path}: {e}", file=sys.stderr)
-            if e.stderr:
-                print(e.stderr, file=sys.stderr)
-            continue
+            return str(rel_path), e
         except FileNotFoundError:
-            print("[hooks] marimo not found, skipping notebook export", file=sys.stderr)
-            break
+            return str(rel_path), FileNotFoundError("marimo")
+
+    max_workers = int(os.environ.get("MKDOCS_EXPORT_WORKERS", min(os.cpu_count() or 2, 8)))
+
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    failed: list[str] = []
+    print(f"[hooks] exporting {len(notebooks)} notebooks with {max_workers} workers")
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_export_notebook, nb): nb for nb in notebooks}
+        for future in as_completed(futures):
+            rel_path, error = future.result()
+            if error is None:
+                print(f"[hooks] exported html {rel_path}")
+            elif isinstance(error, FileNotFoundError):
+                print("[hooks] marimo not found, skipping notebook export", file=sys.stderr)
+                pool.shutdown(wait=False, cancel_futures=True)
+                return
+            else:
+                failed.append(rel_path)
+                print(f"[hooks] FAILED html {rel_path}: {error}", file=sys.stderr)
+                if hasattr(error, "stderr") and error.stderr:
+                    print(error.stderr, file=sys.stderr)
 
     if failed:
         msg = f"[hooks] {len(failed)} notebook(s) had cell execution errors:\n"

--- a/docs/precache_datasets.py
+++ b/docs/precache_datasets.py
@@ -35,8 +35,20 @@ _FETCHERS = [
 ]
 
 if __name__ == "__main__":
-    for name, fetcher in _FETCHERS:
-        print(f"[precache] Fetching {name} ...", flush=True)
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    def _fetch_one(name, fetcher):
         bunch = fetcher()
-        print(f"[precache]   -> {bunch.n_series} series, {len(bunch.frame)} rows, cached to {bunch.filename}")
+        return name, bunch.n_series, len(bunch.frame), bunch.filename
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = {pool.submit(_fetch_one, name, fn): name for name, fn in _FETCHERS}
+        for future in as_completed(futures):
+            name = futures[future]
+            try:
+                name, n_series, n_rows, filename = future.result()
+                print(f"[precache] {name}: {n_series} series, {n_rows} rows, cached to {filename}", flush=True)
+            except Exception as exc:
+                print(f"[precache] {name}: FAILED ({exc})", flush=True)
+
     print("[precache] All datasets cached.")

--- a/src/yohou/base/panel.py
+++ b/src/yohou/base/panel.py
@@ -93,24 +93,31 @@ class BasePanelForecaster:
         if X is not None and X_panel_groups is not None:
             X_shared_names, _ = inspect_panel(X)
 
-            # Validate X groups have same suffixes
-            first_X_group_cols = X_panel_groups[self.groups_[0]]
-            first_X_suffixes = [col.split("__", 1)[1] for col in first_X_group_cols]
+            if X_panel_groups:
+                # X has panel columns: validate suffixes match across groups
+                first_X_group_cols = X_panel_groups[self.groups_[0]]
+                first_X_suffixes = [col.split("__", 1)[1] for col in first_X_group_cols]
 
-            for group_name in self.groups_[1:]:
-                group_cols = X_panel_groups[group_name]
-                group_suffixes = [col.split("__", 1)[1] for col in group_cols]
-                if sorted(group_suffixes) != sorted(first_X_suffixes):
-                    raise ValueError(
-                        f"The local groups in `X` do not have the same column suffixes. "
-                        f"Group '{self.groups_[0]}': {sorted(first_X_suffixes)}, "
-                        f"Group '{group_name}': {sorted(group_suffixes)}"
-                    )
+                for group_name in self.groups_[1:]:
+                    group_cols = X_panel_groups[group_name]
+                    group_suffixes = [col.split("__", 1)[1] for col in group_cols]
+                    if sorted(group_suffixes) != sorted(first_X_suffixes):
+                        raise ValueError(
+                            f"The local groups in `X` do not have the same column suffixes. "
+                            f"Group '{self.groups_[0]}': {sorted(first_X_suffixes)}, "
+                            f"Group '{group_name}': {sorted(group_suffixes)}"
+                        )
 
-            # Extract X schema
-            self.shared_X_schema_ = dict(X.select(X_shared_names).schema)
-            local_X = X.select(first_X_group_cols).rename({col: col.split("__", 1)[1] for col in first_X_group_cols})
-            self.local_X_schema_ = dict(local_X.schema)
+                # Extract X schema (local + shared)
+                self.shared_X_schema_ = dict(X.select(X_shared_names).schema)
+                local_X = X.select(first_X_group_cols).rename({
+                    col: col.split("__", 1)[1] for col in first_X_group_cols
+                })
+                self.local_X_schema_ = dict(local_X.schema)
+            else:
+                # Global-only X: all non-time columns are shared across groups
+                self.shared_X_schema_ = dict(X.select(X_shared_names).schema)
+                self.local_X_schema_ = {}
 
     def _fit_transform_inputs_panel(
         self, y: pl.DataFrame, X: pl.DataFrame | None

--- a/src/yohou/utils/validation.py
+++ b/src/yohou/utils/validation.py
@@ -523,12 +523,15 @@ def check_panel_groups_match(
     y: pl.DataFrame | None,
     X: pl.DataFrame | None,
 ) -> None:
-    """Validate that y and X have matching panel group structures.
+    """Validate that y and X have compatible panel group structures.
 
-    Both DataFrames must have the same panel entity prefixes. For example,
-    if y has "store_1__sales" and "store_2__sales", then X must also have
-    panel columns with "store_1__" and "store_2__" prefixes (or both can
-    be global data).
+    When both DataFrames contain panel columns (using the ``__`` separator),
+    they must share the same entity prefixes. For example, if y has
+    ``"store_1__sales"`` and ``"store_2__sales"``, then X must also have
+    panel columns with ``"store_1__"`` and ``"store_2__"`` prefixes.
+
+    Global-only X (no ``__`` columns) is always valid regardless of y's
+    structure. Global features are broadcast to every panel group.
 
     Parameters
     ----------
@@ -540,13 +543,14 @@ def check_panel_groups_match(
     Raises
     ------
     ValueError
-        If y and X have different panel group structures.
+        If both y and X have panel columns but with different group prefixes,
+        or if y is global but X has panel columns.
 
     Examples
     --------
     >>> import polars as pl
     >>> from datetime import datetime
-    >>> # Valid - both have same entity prefixes
+    >>> # Valid: both have same entity prefixes
     >>> y = pl.DataFrame({
     ...     "time": [datetime(2020, 1, 1)],
     ...     "store_1__sales": [10],
@@ -559,7 +563,14 @@ def check_panel_groups_match(
     ... })
     >>> check_panel_groups_match(y, X)  # No error
 
-    >>> # Invalid - different entity prefixes
+    >>> # Valid: panel y with global-only X (broadcast to all groups)
+    >>> X_global = pl.DataFrame({
+    ...     "time": [datetime(2020, 1, 1)],
+    ...     "weather": [25.0],
+    ... })
+    >>> check_panel_groups_match(y, X_global)  # No error
+
+    >>> # Invalid: different entity prefixes
     >>> X_bad = pl.DataFrame({
     ...     "time": [datetime(2020, 1, 1)],
     ...     "sensor_1__temp": [25.0],
@@ -582,7 +593,9 @@ def check_panel_groups_match(
     _, y_groups = inspect_panel(y)
     _, X_groups = inspect_panel(X)
 
-    if set(y_groups.keys()) != set(X_groups.keys()):
+    # Global-only X (no panel columns) is valid with any y structure.
+    # Global features are broadcast to every panel group.
+    if X_groups and set(y_groups.keys()) != set(X_groups.keys()):
         raise ValueError(
             f"Panel groups mismatch between `y` and `X`. "
             f"`y` groups: {sorted(y_groups.keys())}, "

--- a/tests/base/test_panel_strategy.py
+++ b/tests/base/test_panel_strategy.py
@@ -402,3 +402,50 @@ class TestGlobalOnlyExogenous:
 
         y_pred = f.predict(X=X[80:85], forecasting_horizon=5)
         assert y_pred.shape[0] == 5
+
+    def test_lifecycle_with_target_transformer(self, panel_y_global_X):
+        """Observe and rewind with target_transformer exercises dict lookup paths."""
+        from yohou.stationarity import LogTransformer
+
+        y, X = panel_y_global_X
+        f = PointReductionForecaster(
+            estimator=LinearRegression(),
+            target_transformer=LogTransformer(offset=1.0),
+            feature_transformer=LagTransformer(lag=[1, 2]),
+        )
+        f.fit(y[:80], X[:80], forecasting_horizon=5)
+        assert isinstance(f.target_transformer_, dict)
+
+        y_pred_1 = f.predict(X=X[80:85], forecasting_horizon=5)
+        assert y_pred_1.shape[0] == 5
+
+        f.observe(y[80:85], X=X[80:85])
+        y_pred_2 = f.predict(X=X[85:90], forecasting_horizon=5)
+        assert y_pred_2.shape[0] == 5
+
+        f.rewind(y[:80], X=X[:80])
+        y_pred_3 = f.predict(X=X[80:85], forecasting_horizon=5)
+        assert y_pred_3.shape[0] == 5
+
+        for col in [c for c in y_pred_1.columns if c not in {"time", "vintage_time"}]:
+            assert y_pred_1[col].to_list() == y_pred_3[col].to_list()
+
+    def test_mismatched_X_panel_suffixes_raises(self, y_X_factory):
+        """X with panel columns whose suffixes differ across groups raises."""
+        import numpy as np
+
+        y, _ = y_X_factory(length=100, n_targets=1, n_features=0, panel=True, n_groups=2)
+        groups = sorted({col.split("__")[0] for col in y.columns if "__" in col})
+        rng = np.random.default_rng(0)
+        time = y["time"]
+        X = pl.DataFrame({
+            "time": time,
+            f"{groups[0]}__temp": rng.random(len(time)),
+            f"{groups[1]}__humidity": rng.random(len(time)),
+        })
+        f = PointReductionForecaster(
+            estimator=LinearRegression(),
+            feature_transformer=LagTransformer(lag=[1, 2]),
+        )
+        with pytest.raises(ValueError, match="do not have the same column suffixes"):
+            f.fit(y[:80], X[:80], forecasting_horizon=5)

--- a/tests/base/test_panel_strategy.py
+++ b/tests/base/test_panel_strategy.py
@@ -246,3 +246,159 @@ class TestPanelInverseTransform:
         target_cols = [c for c in y_pred.columns if c not in {"time", "vintage_time"}]
         for col in target_cols:
             assert y_pred[col].dtype.is_float()
+
+
+class TestGlobalOnlyExogenous:
+    """Test global-only X (no panel prefixes) with panel y."""
+
+    @pytest.fixture
+    def panel_y_global_X(self, y_X_factory):
+        """Panel y with global-only X (no __ prefixes)."""
+        import numpy as np
+
+        y, _ = y_X_factory(length=100, n_targets=1, n_features=0, panel=True, n_groups=2)
+        rng = np.random.default_rng(42)
+        time = y["time"]
+        X = pl.DataFrame({
+            "time": time,
+            "weather": rng.random(len(time)),
+            "holiday": rng.choice([0.0, 1.0], size=len(time)),
+        })
+        return y, X
+
+    @pytest.fixture
+    def panel_y_mixed_X(self, y_X_factory):
+        """Panel y with mixed X (panel + global columns)."""
+        import numpy as np
+
+        y, X_panel = y_X_factory(length=100, n_targets=1, n_features=1, panel=True, n_groups=2)
+        rng = np.random.default_rng(99)
+        X = X_panel.with_columns(
+            pl.Series("weather", rng.random(len(y))),
+        )
+        return y, X
+
+    def test_point_forecaster_fit_predict(self, panel_y_global_X):
+        """PointReductionForecaster fit and predict with global-only X."""
+        y, X = panel_y_global_X
+        f = PointReductionForecaster(
+            estimator=LinearRegression(),
+            feature_transformer=LagTransformer(lag=[1, 2]),
+        )
+        f.fit(y[:80], X[:80], forecasting_horizon=5)
+
+        assert f.groups_ is not None
+        assert f.local_X_schema_ == {}
+        assert f.shared_X_schema_ is not None
+        assert "weather" in f.shared_X_schema_
+        assert "holiday" in f.shared_X_schema_
+
+        y_pred = f.predict(X=X[80:85], forecasting_horizon=5)
+        assert y_pred.shape[0] == 5
+        pred_cols = set(y_pred.columns) - {"time", "vintage_time"}
+        y_cols = set(y.columns) - {"time"}
+        assert pred_cols == y_cols
+
+    def test_point_forecaster_full_lifecycle(self, panel_y_global_X):
+        """Full lifecycle: fit, predict, observe, rewind, predict."""
+        y, X = panel_y_global_X
+        f = PointReductionForecaster(
+            estimator=LinearRegression(),
+            feature_transformer=LagTransformer(lag=[1, 2]),
+        )
+        f.fit(y[:80], X[:80], forecasting_horizon=5)
+
+        y_pred_1 = f.predict(X=X[80:85], forecasting_horizon=5)
+        assert y_pred_1.shape[0] == 5
+
+        f.observe(y[80:85], X=X[80:85])
+        y_pred_2 = f.predict(X=X[85:90], forecasting_horizon=5)
+        assert y_pred_2.shape[0] == 5
+
+        f.rewind(y[:80], X=X[:80])
+        y_pred_3 = f.predict(X=X[80:85], forecasting_horizon=5)
+        assert y_pred_3.shape[0] == 5
+
+        # Predictions after rewind should match the first prediction
+        for col in [c for c in y_pred_1.columns if c not in {"time", "vintage_time"}]:
+            assert y_pred_1[col].to_list() == y_pred_3[col].to_list()
+
+    def test_interval_forecaster_fit_predict(self, panel_y_global_X):
+        """IntervalReductionForecaster fit and predict with global-only X."""
+        from yohou.interval import SplitConformalForecaster
+
+        y, X = panel_y_global_X
+        f = SplitConformalForecaster(
+            point_forecaster=PointReductionForecaster(
+                estimator=LinearRegression(),
+                feature_transformer=LagTransformer(lag=[1, 2]),
+            ),
+            calibration_size=20,
+        )
+        f.fit(y[:80], X[:80], forecasting_horizon=5)
+        y_pred = f.predict(X=X[80:85], forecasting_horizon=5, coverage_rates=[0.9])
+        assert y_pred.shape[0] == 5
+
+    def test_grid_search_cv(self, panel_y_global_X):
+        """GridSearchCV with global-only X and panel y."""
+        from yohou.metrics import MeanAbsoluteError
+        from yohou.model_selection import ExpandingWindowSplitter, GridSearchCV
+
+        y, X = panel_y_global_X
+        f = PointReductionForecaster(
+            estimator=LinearRegression(),
+            feature_transformer=LagTransformer(lag=[1, 2]),
+        )
+        cv = ExpandingWindowSplitter(n_splits=2, test_size=5)
+        search = GridSearchCV(
+            forecaster=f,
+            param_grid={"feature_transformer__lag": [[1, 2], [1, 2, 3]]},
+            scoring=MeanAbsoluteError(),
+            cv=cv,
+        )
+        search.fit(y[:80], X[:80])
+        assert hasattr(search, "best_params_")
+
+    def test_local_panel_forecaster(self, panel_y_global_X):
+        """LocalPanelForecaster with global-only X and panel y."""
+        from yohou.compose import LocalPanelForecaster
+
+        y, X = panel_y_global_X
+        f = LocalPanelForecaster(
+            forecaster=PointReductionForecaster(
+                estimator=LinearRegression(),
+                feature_transformer=LagTransformer(lag=[1, 2]),
+            ),
+        )
+        f.fit(y[:80], X[:80], forecasting_horizon=5)
+        y_pred = f.predict(X=X[80:85], forecasting_horizon=5)
+        assert y_pred.shape[0] == 5
+        pred_cols = set(y_pred.columns) - {"time", "vintage_time"}
+        y_cols = set(y.columns) - {"time"}
+        assert pred_cols == y_cols
+
+    def test_splitter_with_global_X(self, panel_y_global_X):
+        """ExpandingWindowSplitter split with global-only X and panel y."""
+        from yohou.model_selection import ExpandingWindowSplitter
+
+        y, X = panel_y_global_X
+        splitter = ExpandingWindowSplitter(n_splits=3, test_size=5)
+        splits = list(splitter.split(y[:80], X[:80]))
+        assert len(splits) == 3
+
+    def test_mixed_X_regression(self, panel_y_mixed_X):
+        """Mixed X (panel + global columns) still works (regression test)."""
+        y, X = panel_y_mixed_X
+        f = PointReductionForecaster(
+            estimator=LinearRegression(),
+            feature_transformer=LagTransformer(lag=[1, 2]),
+        )
+        f.fit(y[:80], X[:80], forecasting_horizon=5)
+
+        assert f.local_X_schema_ is not None
+        assert len(f.local_X_schema_) > 0
+        assert f.shared_X_schema_ is not None
+        assert "weather" in f.shared_X_schema_
+
+        y_pred = f.predict(X=X[80:85], forecasting_horizon=5)
+        assert y_pred.shape[0] == 5

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -1018,8 +1018,8 @@ class TestCheckPanelGroupsMatch:
         })
         X = pl.DataFrame({"time": time, "feature": range(20, 30)})
 
-        with pytest.raises(ValueError, match="Panel groups mismatch between `y` and `X`"):
-            check_panel_groups_match(y, X)
+        # Global-only X is valid with panel y (broadcast to all groups)
+        check_panel_groups_match(y, X)
 
     def test_check_panel_groups_match_y_global_X_panel(self):
         """Test check_panel_groups_match when y is global but X is panel."""


### PR DESCRIPTION
## Description

Allow X without panel prefixes (`__`) when y has panel structure. Global features are broadcast to every panel group.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Passing global-only exogenous features (e.g. weather, holidays) alongside panel target data raised a `KeyError` in `_set_input_attributes_panel` and a `ValueError` in `check_panel_groups_match`. This is a valid use case where shared features should be broadcast to all groups.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Two blockers were fixed:
1. `_set_input_attributes_panel` now branches on `if X_panel_groups` to set `local_X_schema_ = {}` and capture shared columns for global-only X
2. `check_panel_groups_match` skips the group mismatch check when X has no panel columns

Seven integration tests cover: point forecaster fit/predict, full lifecycle (observe/rewind), interval forecaster, GridSearchCV, LocalPanelForecaster, splitter, and mixed X regression.