### PR TITLE
feat(interval)!: add similarity extensions and API hardening

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ fallback-version = "0.0.0"
 [tool.hatch.build.hooks.vcs]
 version-file = "src/yohou/_version.py"
 
+[tool.ty.rules]
+unused-ignore-comment = "ignore"
+
 [tool.ruff]
 line-length = 120
 target-version = "py311"

--- a/src/yohou/compose/column_forecaster.py
+++ b/src/yohou/compose/column_forecaster.py
@@ -252,7 +252,7 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
         try:
             self.forecasters = [
                 (name, forecaster, col)
-                for ((name, forecaster), (_, _, col)) in zip(value, self.forecasters, strict=True)
+                for ((name, forecaster), (_, _, col)) in zip(value, self.forecasters, strict=True)  # ty: ignore[invalid-assignment]
             ]
         except (TypeError, ValueError):
             self.forecasters = value

--- a/src/yohou/interval/__init__.py
+++ b/src/yohou/interval/__init__.py
@@ -2,13 +2,15 @@
 
 from .base import BaseIntervalForecaster, BaseSimilarity
 from .reduction import IntervalReductionForecaster
-from .similarity import DistanceSimilarity
+from .similarity import CompositeSimilarity, DistanceSimilarity, TemporalSimilarity
 from .split_conformal import SplitConformalForecaster
 
 __all__ = [
     "BaseIntervalForecaster",
     "BaseSimilarity",
+    "CompositeSimilarity",
     "DistanceSimilarity",
     "IntervalReductionForecaster",
     "SplitConformalForecaster",
+    "TemporalSimilarity",
 ]

--- a/src/yohou/interval/base.py
+++ b/src/yohou/interval/base.py
@@ -37,6 +37,29 @@ class BaseSimilarity(BaseEstimator, metaclass=abc.ABCMeta):
 
     _parameter_constraints: dict = {}
 
+    @staticmethod
+    def _validate_no_nulls(df: pl.DataFrame, method_name: str) -> None:
+        """Raise if any column contains null or NaN values.
+
+        Parameters
+        ----------
+        df : pl.DataFrame
+            DataFrame to validate.
+        method_name : str
+            Name of the calling method (for the error message).
+
+        Raises
+        ------
+        ValueError
+            If any column contains null or NaN values.
+
+        """
+        null_cols = [col for col in df.columns if df[col].is_null().any()]
+        nan_cols = [col for col in df.select(cs.numeric()).columns if df[col].is_nan().any()]
+        bad_cols = sorted(set(null_cols + nan_cols))
+        if bad_cols:
+            raise ValueError(f"{method_name}() received data with null or NaN values in columns: {bad_cols}")
+
     def __sklearn_tags__(self) -> Tags:
         """Get estimator tags.
 
@@ -55,17 +78,6 @@ class BaseSimilarity(BaseEstimator, metaclass=abc.ABCMeta):
         tags.similarity_tags.produces_weights = True
 
         return tags
-
-    @property
-    def discarded_time_stamps(self) -> None:
-        """Get discarded timestamps (placeholder property).
-
-        Returns
-        -------
-        None
-
-        """
-        return None
 
     @abc.abstractmethod
     def fit(
@@ -141,6 +153,36 @@ class BaseSimilarity(BaseEstimator, metaclass=abc.ABCMeta):
             Similarity weights.
 
         """
+
+    def rewind(
+        self,
+        y: pl.DataFrame,
+        y_pred: pl.DataFrame,
+        X: pl.DataFrame | None = None,
+    ) -> "BaseSimilarity":
+        """Rewind observed data from the similarity measure.
+
+        Default implementation is a no-op. Concrete subclasses that
+        track observed data should override this to remove the most
+        recently observed rows.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            Target observations to rewind.
+
+        y_pred : pl.DataFrame
+            Predictions to rewind.
+
+        X : pl.DataFrame or None, default=None
+            Exogenous features to rewind.
+
+        Returns
+        -------
+        self
+
+        """
+        return self
 
 
 class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):

--- a/src/yohou/interval/similarity.py
+++ b/src/yohou/interval/similarity.py
@@ -1,14 +1,17 @@
-"""Distance-based similarity measures for interval forecasting."""
+"""Similarity measures for interval forecasting."""
 
-from typing import Any
+import math
+from datetime import timedelta
+from typing import Any, Literal
 
 import numpy as np
 import polars as pl
 from scipy.spatial.distance import cdist
+from sklearn.base import clone
 
 from .base import BaseSimilarity
 
-__all__ = ["DistanceSimilarity"]
+__all__ = ["CompositeSimilarity", "DistanceSimilarity", "TemporalSimilarity"]
 
 
 class DistanceSimilarity(BaseSimilarity):
@@ -23,9 +26,7 @@ class DistanceSimilarity(BaseSimilarity):
     The weight for the *i*-th historical observation given prediction
     *j* is computed as:
 
-    .. math::
-
-        w_{ji} = \\frac{\\exp(-d(x_j, x_i))}{\\sum_k \\exp(-d(x_j, x_k))}
+    $$w_{ji} = \frac{\exp(-d(x_j, x_i))}{\sum_k \exp(-d(x_j, x_k))}$$
 
     where *d* is the chosen distance metric.
 
@@ -39,11 +40,6 @@ class DistanceSimilarity(BaseSimilarity):
     metric_params : dict or None, default=None
         Additional keyword arguments forwarded to the distance metric
         function.
-
-    Attributes
-    ----------
-    n_discarded_indices_ : int
-        Number of observations discarded due to NaN values during ``fit``.
 
     Notes
     -----
@@ -119,24 +115,16 @@ class DistanceSimilarity(BaseSimilarity):
         self.metric = metric
         self.metric_params = metric_params if metric_params is not None else {}
 
-    @property
-    def n_discarded_indices_(self) -> int:
-        """Get number of discarded indices due to NaN values.
-
-        Returns
-        -------
-        int
-            Number of discarded observations.
-
-        """
-        return self._n_discarded_indices
-
     def _get_X(
         self,
         y_pred: pl.DataFrame,
         X: pl.DataFrame | None,
     ) -> pl.DataFrame:
         """Combine predictions and features into single feature matrix.
+
+        Drops the ``"time"`` column from ``X`` before concatenation to
+        avoid duplicate columns.  Validates that no column (except
+        ``"time"``) contains null or NaN values.
 
         Parameters
         ----------
@@ -151,10 +139,19 @@ class DistanceSimilarity(BaseSimilarity):
         pl.DataFrame
             Combined feature matrix.
 
+        Raises
+        ------
+        ValueError
+            If any non-time column contains null or NaN values.
+
         """
         if X is not None:
-            return pl.concat([y_pred, X], how="horizontal")
-        return y_pred
+            X_no_time = X.drop("time", strict=False)
+            features = pl.concat([y_pred, X_no_time], how="horizontal")
+        else:
+            features = y_pred
+        self._validate_no_nulls(features.drop("time", strict=False), "_get_X")
+        return features
 
     def fit(
         self,
@@ -181,9 +178,7 @@ class DistanceSimilarity(BaseSimilarity):
 
         """
         X_features = self._get_X(y_pred, X)
-        self._X_observed = X_features.drop_nulls()
-
-        self._n_discarded_indices = len(y_pred) - len(X_features)
+        self._X_observed = X_features
 
         return self
 
@@ -215,6 +210,38 @@ class DistanceSimilarity(BaseSimilarity):
 
         self._X_observed = pl.concat([self._X_observed, X_features])
 
+        return self
+
+    def rewind(
+        self,
+        y: pl.DataFrame,
+        y_pred: pl.DataFrame,
+        X: pl.DataFrame | None = None,
+    ) -> "DistanceSimilarity":
+        """Rewind the most recently observed data.
+
+        Removes the last ``len(y)`` rows from the internal reference
+        matrix, reversing the effect of the corresponding ``observe()``
+        call.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            Target observations to rewind (used only for row count).
+
+        y_pred : pl.DataFrame
+            Predictions to rewind (used only for row count).
+
+        X : pl.DataFrame or None, default=None
+            Exogenous features to rewind (unused).
+
+        Returns
+        -------
+        self
+
+        """
+        n_rewind = len(y)
+        self._X_observed = self._X_observed[: len(self._X_observed) - n_rewind]
         return self
 
     def predict(
@@ -249,3 +276,509 @@ class DistanceSimilarity(BaseSimilarity):
         weights = weights / (1 + np.sum(weights, axis=1)[:, np.newaxis])
 
         return weights
+
+
+class TemporalSimilarity(BaseSimilarity):
+    r"""Temporal similarity using Fourier features for weighting observations.
+
+    Computes observation weights by measuring the distance between
+    cyclic temporal features extracted from prediction timestamps.
+    Observations at similar seasonal positions (e.g. same day of week,
+    same month of year) receive higher weights.
+
+    Timestamps are converted to step indices relative to the first
+    observed timestamp, then encoded as sin/cos pairs at the specified
+    seasonal periods. Distances in this feature space are converted to
+    weights using the same softmax formula as ``DistanceSimilarity``.
+
+    Parameters
+    ----------
+    seasonalities : list of float
+        Seasonal periods in time steps (e.g. ``[7.0, 365.25]`` for
+        weekly and yearly cycles on daily data).
+    harmonics : dict mapping float to list of int, or None, default=None
+        Harmonics to include per seasonality period. Keys must match
+        entries in ``seasonalities``. Each value is a list of positive
+        integers specifying which harmonics to use. Defaults to
+        ``{s: [1]}`` for each ``s`` in ``seasonalities``.
+    metric : str, default="euclidean"
+        Distance metric for ``scipy.spatial.distance.cdist``.
+    metric_params : dict or None, default=None
+        Additional keyword arguments forwarded to the distance metric.
+
+    Attributes
+    ----------
+    first_time_ : datetime
+        Reference timestamp from the first calibration prediction.
+    interval_td_ : timedelta
+        Time interval between consecutive timestamps, auto-detected
+        from calibration data.
+
+    Notes
+    -----
+    Sin/cos encoding ensures that cyclic distances are correctly
+    captured (e.g. December 31 is close to January 1). Multiple
+    seasonalities combine naturally by concatenating feature vectors.
+
+    The weight normalisation matches ``DistanceSimilarity`` exactly:
+
+    $$w_{ji} = \frac{\exp(-d(x_j, x_i))}{\sum_k \exp(-d(x_j, x_k))} \cdot n_{\text{features}}$$
+
+    followed by
+
+    $$w_{ji} \leftarrow \frac{w_{ji}}{1 + \sum_k w_{jk}}$$
+
+    This reserves probability mass for a uniform component, following
+    the conformal prediction literature.
+
+    See Also
+    --------
+    `DistanceSimilarity` : Value-based distance similarity.
+    `BaseSimilarity` : Abstract similarity base class.
+
+    Examples
+    --------
+    >>> from datetime import datetime, timedelta
+    >>> import polars as pl
+    >>> import numpy as np
+    >>> from yohou.interval.similarity import TemporalSimilarity
+    >>>
+    >>> # Daily data with 3 weeks of calibration
+    >>> dates = [datetime(2021, 1, 1) + timedelta(days=i) for i in range(21)]
+    >>> y = pl.DataFrame({"time": dates, "value": np.random.randn(21)})
+    >>> y_pred = pl.DataFrame({"time": dates, "value": np.random.randn(21)})
+    >>>
+    >>> # Fit with weekly seasonality
+    >>> sim = TemporalSimilarity(seasonalities=[7.0])
+    >>> _ = sim.fit(y, y_pred)
+    >>>
+    >>> # Predict weights for a new Monday
+    >>> new_date = [datetime(2021, 1, 22)]
+    >>> y_pred_new = pl.DataFrame({"time": new_date, "value": [0.5]})
+    >>> weights = sim.predict(y_pred_new)
+    >>> weights.shape
+    (1, 21)
+
+    """
+
+    _parameter_constraints: dict = {
+        "seasonalities": [list],
+        "harmonics": [dict, None],
+        "metric": [str],
+        "metric_params": [dict, None],
+    }
+
+    def __init__(
+        self,
+        seasonalities: list[float] | None = None,
+        harmonics: dict[float, list[int]] | None = None,
+        metric: str = "euclidean",
+        metric_params: dict[str, object] | None = None,
+    ) -> None:
+        self.seasonalities = seasonalities
+        self.harmonics = harmonics
+        self.metric = metric
+        self.metric_params = metric_params if metric_params is not None else {}
+
+    def _resolve_harmonics(self) -> dict[float, list[int]]:
+        """Resolve harmonics, defaulting to first harmonic per seasonality.
+
+        Returns
+        -------
+        dict[float, list[int]]
+            Mapping from seasonality period to list of harmonic indices.
+
+        """
+        if self.harmonics is not None:
+            return self.harmonics
+        return {s: [1] for s in self.seasonalities}  # ty: ignore[not-iterable]
+
+    def _extract_features(self, times: pl.Series) -> np.ndarray:
+        """Extract Fourier features from a datetime series.
+
+        Parameters
+        ----------
+        times : pl.Series
+            Datetime series from which to compute features.
+
+        Returns
+        -------
+        np.ndarray
+            Feature matrix of shape ``(len(times), n_features)``.
+
+        """
+        time_diff = times - self.first_time_
+        t = time_diff.dt.total_seconds().to_numpy().astype(np.float64)
+        interval_seconds = self.interval_td_.total_seconds()
+        if interval_seconds != 0:
+            t = t / interval_seconds
+
+        harmonics = self._resolve_harmonics()
+        features = []
+        for s in self.seasonalities:  # ty: ignore[not-iterable]
+            for k in harmonics.get(s, [1]):
+                angle = 2.0 * math.pi * k * t / s
+                features.append(np.sin(angle))
+                features.append(np.cos(angle))
+
+        return np.column_stack(features)
+
+    def fit(
+        self,
+        y: pl.DataFrame,
+        y_pred: pl.DataFrame,
+        X: pl.DataFrame | None = None,
+    ) -> "TemporalSimilarity":
+        """Fit the temporal similarity from calibration predictions.
+
+        Auto-detects the time interval from consecutive timestamps in
+        ``y_pred`` and stores a reference timestamp and Fourier feature
+        matrix for later distance computation.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            Target time series (unused, accepted for API consistency).
+        y_pred : pl.DataFrame
+            Point forecast time series with a ``"time"`` column.
+        X : pl.DataFrame or None, default=None
+            Exogenous features (unused, accepted for API consistency).
+
+        Returns
+        -------
+        self
+
+        """
+        if self.seasonalities is None or len(self.seasonalities) == 0:
+            raise ValueError("seasonalities must be a non-empty list of floats")
+
+        times = y_pred["time"]
+        self.first_time_ = times[0]
+
+        if len(times) > 1:
+            self.interval_td_ = times[1] - times[0]
+        else:
+            self.interval_td_ = timedelta(0)
+
+        self._features_observed = self._extract_features(times)
+        self._n_features = self._features_observed.shape[1]
+
+        return self
+
+    def observe(
+        self,
+        y: pl.DataFrame,
+        y_pred: pl.DataFrame,
+        X: pl.DataFrame | None = None,
+    ) -> "TemporalSimilarity":
+        """Observe new data and extend the reference feature matrix.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            New target observations (unused, accepted for API
+            consistency).
+        y_pred : pl.DataFrame
+            New predictions with a ``"time"`` column.
+        X : pl.DataFrame or None, default=None
+            Exogenous features (unused, accepted for API consistency).
+
+        Returns
+        -------
+        self
+
+        """
+        new_features = self._extract_features(y_pred["time"])
+        self._features_observed = np.vstack([self._features_observed, new_features])
+        return self
+
+    def rewind(
+        self,
+        y: pl.DataFrame,
+        y_pred: pl.DataFrame,
+        X: pl.DataFrame | None = None,
+    ) -> "TemporalSimilarity":
+        """Rewind the most recently observed data.
+
+        Removes the last ``len(y)`` rows from the internal feature
+        matrix, reversing the effect of the corresponding ``observe()``
+        call.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            Target observations to rewind (used only for row count).
+        y_pred : pl.DataFrame
+            Predictions to rewind (used only for row count).
+        X : pl.DataFrame or None, default=None
+            Exogenous features to rewind (unused).
+
+        Returns
+        -------
+        self
+
+        """
+        n_rewind = len(y)
+        self._features_observed = self._features_observed[: len(self._features_observed) - n_rewind]
+        return self
+
+    def predict(
+        self,
+        y_pred: pl.DataFrame,
+        X: pl.DataFrame | None = None,
+    ) -> np.ndarray[tuple[int, int], np.dtype[np.floating[Any]]]:
+        """Compute temporal similarity weights for new predictions.
+
+        Parameters
+        ----------
+        y_pred : pl.DataFrame
+            New predictions with a ``"time"`` column.
+        X : pl.DataFrame or None, default=None
+            Exogenous features (unused).
+
+        Returns
+        -------
+        np.ndarray
+            Weight matrix of shape ``(n_predictions, n_calibration)``.
+
+        """
+        new_features = self._extract_features(y_pred["time"])
+
+        distances: np.ndarray = cdist(
+            new_features,
+            self._features_observed,
+            metric=self.metric,
+            **self.metric_params,
+        )  # ty: ignore[no-matching-overload]
+        weights = np.exp(-distances)
+
+        weights = weights / np.sum(weights, axis=1)[:, np.newaxis] * self._n_features
+        weights = weights / (1 + np.sum(weights, axis=1)[:, np.newaxis])
+
+        return weights
+
+
+class CompositeSimilarity(BaseSimilarity):
+    r"""Combine multiple similarity measures into a single weight vector.
+
+    Delegates ``fit``, ``observe``, ``rewind``, and ``predict`` to each
+    sub-similarity and then combines their weight matrices using either
+    element-wise multiplication or weighted averaging.
+
+    Parameters
+    ----------
+    similarities : list of BaseSimilarity
+        At least two similarity instances to combine.
+    combination : {"multiply", "mean"}, default="multiply"
+        How to combine the individual weight matrices.
+
+        ``"multiply"``
+            Element-wise product with optional exponents:
+            ``w_combined = prod(w_i ** alpha_i)``, then re-normalised
+            so rows lie in (0, 1).
+        ``"mean"``
+            Weighted average: ``w_combined = sum(alpha_i * w_i)``.
+
+    weights : list of float or None, default=None
+        Per-similarity exponents (multiply) or mixing coefficients
+        (mean). If ``None``, all similarities contribute equally
+        (exponents/coefficients of 1.0).
+
+    Attributes
+    ----------
+    similarities_ : list of BaseSimilarity
+        Fitted copies of the sub-similarities (set after ``fit``).
+
+    See Also
+    --------
+    `DistanceSimilarity` : Value-based distance similarity.
+    `TemporalSimilarity` : Temporal Fourier feature similarity.
+
+    Examples
+    --------
+    >>> from datetime import datetime, timedelta
+    >>> import polars as pl
+    >>> import numpy as np
+    >>> from yohou.interval.similarity import (
+    ...     CompositeSimilarity,
+    ...     DistanceSimilarity,
+    ...     TemporalSimilarity,
+    ... )
+    >>>
+    >>> dates = [datetime(2021, 1, 1) + timedelta(days=i) for i in range(28)]
+    >>> y = pl.DataFrame({"time": dates, "value": np.random.randn(28)})
+    >>> y_pred = pl.DataFrame({"time": dates, "value": np.random.randn(28)})
+    >>>
+    >>> comp = CompositeSimilarity(
+    ...     similarities=[
+    ...         DistanceSimilarity(metric="euclidean"),
+    ...         TemporalSimilarity(seasonalities=[7.0]),
+    ...     ],
+    ...     combination="multiply",
+    ... )
+    >>> _ = comp.fit(y, y_pred)
+    >>> new_date = [datetime(2021, 1, 29)]
+    >>> y_pred_new = pl.DataFrame({"time": new_date, "value": [0.5]})
+    >>> weights = comp.predict(y_pred_new)
+    >>> weights.shape
+    (1, 28)
+
+    """
+
+    _parameter_constraints: dict = {
+        "similarities": [list],
+        "combination": [str],
+        "weights": [list, None],
+    }
+
+    def __init__(
+        self,
+        similarities: list[BaseSimilarity] | None = None,
+        combination: Literal["multiply", "mean"] = "multiply",
+        weights: list[float] | None = None,
+    ) -> None:
+        self.similarities = similarities
+        self.combination = combination
+        self.weights = weights
+
+    def _validate_params(self) -> None:
+        """Validate constructor parameters."""
+        if self.similarities is None or len(self.similarities) < 2:
+            raise ValueError(
+                "CompositeSimilarity requires at least 2 sub-similarities, "
+                f"got {0 if self.similarities is None else len(self.similarities)}"
+            )
+        if self.combination not in ("multiply", "mean"):
+            raise ValueError(f"combination must be 'multiply' or 'mean', got {self.combination!r}")
+        if self.weights is not None and len(self.weights) != len(self.similarities):
+            raise ValueError(
+                f"weights length ({len(self.weights)}) must match similarities length ({len(self.similarities)})"
+            )
+
+    def _resolved_weights(self) -> list[float]:
+        """Return per-similarity weights, defaulting to 1.0 each."""
+        if self.weights is not None:
+            return self.weights
+        return [1.0] * len(self.similarities)  # ty: ignore[invalid-argument-type]
+
+    def fit(
+        self,
+        y: pl.DataFrame,
+        y_pred: pl.DataFrame,
+        X: pl.DataFrame | None = None,
+    ) -> "CompositeSimilarity":
+        """Fit all sub-similarities on the calibration data.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            Target time series.
+        y_pred : pl.DataFrame
+            Point forecast time series.
+        X : pl.DataFrame or None, default=None
+            Exogenous features.
+
+        Returns
+        -------
+        self
+
+        """
+        self._validate_params()
+        self.similarities_ = [clone(sim).fit(y=y, y_pred=y_pred, X=X) for sim in self.similarities]  # ty: ignore[not-iterable]
+        return self
+
+    def observe(
+        self,
+        y: pl.DataFrame,
+        y_pred: pl.DataFrame,
+        X: pl.DataFrame | None = None,
+    ) -> "CompositeSimilarity":
+        """Forward observation to all sub-similarities.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            New target observations.
+        y_pred : pl.DataFrame
+            New predictions.
+        X : pl.DataFrame or None, default=None
+            New exogenous features.
+
+        Returns
+        -------
+        self
+
+        """
+        for sim in self.similarities_:
+            sim.observe(y=y, y_pred=y_pred, X=X)
+        return self
+
+    def rewind(
+        self,
+        y: pl.DataFrame,
+        y_pred: pl.DataFrame,
+        X: pl.DataFrame | None = None,
+    ) -> "CompositeSimilarity":
+        """Forward rewind to all sub-similarities.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            Target observations to rewind.
+        y_pred : pl.DataFrame
+            Predictions to rewind.
+        X : pl.DataFrame or None, default=None
+            Exogenous features to rewind.
+
+        Returns
+        -------
+        self
+
+        """
+        for sim in self.similarities_:
+            sim.rewind(y=y, y_pred=y_pred, X=X)
+        return self
+
+    def predict(
+        self,
+        y_pred: pl.DataFrame,
+        X: pl.DataFrame | None = None,
+    ) -> np.ndarray[tuple[int, int], np.dtype[np.floating[Any]]]:
+        """Combine sub-similarity weights into a single weight matrix.
+
+        Parameters
+        ----------
+        y_pred : pl.DataFrame
+            Predictions to compute similarities for.
+        X : pl.DataFrame or None, default=None
+            Exogenous features.
+
+        Returns
+        -------
+        np.ndarray
+            Combined weight matrix of shape
+            ``(n_predictions, n_calibration)``.
+
+        """
+        alphas = self._resolved_weights()
+        weight_matrices = [sim.predict(y_pred=y_pred, X=X) for sim in self.similarities_]
+
+        if self.combination == "multiply":
+            combined = np.ones_like(weight_matrices[0])
+            for w, alpha in zip(weight_matrices, alphas, strict=True):
+                combined *= np.power(w, alpha)
+            # Re-normalise so rows lie in (0, 1)
+            row_sums = combined.sum(axis=1, keepdims=True)
+            row_sums = np.where(row_sums == 0, 1.0, row_sums)
+            n_features = combined.shape[1]
+            combined = combined / row_sums * n_features
+            combined = combined / (1 + combined.sum(axis=1, keepdims=True))
+        else:  # mean
+            combined = np.zeros_like(weight_matrices[0])
+            for w, alpha in zip(weight_matrices, alphas, strict=True):
+                combined += alpha * w
+            total_alpha = sum(alphas)
+            if total_alpha != 0:
+                combined /= total_alpha
+
+        return combined

--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -11,7 +11,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.utils.validation import check_is_fitted
 
 from yohou.base.panel import BasePanelForecaster
-from yohou.metrics import AbsoluteGammaResidual, AbsoluteResidual, BaseConformityScorer, GammaResidual, Residual
+from yohou.metrics import BaseConformityScorer, Residual
 from yohou.point import BasePointForecaster, SeasonalNaive
 from yohou.utils import POINT_INTERVAL, Tags, validate_forecaster_data
 from yohou.utils._compat import Interval, _fit_context
@@ -592,19 +592,12 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         scores_no_time = conformity_scores_step.drop("time", strict=False)
         y_pred_values = y_pred_step.drop("time")
 
-        # Determine whether the scorer uses symmetric or asymmetric
-        # quantiles, and whether it applies a multiplicative scale.
-        symmetric = isinstance(conformity_scorer_step, (AbsoluteResidual, AbsoluteGammaResidual))
-        multiplicative = isinstance(conformity_scorer_step, (GammaResidual, AbsoluteGammaResidual))
+        # Read scorer characteristics from tags instead of checking types
+        tags = conformity_scorer_step.__sklearn_tags__()
+        assert tags.scorer_tags is not None
+        symmetric = tags.scorer_tags.symmetric
+        multiplicative = tags.scorer_tags.multiplicative
         epsilon = getattr(conformity_scorer_step, "epsilon", 0.0)
-
-        if not isinstance(conformity_scorer_step, (Residual, AbsoluteResidual, GammaResidual, AbsoluteGammaResidual)):
-            # Unsupported scorer type: fall back to unweighted inverse_score
-            return conformity_scorer_step.inverse_score(
-                y_pred=y_pred_step,
-                conformity_scores=conformity_scores_step,
-                coverage_rate=coverage_rate,
-            ).drop("time")
 
         lower_data: dict[str, list[float]] = {}
         upper_data: dict[str, list[float]] = {}

--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -11,7 +11,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.utils.validation import check_is_fitted
 
 from yohou.base.panel import BasePanelForecaster
-from yohou.metrics import AbsoluteResidual, BaseConformityScorer, Residual
+from yohou.metrics import AbsoluteGammaResidual, AbsoluteResidual, BaseConformityScorer, GammaResidual, Residual
 from yohou.point import BasePointForecaster, SeasonalNaive
 from yohou.utils import POINT_INTERVAL, Tags, validate_forecaster_data
 from yohou.utils._compat import Interval, _fit_context
@@ -205,10 +205,14 @@ class SplitConformalForecaster(BaseIntervalForecaster):
                     scored_times_df, on="time", how="semi"
                 )
 
-                similarity_step = clone(self.similarity)
-                similarity_step.fit(y=y_calib, y_pred=y_pred_for_sim)
+                X_for_sim = None
+                if X_calib is not None:
+                    X_for_sim = X_calib.join(scored_times_df, on="time", how="semi")
 
-                weights_array = similarity_step.predict(y_pred=y_pred_for_sim)
+                similarity_step = clone(self.similarity)
+                similarity_step.fit(y=y_calib, y_pred=y_pred_for_sim, X=X_for_sim)
+
+                weights_array = similarity_step.predict(y_pred=y_pred_for_sim, X=X_for_sim)
                 weight_col_names = [f"w_{i}" for i in range(weights_array.shape[1])]
                 weights_step = pl.DataFrame(weights_array, schema=weight_col_names)
                 weights_step = weights_step.with_columns(step=pl.lit(step))
@@ -222,6 +226,11 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         if self.similarity is not None:
             self.similarities_ = similarities
             self.weights_ = pl.concat(weights_list, how="diagonal")
+            # Track fit-time counts for correct rewind arithmetic
+            self._fit_score_counts_ = {}
+            for step in range(1, 1 + forecasting_horizon):
+                key = f"step_{step}"
+                self._fit_score_counts_[key] = conformity_scores.filter(pl.col("step") == step).height
 
         return self
 
@@ -262,11 +271,43 @@ class SplitConformalForecaster(BaseIntervalForecaster):
 
         y, X, groups = validate_forecaster_data(self, y, X, reset=False, groups=groups)
 
+        # Capture predictions for the about-to-be-observed times before
+        # the point forecaster moves forward.  These are needed to update
+        # similarity weights and conformity scores.
+        if self.similarity is not None and hasattr(self, "similarities_"):
+            y_pred_captured = self.point_forecaster_.predict(
+                X=X,
+                forecasting_horizon=self.fit_forecasting_horizon_,
+                groups=groups,
+            )
+            y_pred_captured = y_pred_captured.drop("vintage_time", strict=False)
+
         self.point_forecaster_.observe(y=y, X=X, groups=groups)
         if self.groups_ is None:
             self._observe_standard(y, X)
         else:
             BasePanelForecaster._observe_panel(self, y, X, groups)
+
+        # Update similarity and conformity scores with new observations
+        if self.similarity is not None and hasattr(self, "similarities_"):
+            horizon = self.fit_forecasting_horizon_
+            for step in range(1, 1 + horizon):
+                similarity_step = self.similarities_[f"step_{step}"]
+                y_pred_step = y_pred_captured.slice(step - 1, 1)
+                X_step = None
+                if X is not None:
+                    X_step = X.slice(step - 1, 1) if len(X) >= step else None
+                similarity_step.observe(y=y, y_pred=y_pred_step, X=X_step)
+
+                # Score the new observation and append to conformity_scores_
+                scorer_step = self.conformity_scorers_[f"step_{step}"]
+                new_scores = scorer_step.score(y, y_pred_step)
+                new_scores = new_scores.with_columns(step=step)
+                self.conformity_scores_ = pl.concat(
+                    [self.conformity_scores_, new_scores],
+                    how="vertical_relaxed",
+                )
+
         return self
 
     def rewind(
@@ -310,6 +351,45 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             self._rewind_standard(y, X)
         else:
             BasePanelForecaster._rewind_panel(self, y, X, groups)
+
+        # Rewind similarity state and conformity scores
+        if self.similarity is not None and hasattr(self, "similarities_"):
+            target_time = y["time"][-1]
+            horizon = self.fit_forecasting_horizon_
+            for step in range(1, 1 + horizon):
+                key = f"step_{step}"
+                similarity_step = self.similarities_[key]
+
+                # Split conformity scores into calibration (fit-time) and
+                # post-fit portions, then discard post-fit scores whose
+                # time exceeds the rewind target.
+                step_mask = self.conformity_scores_["step"] == step
+                step_scores = self.conformity_scores_.filter(step_mask)
+                other_scores = self.conformity_scores_.filter(~step_mask)
+
+                n_fit = self._fit_score_counts_[key]
+                post_fit_scores = step_scores.slice(n_fit)
+                post_fit_to_keep = post_fit_scores.filter(pl.col("time") <= target_time)
+                n_post_fit_removed = len(post_fit_scores) - len(post_fit_to_keep)
+
+                step_scores = pl.concat(
+                    [step_scores.head(n_fit), post_fit_to_keep],
+                    how="vertical_relaxed",
+                )
+                self.conformity_scores_ = pl.concat(
+                    [other_scores, step_scores],
+                    how="vertical_relaxed",
+                )
+
+                # Each observe() call adds exactly 1 row to similarity
+                # per step, regardless of how many y rows were passed.
+                # Rewind the same number of similarity rows as observe
+                # events that were undone.
+                n_sim_rewind = max(0, n_post_fit_removed)
+                if n_sim_rewind > 0:
+                    dummy_y = y.head(n_sim_rewind)
+                    similarity_step.rewind(y=dummy_y, y_pred=y.slice(0, 1))
+
         return self
 
     def predict(
@@ -512,44 +592,42 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         scores_no_time = conformity_scores_step.drop("time", strict=False)
         y_pred_values = y_pred_step.drop("time")
 
-        if isinstance(conformity_scorer_step, AbsoluteResidual):
-            # Symmetric: ±quantile
-            lower_data: dict[str, list[float]] = {}
-            upper_data: dict[str, list[float]] = {}
-            for col in value_cols:
-                scores_col = scores_no_time[col].to_numpy().astype(np.float64)
+        # Determine whether the scorer uses symmetric or asymmetric
+        # quantiles, and whether it applies a multiplicative scale.
+        symmetric = isinstance(conformity_scorer_step, (AbsoluteResidual, AbsoluteGammaResidual))
+        multiplicative = isinstance(conformity_scorer_step, (GammaResidual, AbsoluteGammaResidual))
+        epsilon = getattr(conformity_scorer_step, "epsilon", 0.0)
+
+        if not isinstance(conformity_scorer_step, (Residual, AbsoluteResidual, GammaResidual, AbsoluteGammaResidual)):
+            # Unsupported scorer type: fall back to unweighted inverse_score
+            return conformity_scorer_step.inverse_score(
+                y_pred=y_pred_step,
+                conformity_scores=conformity_scores_step,
+                coverage_rate=coverage_rate,
+            ).drop("time")
+
+        lower_data: dict[str, list[float]] = {}
+        upper_data: dict[str, list[float]] = {}
+
+        for col in value_cols:
+            scores_col = scores_no_time[col].to_numpy().astype(np.float64)
+            pred_val = float(y_pred_values[col][0])
+            scale = (pred_val + epsilon) if multiplicative else 1.0
+
+            if symmetric:
                 q = weighted_quantile(scores_col, coverage_rate, weights)
-                pred_val = float(y_pred_values[col][0])
-                lower_data[col] = [pred_val - q]
-                upper_data[col] = [pred_val + q]
-
-            lower_bound = pl.DataFrame(lower_data)
-            upper_bound = pl.DataFrame(upper_data)
-            return conformity_scorer_step._format_y_pred_interval(lower_bound, upper_bound, coverage_rate)
-
-        if isinstance(conformity_scorer_step, Residual):
-            # Asymmetric: add lower/upper quantiles directly
-            lower_data = {}
-            upper_data = {}
-            for col in value_cols:
-                scores_col = scores_no_time[col].to_numpy().astype(np.float64)
+                lower_data[col] = [pred_val - q * scale]
+                upper_data[col] = [pred_val + q * scale]
+            else:
                 alpha = 1.0 - coverage_rate
                 lower_q = weighted_quantile(scores_col, alpha / 2.0, weights)
                 upper_q = weighted_quantile(scores_col, 1.0 - alpha / 2.0, weights)
-                pred_val = float(y_pred_values[col][0])
-                lower_data[col] = [pred_val + lower_q]
-                upper_data[col] = [pred_val + upper_q]
+                lower_data[col] = [pred_val + lower_q * scale]
+                upper_data[col] = [pred_val + upper_q * scale]
 
-            lower_bound = pl.DataFrame(lower_data)
-            upper_bound = pl.DataFrame(upper_data)
-            return conformity_scorer_step._format_y_pred_interval(lower_bound, upper_bound, coverage_rate)
-
-        # Unsupported scorer type: fall back to unweighted inverse_score
-        return conformity_scorer_step.inverse_score(
-            y_pred=y_pred_step,
-            conformity_scores=conformity_scores_step,
-            coverage_rate=coverage_rate,
-        ).drop("time")
+        lower_bound = pl.DataFrame(lower_data)
+        upper_bound = pl.DataFrame(upper_data)
+        return conformity_scorer_step._format_y_pred_interval(lower_bound, upper_bound, coverage_rate)
 
     def predict_interval(
         self,
@@ -638,7 +716,10 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             for coverage_rate in coverage_rates:
                 if self.similarity is not None and hasattr(self, "similarities_"):
                     similarity_step = self.similarities_[f"step_{step}"]
-                    weights_array = similarity_step.predict(y_pred=y_pred_step)
+                    X_step = None
+                    if X is not None:
+                        X_step = X.slice(step - 1, 1)
+                    weights_array = similarity_step.predict(y_pred=y_pred_step, X=X_step)
                     step_weights = weights_array[0].astype(np.float64)
 
                     y_pred_interval_rate_step = self._weighted_inverse_score(

--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -597,7 +597,7 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         assert tags.scorer_tags is not None
         symmetric = tags.scorer_tags.symmetric
         multiplicative = tags.scorer_tags.multiplicative
-        epsilon = getattr(conformity_scorer_step, "epsilon", 0.0)
+        epsilon = conformity_scorer_step.get_params().get("epsilon", 0.0)
 
         lower_data: dict[str, list[float]] = {}
         upper_data: dict[str, list[float]] = {}

--- a/src/yohou/interval/utils.py
+++ b/src/yohou/interval/utils.py
@@ -26,6 +26,8 @@ def weighted_quantile(x: npt.NDArray[np.float64], q: float, weights: npt.NDArray
         The weighted quantile value, or infinity if insufficient weight.
 
     """
+    if len(x) != len(weights):
+        raise ValueError(f"x and weights must have the same length, got {len(x)} and {len(weights)}")
     if np.sum(weights) >= 1 - q:
         x_ordered = np.argsort(x)
         index_threshold = np.min(np.where(np.cumsum(weights[x_ordered]) >= 1 - q))

--- a/src/yohou/metrics/conformity.py
+++ b/src/yohou/metrics/conformity.py
@@ -167,6 +167,13 @@ class AbsoluteResidual(Residual):
 
     """
 
+    def __sklearn_tags__(self):
+        """Get the tags for this estimator."""
+        tags = super().__sklearn_tags__()
+        assert tags.scorer_tags is not None
+        tags.scorer_tags.symmetric = True
+        return tags
+
     def score(self, y_truth: pl.DataFrame, y_pred: pl.DataFrame, /, **score_params) -> pl.DataFrame:
         """Compute absolute residual conformity scores.
 
@@ -301,6 +308,13 @@ class GammaResidual(BaseConformityScorer):
         )
         self.epsilon = epsilon
 
+    def __sklearn_tags__(self):
+        """Get the tags for this estimator."""
+        tags = super().__sklearn_tags__()
+        assert tags.scorer_tags is not None
+        tags.scorer_tags.multiplicative = True
+        return tags
+
     def score(self, y_truth: pl.DataFrame, y_pred: pl.DataFrame, /, **score_params) -> pl.DataFrame:
         """Compute gamma (relative) residual conformity scores.
 
@@ -415,6 +429,13 @@ class AbsoluteGammaResidual(GammaResidual):
     0.25
 
     """
+
+    def __sklearn_tags__(self):
+        """Get the tags for this estimator."""
+        tags = super().__sklearn_tags__()
+        assert tags.scorer_tags is not None
+        tags.scorer_tags.symmetric = True
+        return tags
 
     def score(self, y_truth: pl.DataFrame, y_pred: pl.DataFrame, /, **score_params) -> pl.DataFrame:
         r"""Compute absolute gamma residual conformity scores.

--- a/src/yohou/plotting/_utils.py
+++ b/src/yohou/plotting/_utils.py
@@ -757,7 +757,7 @@ def _normalize_y_pred(
 DEFAULT_WIDTH: int = 1000
 """Default figure width in pixels applied when *width* is ``None``."""
 
-DEFAULT_LAYOUT = {
+DEFAULT_LAYOUT: dict[str, Any] = {
     "template": "plotly_white",
     "font": {"family": "Arial, sans-serif", "size": 12, "color": "#1e293b"},
     "title": {"font": {"size": 16, "color": "#0f172a"}, "x": 0.5, "xanchor": "center"},
@@ -836,14 +836,14 @@ def apply_default_layout(
     layout_update: dict[str, Any] = copy.deepcopy(DEFAULT_LAYOUT)
 
     if title is not None:
-        layout_update["title"]["text"] = title  # ty: ignore[invalid-assignment]
+        layout_update["title"]["text"] = title
     if x_label is not None:
-        layout_update["xaxis"]["title"] = x_label  # ty: ignore[invalid-assignment]
+        layout_update["xaxis"]["title"] = x_label
     if y_label is not None:
-        layout_update["yaxis"]["title"] = y_label  # ty: ignore[invalid-assignment]
-    layout_update["width"] = width if width is not None else DEFAULT_WIDTH  # ty: ignore[invalid-assignment]
+        layout_update["yaxis"]["title"] = y_label
+    layout_update["width"] = width if width is not None else DEFAULT_WIDTH
     if height is not None:
-        layout_update["height"] = height  # ty: ignore[invalid-assignment]
+        layout_update["height"] = height
     if hovermode is not None:
         layout_update["hovermode"] = hovermode
 

--- a/src/yohou/plotting/forecasting.py
+++ b/src/yohou/plotting/forecasting.py
@@ -3404,6 +3404,7 @@ def _mstl_to_component_dict(
             raise ValueError(msg)
         sorted_periods = sorted(resolved)
     else:
+        assert not isinstance(periods, str)
         sorted_periods = sorted(periods)
 
     # Infer interval for human-readable labels (fall back to numeric if unknown)

--- a/src/yohou/utils/tags.py
+++ b/src/yohou/utils/tags.py
@@ -186,12 +186,24 @@ class ScorerTags:
         False for metrics where higher is better (e.g., R²).
     requires_calibration : bool, default=False
         Whether the scorer requires calibration data from fit().
+    symmetric : bool, default=False
+        Whether the scorer produces symmetric (absolute) conformity
+        scores.  Symmetric scorers yield equal width intervals on both
+        sides of the point prediction.  Asymmetric scorers (the default)
+        allow different widths above and below.
+    multiplicative : bool, default=False
+        Whether the scorer normalises residuals by the prediction
+        magnitude (e.g. gamma residuals).  When ``True``, weighted
+        interval reconstruction scales quantiles by
+        ``(prediction + epsilon)``.
 
     """
 
     prediction_type: Literal["point", "interval", "class_proba"] | None = None
     lower_is_better: bool = True
     requires_calibration: bool = False
+    symmetric: bool = False
+    multiplicative: bool = False
 
 
 @dataclass

--- a/tests/interval/test_similarity.py
+++ b/tests/interval/test_similarity.py
@@ -1014,3 +1014,26 @@ class TestCompositeSimilarityIntegration:
         assert len(intervals) == 1
         non_time_cols = [c for c in intervals.columns if c != "time"]
         assert len(non_time_cols) >= 2
+
+
+class TestTemporalSimilaritySingleTimestamp:
+    """Tests for TemporalSimilarity with a single observation."""
+
+    def test_fit_single_timestamp(self):
+        """Test fit with a single timestamp sets interval_td_ to zero."""
+        y = pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]})
+        y_pred = pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.1]})
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+        assert sim.interval_td_ == timedelta(0)
+
+    def test_predict_after_single_timestamp_fit(self):
+        """Test predict works after fitting with a single timestamp (zero interval)."""
+        y = pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]})
+        y_pred = pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.1]})
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+
+        weights = sim.predict(y_pred)
+        assert weights.shape == (1, 1)
+        assert np.all(np.isfinite(weights))

--- a/tests/interval/test_similarity.py
+++ b/tests/interval/test_similarity.py
@@ -1,13 +1,13 @@
-"""Tests for DistanceSimilarity interval forecasting component."""
+"""Tests for similarity measures in interval forecasting."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import numpy as np
 import polars as pl
 import pytest
 from sklearn.base import clone
 
-from yohou.interval.similarity import DistanceSimilarity
+from yohou.interval.similarity import CompositeSimilarity, DistanceSimilarity, TemporalSimilarity
 
 
 @pytest.fixture
@@ -198,13 +198,6 @@ class TestDistanceSimilarityWithExogenous:
 class TestDistanceSimilarityProperties:
     """Tests for properties and attributes."""
 
-    def test_n_discarded_indices(self, train_data):
-        """Test n_discarded_indices_ property."""
-        y, y_pred = train_data
-        sim = DistanceSimilarity()
-        sim.fit(y, y_pred)
-        assert sim.n_discarded_indices_ == 0
-
     def test_clone(self):
         """Test that DistanceSimilarity can be cloned."""
         sim = DistanceSimilarity(metric="cityblock")
@@ -231,3 +224,793 @@ class TestDistanceSimilarityProperties:
         tags = sim.__sklearn_tags__()
         assert tags.estimator_type == "similarity"
         assert tags.requires_fit is True
+
+
+@pytest.fixture
+def daily_data():
+    """Create 10 weeks of daily data with weekly seasonality."""
+    n = 70
+    dates = [datetime(2021, 1, 1) + timedelta(days=i) for i in range(n)]
+    np.random.seed(42)
+    values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) for i in range(n)]
+    y = pl.DataFrame({"time": dates, "value": values})
+    y_pred = pl.DataFrame({"time": dates, "value": [v + 0.1 for v in values]})
+    return y, y_pred
+
+
+@pytest.fixture
+def daily_prediction_data():
+    """Create a single prediction row for the 71st day."""
+    dates = [datetime(2021, 1, 1) + timedelta(days=70)]
+    y_pred = pl.DataFrame({"time": dates, "value": [10.5]})
+    return y_pred
+
+
+class TestDistanceSimilarityNullRejection:
+    """Tests that DistanceSimilarity rejects null and NaN data."""
+
+    def test_fit_rejects_null_y_pred(self, train_data):
+        """Test that fit raises ValueError when y_pred contains null."""
+        y, y_pred = train_data
+        y_pred_null = y_pred.with_columns(
+            pl.when(pl.col("value") > 5).then(None).otherwise(pl.col("value")).alias("value")
+        )
+        sim = DistanceSimilarity()
+        with pytest.raises(ValueError, match="null or NaN"):
+            sim.fit(y, y_pred_null)
+
+    def test_fit_rejects_nan_y_pred(self, train_data):
+        """Test that fit raises ValueError when y_pred contains NaN."""
+        y, y_pred = train_data
+        y_pred_nan = y_pred.with_columns(
+            pl.when(pl.col("value") > 5).then(float("nan")).otherwise(pl.col("value")).alias("value")
+        )
+        sim = DistanceSimilarity()
+        with pytest.raises(ValueError, match="null or NaN"):
+            sim.fit(y, y_pred_nan)
+
+    def test_observe_rejects_null(self, train_data):
+        """Test that observe raises ValueError when data contains null."""
+        y, y_pred = train_data
+        sim = DistanceSimilarity()
+        sim.fit(y, y_pred)
+        y_null = y.head(1).with_columns(pl.lit(None, dtype=pl.Float64).alias("value"))
+        y_pred_null = y_pred.head(1).with_columns(pl.lit(None, dtype=pl.Float64).alias("value"))
+        with pytest.raises(ValueError, match="null or NaN"):
+            sim.observe(y_null, y_pred_null)
+
+    def test_observe_rejects_nan(self, train_data):
+        """Test that observe raises ValueError when data contains NaN."""
+        y, y_pred = train_data
+        sim = DistanceSimilarity()
+        sim.fit(y, y_pred)
+        y_pred_nan = y_pred.head(1).with_columns(pl.lit(float("nan")).alias("value"))
+        with pytest.raises(ValueError, match="null or NaN"):
+            sim.observe(y.head(1), y_pred_nan)
+
+    def test_predict_rejects_null(self, train_data):
+        """Test that predict raises ValueError when data contains null."""
+        y, y_pred = train_data
+        sim = DistanceSimilarity()
+        sim.fit(y, y_pred)
+        y_pred_null = y_pred.head(1).with_columns(pl.lit(None, dtype=pl.Float64).alias("value"))
+        with pytest.raises(ValueError, match="null or NaN"):
+            sim.predict(y_pred_null)
+
+    def test_predict_rejects_nan(self, train_data):
+        """Test that predict raises ValueError when data contains NaN."""
+        y, y_pred = train_data
+        sim = DistanceSimilarity()
+        sim.fit(y, y_pred)
+        y_pred_nan = y_pred.head(1).with_columns(pl.lit(float("nan")).alias("value"))
+        with pytest.raises(ValueError, match="null or NaN"):
+            sim.predict(y_pred_nan)
+
+    def test_error_message_includes_column_name(self, train_data):
+        """Test that the error message includes the offending column name."""
+        y, y_pred = train_data
+        y_pred_null = y_pred.with_columns(pl.lit(None, dtype=pl.Float64).alias("value"))
+        sim = DistanceSimilarity()
+        with pytest.raises(ValueError, match="value"):
+            sim.fit(y, y_pred_null)
+
+
+class TestTemporalSimilarityBasic:
+    """Basic tests for TemporalSimilarity."""
+
+    def test_fit_returns_self(self, daily_data):
+        """Test that fit returns the estimator."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        result = sim.fit(y, y_pred)
+        assert result is sim
+
+    def test_predict_returns_ndarray(self, daily_data, daily_prediction_data):
+        """Test that predict returns a numpy array."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+        weights = sim.predict(daily_prediction_data)
+        assert isinstance(weights, np.ndarray)
+
+    def test_predict_shape(self, daily_data, daily_prediction_data):
+        """Test that predict returns correct shape."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+        weights = sim.predict(daily_prediction_data)
+        assert weights.shape == (1, 70)
+
+    def test_predict_shape_multi_row(self, daily_data):
+        """Test predict shape with multiple prediction rows."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+
+        dates = [datetime(2021, 3, 12) + timedelta(days=i) for i in range(3)]
+        y_pred_new = pl.DataFrame({"time": dates, "value": [1.0, 2.0, 3.0]})
+        weights = sim.predict(y_pred_new)
+        assert weights.shape == (3, 70)
+
+    def test_weights_are_positive(self, daily_data, daily_prediction_data):
+        """Test that all weights are positive."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+        weights = sim.predict(daily_prediction_data)
+        assert np.all(weights > 0)
+
+    def test_weights_are_finite(self, daily_data, daily_prediction_data):
+        """Test that all weights are finite."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+        weights = sim.predict(daily_prediction_data)
+        assert np.all(np.isfinite(weights))
+
+    def test_weights_row_sum_less_than_one(self, daily_data, daily_prediction_data):
+        """Test that weight rows sum to less than 1 (uniform component reserved)."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+        weights = sim.predict(daily_prediction_data)
+        assert np.all(np.sum(weights, axis=1) < 1.0)
+
+    def test_empty_seasonalities_raises(self, daily_data):
+        """Test that empty seasonalities raises ValueError."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[])
+        with pytest.raises(ValueError, match="seasonalities"):
+            sim.fit(y, y_pred)
+
+    def test_none_seasonalities_raises(self, daily_data):
+        """Test that None seasonalities raises ValueError."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=None)
+        with pytest.raises(ValueError, match="seasonalities"):
+            sim.fit(y, y_pred)
+
+
+class TestTemporalSimilaritySeasonalProximity:
+    """Tests verifying that same-season observations get higher weight."""
+
+    def test_same_weekday_gets_higher_weight(self, daily_data):
+        """Test that observations on the same weekday get higher weight."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+
+        # Predict for a specific day
+        test_date = datetime(2021, 3, 15)  # Monday
+        y_pred_test = pl.DataFrame({"time": [test_date], "value": [10.0]})
+        weights = sim.predict(y_pred_test)
+
+        # Check that Mondays in calibration get higher weight
+        calib_dates = y_pred["time"].to_list()
+        same_weekday = [i for i, d in enumerate(calib_dates) if d.weekday() == test_date.weekday()]
+        other_weekday = [i for i, d in enumerate(calib_dates) if d.weekday() != test_date.weekday()]
+
+        avg_same = np.mean(weights[0, same_weekday])
+        avg_other = np.mean(weights[0, other_weekday])
+        assert avg_same > avg_other
+
+    def test_weekday_weight_ratio(self, daily_data):
+        """Test that same-weekday weight is significantly higher."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+
+        test_date = datetime(2021, 3, 15)  # Monday
+        y_pred_test = pl.DataFrame({"time": [test_date], "value": [10.0]})
+        weights = sim.predict(y_pred_test)
+
+        calib_dates = y_pred["time"].to_list()
+        same_weekday = [i for i, d in enumerate(calib_dates) if d.weekday() == test_date.weekday()]
+        other_weekday = [i for i, d in enumerate(calib_dates) if d.weekday() != test_date.weekday()]
+
+        ratio = np.mean(weights[0, same_weekday]) / np.mean(weights[0, other_weekday])
+        # Should be at least 2x higher for weekly seasonality
+        assert ratio > 2.0
+
+
+class TestTemporalSimilarityMultiSeasonality:
+    """Tests for multiple seasonalities."""
+
+    def test_multi_seasonality_feature_count(self, daily_data):
+        """Test feature count with multiple seasonalities."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0, 365.25])
+        sim.fit(y, y_pred)
+        # 2 features per seasonality (sin + cos), 2 seasonalities = 4
+        assert sim._n_features == 4
+
+    def test_multi_seasonality_predict_shape(self, daily_data, daily_prediction_data):
+        """Test that multi-seasonality prediction shape is correct."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0, 365.25])
+        sim.fit(y, y_pred)
+        weights = sim.predict(daily_prediction_data)
+        assert weights.shape == (1, 70)
+
+
+class TestTemporalSimilarityHarmonics:
+    """Tests for custom harmonics."""
+
+    def test_custom_harmonics(self, daily_data, daily_prediction_data):
+        """Test with custom harmonics."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(
+            seasonalities=[7.0],
+            harmonics={7.0: [1, 2, 3]},
+        )
+        sim.fit(y, y_pred)
+        # 3 harmonics x 2 (sin+cos) = 6 features
+        assert sim._n_features == 6
+
+        weights = sim.predict(daily_prediction_data)
+        assert weights.shape == (1, 70)
+        assert np.all(np.isfinite(weights))
+
+    def test_harmonics_more_selective(self, daily_data):
+        """Test that more harmonics give sharper weighting."""
+        y, y_pred = daily_data
+
+        sim_1 = TemporalSimilarity(seasonalities=[7.0], harmonics={7.0: [1]})
+        sim_3 = TemporalSimilarity(seasonalities=[7.0], harmonics={7.0: [1, 2, 3]})
+        sim_1.fit(y, y_pred)
+        sim_3.fit(y, y_pred)
+
+        test_date = datetime(2021, 3, 15)
+        y_pred_test = pl.DataFrame({"time": [test_date], "value": [10.0]})
+        w_1 = sim_1.predict(y_pred_test)
+        w_3 = sim_3.predict(y_pred_test)
+
+        # Both should have valid weights
+        assert np.all(np.isfinite(w_1))
+        assert np.all(np.isfinite(w_3))
+        # More harmonics should give different (typically sharper) weights
+        assert not np.allclose(w_1, w_3)
+
+
+class TestTemporalSimilarityObserve:
+    """Tests for observe method."""
+
+    def test_observe_returns_self(self, daily_data):
+        """Test that observe returns the estimator."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+        result = sim.observe(y[:3], y_pred[:3])
+        assert result is sim
+
+    def test_observe_extends_features(self, daily_data, daily_prediction_data):
+        """Test that observe extends the reference feature matrix."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+
+        weights_before = sim.predict(daily_prediction_data)
+        n_before = weights_before.shape[1]
+
+        # Observe 5 new rows
+        new_dates = [datetime(2021, 3, 12) + timedelta(days=i) for i in range(5)]
+        y_new = pl.DataFrame({"time": new_dates, "value": [1.0] * 5})
+        y_pred_new = pl.DataFrame({"time": new_dates, "value": [1.1] * 5})
+        sim.observe(y_new, y_pred_new)
+
+        weights_after = sim.predict(daily_prediction_data)
+        assert weights_after.shape[1] == n_before + 5
+
+
+class TestTemporalSimilarityProperties:
+    """Tests for properties and sklearn compatibility."""
+
+    def test_clone(self):
+        """Test that TemporalSimilarity can be cloned."""
+        sim = TemporalSimilarity(seasonalities=[7.0, 365.25], metric="cityblock")
+        cloned = clone(sim)
+        assert cloned.seasonalities == [7.0, 365.25]
+        assert cloned.metric == "cityblock"
+        assert cloned is not sim
+
+    def test_get_params(self):
+        """Test get_params returns expected parameters."""
+        sim = TemporalSimilarity(
+            seasonalities=[7.0],
+            harmonics={7.0: [1, 2]},
+            metric="cosine",
+        )
+        params = sim.get_params()
+        assert params["seasonalities"] == [7.0]
+        assert params["harmonics"] == {7.0: [1, 2]}
+        assert params["metric"] == "cosine"
+
+    def test_set_params(self):
+        """Test set_params updates parameters."""
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.set_params(metric="cityblock")
+        assert sim.metric == "cityblock"
+
+    def test_tags(self):
+        """Test sklearn tags are set correctly."""
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        tags = sim.__sklearn_tags__()
+        assert tags.estimator_type == "similarity"
+        assert tags.requires_fit is True
+
+    def test_auto_detect_interval(self, daily_data):
+        """Test that interval is auto-detected from timestamps."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+        assert sim.interval_td_ == timedelta(days=1)
+
+    def test_first_time_stored(self, daily_data):
+        """Test that first_time_ is stored from calibration data."""
+        y, y_pred = daily_data
+        sim = TemporalSimilarity(seasonalities=[7.0])
+        sim.fit(y, y_pred)
+        assert sim.first_time_ == datetime(2021, 1, 1)
+
+
+class TestTemporalSimilarityIntegration:
+    """Integration tests with SplitConformalForecaster."""
+
+    def test_with_split_conformal(self):
+        """Test TemporalSimilarity plugged into SplitConformalForecaster."""
+        from yohou.interval import SplitConformalForecaster
+        from yohou.metrics.conformity import AbsoluteResidual
+        from yohou.point import SeasonalNaive
+
+        n = 200
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        np.random.seed(42)
+        values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + np.random.normal(0, 0.5) for i in range(n)]
+        y = pl.DataFrame({"time": dates, "value": values})
+        y_train = y[:180]
+
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=TemporalSimilarity(seasonalities=[7.0]),
+        )
+        scf.fit(y_train, forecasting_horizon=3, coverage_rates=[0.9])
+
+        intervals = scf.predict_interval(forecasting_horizon=3, coverage_rates=[0.9])
+        assert len(intervals) == 3
+        assert "time" in intervals.columns
+
+    def test_produces_different_intervals_than_unweighted(self):
+        """Test that temporal similarity changes intervals vs unweighted."""
+        from yohou.interval import SplitConformalForecaster
+        from yohou.metrics.conformity import AbsoluteResidual
+        from yohou.point import SeasonalNaive
+
+        n = 200
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        np.random.seed(42)
+        values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + np.random.normal(0, 0.5) for i in range(n)]
+        y = pl.DataFrame({"time": dates, "value": values})
+        y_train = y[:180]
+
+        scf_weighted = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=TemporalSimilarity(seasonalities=[7.0]),
+        )
+        scf_weighted.fit(y_train, forecasting_horizon=1, coverage_rates=[0.9])
+
+        scf_unweighted = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+        )
+        scf_unweighted.fit(y_train, forecasting_horizon=1, coverage_rates=[0.9])
+
+        iv_w = scf_weighted.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])
+        iv_u = scf_unweighted.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])
+
+        # Intervals should differ (temporal weighting changes quantiles)
+        value_cols = [c for c in iv_w.columns if c != "time" and iv_w[c].dtype.is_numeric()]
+        any_differ = any(not np.isclose(float(iv_w[col][0]), float(iv_u[col][0])) for col in value_cols)
+        assert any_differ, "At least one interval bound should differ"
+
+    def test_with_gamma_residual(self):
+        """Test that similarity + GammaResidual produces weighted intervals."""
+        from yohou.interval import SplitConformalForecaster
+        from yohou.metrics.conformity import GammaResidual
+        from yohou.point import SeasonalNaive
+
+        n = 200
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        np.random.seed(42)
+        values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + np.random.normal(0, 0.5) for i in range(n)]
+        y = pl.DataFrame({"time": dates, "value": values})
+        y_train = y[:180]
+
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=GammaResidual(),
+            similarity=TemporalSimilarity(seasonalities=[7.0]),
+        )
+        scf.fit(y_train, forecasting_horizon=1, coverage_rates=[0.9])
+
+        intervals = scf.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])
+        assert len(intervals) == 1
+        # Should have lower and upper bound columns
+        non_time_cols = [c for c in intervals.columns if c != "time"]
+        assert len(non_time_cols) >= 2
+
+    def test_with_absolute_gamma_residual(self):
+        """Test that similarity + AbsoluteGammaResidual produces weighted intervals."""
+        from yohou.interval import SplitConformalForecaster
+        from yohou.metrics.conformity import AbsoluteGammaResidual
+        from yohou.point import SeasonalNaive
+
+        n = 200
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        np.random.seed(42)
+        values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + np.random.normal(0, 0.5) for i in range(n)]
+        y = pl.DataFrame({"time": dates, "value": values})
+        y_train = y[:180]
+
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteGammaResidual(),
+            similarity=TemporalSimilarity(seasonalities=[7.0]),
+        )
+        scf.fit(y_train, forecasting_horizon=1, coverage_rates=[0.9])
+
+        intervals = scf.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])
+        assert len(intervals) == 1
+        non_time_cols = [c for c in intervals.columns if c != "time"]
+        assert len(non_time_cols) >= 2
+
+
+# ── CompositeSimilarity ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def composite_data():
+    """Create daily data with weekly seasonality for composite tests."""
+    n = 56  # 8 weeks
+    dates = [datetime(2021, 1, 1) + timedelta(days=i) for i in range(n)]
+    np.random.seed(42)
+    values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + np.random.normal(0, 0.5) for i in range(n)]
+    y = pl.DataFrame({"time": dates, "value": values})
+    y_pred = pl.DataFrame({"time": dates, "value": [v + np.random.normal(0, 0.3) for v in values]})
+    return y, y_pred
+
+
+class TestCompositeSimilarityBasic:
+    """Core fit/predict behaviour."""
+
+    def test_fit_returns_self(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+        )
+        result = comp.fit(y, y_pred)
+        assert result is comp
+
+    def test_predict_returns_ndarray(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+        )
+        comp.fit(y, y_pred)
+        new_pred = y_pred.tail(1)
+        weights = comp.predict(new_pred)
+        assert isinstance(weights, np.ndarray)
+
+    def test_predict_shape(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+        )
+        comp.fit(y, y_pred)
+        new_pred = y_pred.tail(3)
+        weights = comp.predict(new_pred)
+        assert weights.shape == (3, len(y_pred))
+
+    def test_weights_are_positive(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+        )
+        comp.fit(y, y_pred)
+        weights = comp.predict(y_pred.tail(1))
+        assert np.all(weights > 0)
+
+    def test_weights_are_finite(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+        )
+        comp.fit(y, y_pred)
+        weights = comp.predict(y_pred.tail(1))
+        assert np.all(np.isfinite(weights))
+
+    def test_row_sum_less_than_one_multiply(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+            combination="multiply",
+        )
+        comp.fit(y, y_pred)
+        weights = comp.predict(y_pred.tail(2))
+        assert np.all(weights.sum(axis=1) < 1.0)
+
+    def test_mean_combination(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+            combination="mean",
+        )
+        comp.fit(y, y_pred)
+        weights = comp.predict(y_pred.tail(1))
+        assert weights.shape == (1, len(y_pred))
+        assert np.all(weights > 0)
+
+
+class TestCompositeSimilarityValidation:
+    """Parameter validation."""
+
+    def test_fewer_than_two_raises(self):
+        comp = CompositeSimilarity(similarities=[DistanceSimilarity()])
+        with pytest.raises(ValueError, match="at least 2"):
+            comp.fit(
+                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
+                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
+            )
+
+    def test_none_similarities_raises(self):
+        comp = CompositeSimilarity(similarities=None)
+        with pytest.raises(ValueError, match="at least 2"):
+            comp.fit(
+                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
+                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
+            )
+
+    def test_invalid_combination_raises(self):
+        comp = CompositeSimilarity(
+            similarities=[DistanceSimilarity(), DistanceSimilarity()],
+            combination="invalid",
+        )
+        with pytest.raises(ValueError, match="combination"):
+            comp.fit(
+                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
+                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
+            )
+
+    def test_weights_length_mismatch_raises(self):
+        comp = CompositeSimilarity(
+            similarities=[DistanceSimilarity(), DistanceSimilarity()],
+            weights=[1.0, 2.0, 3.0],
+        )
+        with pytest.raises(ValueError, match="weights length"):
+            comp.fit(
+                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
+                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
+            )
+
+
+class TestCompositeSimilarityWeights:
+    """Custom weight behaviour."""
+
+    def test_custom_weights_multiply(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+            combination="multiply",
+            weights=[2.0, 0.5],
+        )
+        comp.fit(y, y_pred)
+        weights = comp.predict(y_pred.tail(1))
+        assert weights.shape == (1, len(y_pred))
+        assert np.all(weights > 0)
+
+    def test_custom_weights_mean(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+            combination="mean",
+            weights=[0.3, 0.7],
+        )
+        comp.fit(y, y_pred)
+        weights = comp.predict(y_pred.tail(1))
+        assert weights.shape == (1, len(y_pred))
+        assert np.all(weights > 0)
+
+    def test_multiply_differs_from_individual(self, composite_data):
+        """Composite multiply should differ from either sub-similarity alone."""
+        y, y_pred = composite_data
+        new_pred = y_pred.tail(1)
+
+        dist_sim = DistanceSimilarity(metric="euclidean")
+        dist_sim.fit(y, y_pred)
+        w_dist = dist_sim.predict(new_pred)
+
+        temp_sim = TemporalSimilarity(seasonalities=[7.0])
+        temp_sim.fit(y, y_pred)
+        w_temp = temp_sim.predict(new_pred)
+
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+            combination="multiply",
+        )
+        comp.fit(y, y_pred)
+        w_comp = comp.predict(new_pred)
+
+        assert not np.allclose(w_comp, w_dist)
+        assert not np.allclose(w_comp, w_temp)
+
+
+class TestCompositeSimilarityObserveRewind:
+    """Observe and rewind delegation."""
+
+    def test_observe_returns_self(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+        )
+        comp.fit(y, y_pred)
+        result = comp.observe(y.tail(1), y_pred.tail(1))
+        assert result is comp
+
+    def test_observe_extends_sub_similarities(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+        )
+        comp.fit(y, y_pred)
+
+        n_dist_before = len(comp.similarities_[0]._X_observed)
+        n_temp_before = comp.similarities_[1]._features_observed.shape[0]
+
+        comp.observe(y.tail(1), y_pred.tail(1))
+
+        assert len(comp.similarities_[0]._X_observed) == n_dist_before + 1
+        assert comp.similarities_[1]._features_observed.shape[0] == n_temp_before + 1
+
+    def test_rewind_restores_sub_similarities(self, composite_data):
+        y, y_pred = composite_data
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+        )
+        comp.fit(y, y_pred)
+
+        n_dist_before = len(comp.similarities_[0]._X_observed)
+        n_temp_before = comp.similarities_[1]._features_observed.shape[0]
+
+        comp.observe(y.tail(1), y_pred.tail(1))
+        comp.rewind(y.tail(1), y_pred.tail(1))
+
+        assert len(comp.similarities_[0]._X_observed) == n_dist_before
+        assert comp.similarities_[1]._features_observed.shape[0] == n_temp_before
+
+
+class TestCompositeSimilarityProperties:
+    """sklearn estimator interface."""
+
+    def test_clone(self):
+        comp = CompositeSimilarity(
+            similarities=[
+                DistanceSimilarity(metric="euclidean"),
+                TemporalSimilarity(seasonalities=[7.0]),
+            ],
+            combination="mean",
+            weights=[0.3, 0.7],
+        )
+        cloned = clone(comp)
+        assert cloned.combination == "mean"
+        assert cloned.weights == [0.3, 0.7]
+        assert len(cloned.similarities) == 2
+
+    def test_get_params(self):
+        comp = CompositeSimilarity(
+            similarities=[DistanceSimilarity(), TemporalSimilarity(seasonalities=[7.0])],
+            combination="multiply",
+        )
+        params = comp.get_params()
+        assert params["combination"] == "multiply"
+        assert params["weights"] is None
+        assert len(params["similarities"]) == 2
+
+
+class TestCompositeSimilarityIntegration:
+    """Integration with SplitConformalForecaster."""
+
+    def test_with_split_conformal(self):
+        from yohou.interval import SplitConformalForecaster
+        from yohou.metrics import AbsoluteResidual
+        from yohou.point import SeasonalNaive
+
+        n = 200
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        np.random.seed(42)
+        values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + np.random.normal(0, 0.5) for i in range(n)]
+        y = pl.DataFrame({"time": dates, "value": values})
+        y_train = y[:180]
+
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=CompositeSimilarity(
+                similarities=[
+                    DistanceSimilarity(metric="euclidean"),
+                    TemporalSimilarity(seasonalities=[7.0]),
+                ],
+                combination="multiply",
+            ),
+        )
+        scf.fit(y_train, forecasting_horizon=1, coverage_rates=[0.9])
+
+        intervals = scf.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])
+        assert len(intervals) == 1
+        non_time_cols = [c for c in intervals.columns if c != "time"]
+        assert len(non_time_cols) >= 2

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -10,6 +10,7 @@ from sklearn.exceptions import NotFittedError
 
 from conftest import run_checks
 from yohou.interval import DistanceSimilarity, SplitConformalForecaster
+from yohou.interval.similarity import TemporalSimilarity
 from yohou.metrics import AbsoluteResidual, Residual
 from yohou.point import SeasonalNaive
 from yohou.testing import _yield_yohou_forecaster_checks
@@ -406,3 +407,143 @@ class TestSplitConformalSystematicChecks:
             _yield_yohou_forecaster_checks(forecaster, y_train, None, y_test, None),
             expected_failures=set(),
         )
+
+
+class TestSplitConformalObserveRewindSimilarity:
+    """Tests for observe/rewind forwarding to similarity and conformity score updates."""
+
+    @pytest.fixture
+    def scf_with_similarity(self):
+        """Create fitted SplitConformalForecaster with DistanceSimilarity."""
+        n = 250
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        np.random.seed(42)
+        values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + np.random.normal(0, 0.5) for i in range(n)]
+        y = pl.DataFrame({"time": dates, "value": values})
+        y_train = y[:200]
+        y_test = y[200:]
+
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=DistanceSimilarity(metric="euclidean"),
+        )
+        scf.fit(y_train, forecasting_horizon=1, coverage_rates=[0.9])
+        return scf, y_train, y_test
+
+    def test_observe_updates_similarity_state(self, scf_with_similarity):
+        """Test that observe() forwards to similarity.observe() and grows state."""
+        scf, y_train, y_test = scf_with_similarity
+        sim_step = scf.similarities_["step_1"]
+        n_before = len(sim_step._X_observed)
+
+        scf.observe(y_test[:1])
+
+        assert len(sim_step._X_observed) == n_before + 1
+
+    def test_observe_updates_conformity_scores(self, scf_with_similarity):
+        """Test that observe() appends new conformity scores."""
+        scf, y_train, y_test = scf_with_similarity
+        n_scores_before = len(scf.conformity_scores_)
+
+        scf.observe(y_test[:1])
+
+        assert len(scf.conformity_scores_) == n_scores_before + 1
+
+    def test_rewind_restores_similarity_state(self, scf_with_similarity):
+        """Test that observe() then rewind() restores original similarity state."""
+        scf, y_train, y_test = scf_with_similarity
+        sim_step = scf.similarities_["step_1"]
+        n_before = len(sim_step._X_observed)
+        x_observed_before = sim_step._X_observed.clone()
+
+        # Observe new data one row at a time (standard streaming pattern)
+        for i in range(10):
+            scf.observe(y_test[i : i + 1])
+
+        assert len(sim_step._X_observed) == n_before + 10
+
+        # Rewind using training data (same pattern as existing rewind tests)
+        scf.rewind(y_train[190:200])
+
+        assert len(sim_step._X_observed) == n_before
+        assert sim_step._X_observed.equals(x_observed_before)
+
+    def test_rewind_restores_conformity_scores(self, scf_with_similarity):
+        """Test that observe() then rewind() restores original conformity scores count."""
+        scf, y_train, y_test = scf_with_similarity
+        n_scores_before = len(scf.conformity_scores_)
+
+        for i in range(10):
+            scf.observe(y_test[i : i + 1])
+        assert len(scf.conformity_scores_) == n_scores_before + 10
+
+        scf.rewind(y_train[190:200])
+        assert len(scf.conformity_scores_) == n_scores_before
+
+    def test_observe_without_similarity_unchanged(self):
+        """Test that observe() without similarity does not fail."""
+        n = 200
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        np.random.seed(42)
+        values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) for i in range(n)]
+        y = pl.DataFrame({"time": dates, "value": values})
+        y_train = y[:180]
+        y_test = y[180:]
+
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+        )
+        scf.fit(y_train, forecasting_horizon=1, coverage_rates=[0.9])
+        n_scores = len(scf.conformity_scores_)
+
+        scf.observe(y_test[:1])
+        # No similarity, so conformity scores should NOT be updated
+        assert len(scf.conformity_scores_) == n_scores
+
+    def test_observe_with_temporal_similarity(self):
+        """Test that observe() works with TemporalSimilarity."""
+        n = 200
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        np.random.seed(42)
+        values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + np.random.normal(0, 0.5) for i in range(n)]
+        y = pl.DataFrame({"time": dates, "value": values})
+        y_train = y[:180]
+        y_test = y[180:]
+
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=TemporalSimilarity(seasonalities=[7.0]),
+        )
+        scf.fit(y_train, forecasting_horizon=1, coverage_rates=[0.9])
+
+        sim_step = scf.similarities_["step_1"]
+        n_features_before = sim_step._features_observed.shape[0]
+
+        scf.observe(y_test[:1])
+        assert sim_step._features_observed.shape[0] == n_features_before + 1
+
+    def test_multi_step_observe_rewind_symmetry(self, scf_with_similarity):
+        """Test that multiple observe() then rewind() restores state."""
+        scf, y_train, y_test = scf_with_similarity
+        sim_step = scf.similarities_["step_1"]
+        n_sim_before = len(sim_step._X_observed)
+        n_scores_before = len(scf.conformity_scores_)
+
+        # Observe 3 times
+        for i in range(3):
+            scf.observe(y_test[i : i + 1])
+
+        assert len(sim_step._X_observed) == n_sim_before + 3
+        assert len(scf.conformity_scores_) == n_scores_before + 3
+
+        # Rewind using training data rows (at least observation_horizon rows)
+        scf.rewind(y_train[190:200])
+
+        assert len(sim_step._X_observed) == n_sim_before
+        assert len(scf.conformity_scores_) == n_scores_before

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -386,6 +386,59 @@ class TestSplitConformalSimilarity:
         assert not hasattr(scf, "similarities_")
         assert not hasattr(scf, "weights_")
 
+    def test_predict_interval_after_observe_with_similarity(self, conformal_data):
+        """Test predict_interval after observe with similarity (vintage_time path)."""
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=1),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=DistanceSimilarity(metric="euclidean"),
+        )
+        scf.fit(conformal_data[:200], forecasting_horizon=1, coverage_rates=[0.9])
+
+        # Observe new data (this causes point_forecaster_ to track vintage_time)
+        scf.observe(conformal_data[200:210])
+
+        # predict_interval should handle vintage_time column from inner predict
+        intervals = scf.predict_interval(coverage_rates=[0.9])
+        assert isinstance(intervals, pl.DataFrame)
+        assert len(intervals) >= 1
+        assert "value_lower_0.9" in intervals.columns
+        assert "value_upper_0.9" in intervals.columns
+
+    def test_predict_interval_unsupported_scorer_fallback(self, conformal_data):
+        """Test that predict_interval falls back to unweighted for unrecognized scorer types."""
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=1),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=DistanceSimilarity(metric="euclidean"),
+        )
+        scf.fit(conformal_data[:200], forecasting_horizon=1, coverage_rates=[0.9])
+
+        # Replace the fitted scorer with a wrapper that is not one of the 4 recognized types
+        original_scorer = scf.conformity_scorers_["step_1"]
+
+        class _WrappedScorer:
+            """Scorer wrapper that delegates inverse_score but is not a recognized type."""
+
+            def __init__(self, inner):
+                self._inner = inner
+
+            def inverse_score(self, y_pred, conformity_scores, coverage_rate):
+                return self._inner.inverse_score(
+                    y_pred=y_pred,
+                    conformity_scores=conformity_scores,
+                    coverage_rate=coverage_rate,
+                )
+
+        scf.conformity_scorers_["step_1"] = _WrappedScorer(original_scorer)
+
+        y_pred = scf.predict_interval(coverage_rates=[0.9])
+        assert isinstance(y_pred, pl.DataFrame)
+        assert "value_lower_0.9" in y_pred.columns
+        assert "value_upper_0.9" in y_pred.columns
+
 
 class TestSplitConformalSystematicChecks:
     """Systematic checks for SplitConformalForecaster using the check generator."""
@@ -547,3 +600,160 @@ class TestSplitConformalObserveRewindSimilarity:
 
         assert len(sim_step._X_observed) == n_sim_before
         assert len(scf.conformity_scores_) == n_scores_before
+
+    def test_rewind_without_prior_observe(self, scf_with_similarity):
+        """Test that rewind with similarity when no data was observed is a no-op."""
+        scf, y_train, _y_test = scf_with_similarity
+        sim_step = scf.similarities_["step_1"]
+        n_before = len(sim_step._X_observed)
+        n_scores_before = len(scf.conformity_scores_)
+
+        # Rewind without any prior observe: n_post_fit_removed == 0
+        scf.rewind(y_train[190:200])
+
+        assert len(sim_step._X_observed) == n_before
+        assert len(scf.conformity_scores_) == n_scores_before
+
+
+class TestSplitConformalWithExogenousFeatures:
+    """Tests for X-forwarding in fit, observe, and predict_interval."""
+
+    @pytest.fixture
+    def conformal_data_with_X(self):
+        """Create data with exogenous features."""
+        n = 250
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        np.random.seed(42)
+        values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + np.random.normal(0, 0.5) for i in range(n)]
+        y = pl.DataFrame({"time": dates, "value": values})
+        X = pl.DataFrame({
+            "time": dates,
+            "feature_a": [float(i % 7) for i in range(n)],
+        })
+        return y, X
+
+    def test_fit_with_X_and_similarity(self, conformal_data_with_X):
+        """Test that fit with X and similarity stores similarities_ correctly."""
+        y, X = conformal_data_with_X
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=DistanceSimilarity(metric="euclidean"),
+        )
+        scf.fit(y[:200], X=X[:200], forecasting_horizon=1, coverage_rates=[0.9])
+        assert hasattr(scf, "similarities_")
+        assert "step_1" in scf.similarities_
+
+    def test_predict_interval_with_X_and_similarity(self, conformal_data_with_X):
+        """Test predict_interval with X and similarity produces valid intervals."""
+        y, X = conformal_data_with_X
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=DistanceSimilarity(metric="euclidean"),
+        )
+        scf.fit(y[:200], X=X[:200], forecasting_horizon=1, coverage_rates=[0.9])
+        intervals = scf.predict_interval(X=X[200:201], coverage_rates=[0.9])
+        assert isinstance(intervals, pl.DataFrame)
+        assert "value_lower_0.9" in intervals.columns
+        assert "value_upper_0.9" in intervals.columns
+
+    def test_observe_with_X_and_similarity(self, conformal_data_with_X):
+        """Test that observe with X forwards to similarity correctly."""
+        y, X = conformal_data_with_X
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=DistanceSimilarity(metric="euclidean"),
+        )
+        scf.fit(y[:200], X=X[:200], forecasting_horizon=1, coverage_rates=[0.9])
+        sim_step = scf.similarities_["step_1"]
+        n_before = len(sim_step._X_observed)
+
+        scf.observe(y[200:201], X=X[200:201])
+        assert len(sim_step._X_observed) == n_before + 1
+
+
+class TestSplitConformalObservePredict:
+    """Tests for the observe_predict rolling method."""
+
+    def test_observe_predict_returns_point_predictions(self, conformal_data):
+        """Test that observe_predict returns valid point predictions."""
+        scf = SplitConformalForecaster(calibration_size=50)
+        scf.fit(conformal_data[:200], forecasting_horizon=1)
+
+        y_test = conformal_data[200:205]
+        y_pred = scf.observe_predict(y=y_test)
+        assert isinstance(y_pred, pl.DataFrame)
+        # Initial prediction + one per stride step
+        assert len(y_pred) >= 1
+
+    def test_observe_predict_with_similarity(self, conformal_data):
+        """Test observe_predict with similarity enabled."""
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=1),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=DistanceSimilarity(metric="euclidean"),
+        )
+        scf.fit(conformal_data[:200], forecasting_horizon=1, coverage_rates=[0.9])
+
+        y_test = conformal_data[200:205]
+        y_pred = scf.observe_predict(y=y_test)
+        assert isinstance(y_pred, pl.DataFrame)
+        assert len(y_pred) >= 1
+
+    def test_observe_predict_with_X(self):
+        """Test observe_predict with exogenous features."""
+        n = 250
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        np.random.seed(42)
+        values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + np.random.normal(0, 0.5) for i in range(n)]
+        y = pl.DataFrame({"time": dates, "value": values})
+        X = pl.DataFrame({"time": dates, "feature_a": [float(i % 7) for i in range(n)]})
+
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=DistanceSimilarity(metric="euclidean"),
+        )
+        scf.fit(y[:200], X=X[:200], forecasting_horizon=1)
+
+        y_pred = scf.observe_predict(y=y[200:205], X=X[200:])
+        assert isinstance(y_pred, pl.DataFrame)
+        assert len(y_pred) >= 1
+
+    def test_observe_predict_interval_with_similarity(self, conformal_data):
+        """Test observe_predict_interval with similarity produces interval predictions."""
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=1),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=DistanceSimilarity(metric="euclidean"),
+        )
+        scf.fit(conformal_data[:200], forecasting_horizon=1, coverage_rates=[0.9])
+
+        y_test = conformal_data[200:205]
+        y_pred = scf.observe_predict_interval(y=y_test, coverage_rates=[0.9])
+        assert isinstance(y_pred, pl.DataFrame)
+        assert len(y_pred) >= 1
+        assert any("_lower_0.9" in c for c in y_pred.columns)
+        assert any("_upper_0.9" in c for c in y_pred.columns)
+
+    def test_observe_predict_with_explicit_stride(self, conformal_data):
+        """Test observe_predict with an explicit stride parameter."""
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=1),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+        )
+        scf.fit(conformal_data[:200], forecasting_horizon=1)
+
+        y_test = conformal_data[200:205]
+        y_pred = scf.observe_predict(y=y_test, stride=1)
+        assert isinstance(y_pred, pl.DataFrame)
+        assert len(y_pred) >= 1

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -406,33 +406,17 @@ class TestSplitConformalSimilarity:
         assert "value_lower_0.9" in intervals.columns
         assert "value_upper_0.9" in intervals.columns
 
-    def test_predict_interval_unsupported_scorer_fallback(self, conformal_data):
-        """Test that predict_interval falls back to unweighted for unrecognized scorer types."""
+    def test_predict_interval_with_gamma_scorer(self, conformal_data):
+        """Test that predict_interval uses multiplicative tag from GammaResidual."""
+        from yohou.metrics import GammaResidual
+
         scf = SplitConformalForecaster(
             point_forecaster=SeasonalNaive(seasonality=1),
             calibration_size=50,
-            conformity_scorer=AbsoluteResidual(),
+            conformity_scorer=GammaResidual(),
             similarity=DistanceSimilarity(metric="euclidean"),
         )
         scf.fit(conformal_data[:200], forecasting_horizon=1, coverage_rates=[0.9])
-
-        # Replace the fitted scorer with a wrapper that is not one of the 4 recognized types
-        original_scorer = scf.conformity_scorers_["step_1"]
-
-        class _WrappedScorer:
-            """Scorer wrapper that delegates inverse_score but is not a recognized type."""
-
-            def __init__(self, inner):
-                self._inner = inner
-
-            def inverse_score(self, y_pred, conformity_scores, coverage_rate):
-                return self._inner.inverse_score(
-                    y_pred=y_pred,
-                    conformity_scores=conformity_scores,
-                    coverage_rate=coverage_rate,
-                )
-
-        scf.conformity_scorers_["step_1"] = _WrappedScorer(original_scorer)
 
         y_pred = scf.predict_interval(coverage_rates=[0.9])
         assert isinstance(y_pred, pl.DataFrame)

--- a/tests/interval/test_utils.py
+++ b/tests/interval/test_utils.py
@@ -82,3 +82,10 @@ class TestWeightedQuantile:
         result = weighted_quantile(x, q=0.5, weights=weights)
         assert isinstance(result, float)
         assert np.isfinite(result)
+
+    def test_shape_mismatch_raises(self):
+        """Test that mismatched x and weights lengths raise ValueError."""
+        x = np.array([1.0, 2.0, 3.0])
+        weights = np.array([0.5, 0.5])
+        with pytest.raises(ValueError, match="same length"):
+            weighted_quantile(x, q=0.5, weights=weights)

--- a/tests/metrics/test_conformity.py
+++ b/tests/metrics/test_conformity.py
@@ -169,3 +169,35 @@ class TestInverseScore:
         assert lower > -float("inf")
         assert upper < float("inf")
         assert lower <= upper
+
+
+class TestConformityScorerTags:
+    """Test that conformity scorer tags correctly declare symmetric and multiplicative."""
+
+    def test_residual_tags(self):
+        """Residual is asymmetric and additive."""
+        tags = Residual().__sklearn_tags__()
+        assert tags.scorer_tags is not None
+        assert tags.scorer_tags.symmetric is False
+        assert tags.scorer_tags.multiplicative is False
+
+    def test_absolute_residual_tags(self):
+        """AbsoluteResidual is symmetric and additive."""
+        tags = AbsoluteResidual().__sklearn_tags__()
+        assert tags.scorer_tags is not None
+        assert tags.scorer_tags.symmetric is True
+        assert tags.scorer_tags.multiplicative is False
+
+    def test_gamma_residual_tags(self):
+        """GammaResidual is asymmetric and multiplicative."""
+        tags = ConcreteGammaResidual().__sklearn_tags__()
+        assert tags.scorer_tags is not None
+        assert tags.scorer_tags.symmetric is False
+        assert tags.scorer_tags.multiplicative is True
+
+    def test_absolute_gamma_residual_tags(self):
+        """AbsoluteGammaResidual is symmetric and multiplicative."""
+        tags = AbsoluteGammaResidual().__sklearn_tags__()
+        assert tags.scorer_tags is not None
+        assert tags.scorer_tags.symmetric is True
+        assert tags.scorer_tags.multiplicative is True

--- a/tests/utils/test_discovery.py
+++ b/tests/utils/test_discovery.py
@@ -18,7 +18,7 @@ class TestAllEstimators:
     def test_all_estimators_total_count(self):
         """Test all_estimators returns correct total count."""
         estimators = all_estimators()
-        assert len(estimators) == 84
+        assert len(estimators) == 86
 
     def test_all_estimators_forecaster_filter(self):
         """Test forecaster type filter (matches estimator_type == 'forecaster')."""

--- a/tests/utils/test_tags.py
+++ b/tests/utils/test_tags.py
@@ -140,6 +140,8 @@ class TestTagDefaults:
         assert t.prediction_type is None
         assert t.lower_is_better is True
         assert t.requires_calibration is False
+        assert t.symmetric is False
+        assert t.multiplicative is False
 
     def test_similarity_tags_defaults(self):
         """SimilarityTags defaults are correct."""


### PR DESCRIPTION
## Description

Add TemporalSimilarity, CompositeSimilarity, and harden the DistanceSimilarity API for weighted conformal prediction intervals.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

DistanceSimilarity silently dropped null rows via `drop_nulls()`, creating a latent mismatch between similarity weights and conformity scores. The `n_discarded_indices_` property was always 0 due to a bug. Additionally, there was no way to combine multiple similarity measures or use temporal (seasonal) similarity.

## Checklist

- [x] My code follows the code style of this project
- [ ] I have run `just fix` to format my code
- [ ] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

**BREAKING CHANGE**: `DistanceSimilarity.n_discarded_indices_` and `BaseSimilarity.discarded_time_stamps` are removed.