### PR TITLE
chore: remove unused uv workspace config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,9 +80,6 @@ Documentation = "https://yohou.readthedocs.io"
 Repository = "https://github.com/stateful-y/yohou"
 "Bug Tracker" = "https://github.com/stateful-y/yohou/issues"
 
-[tool.uv.workspace]
-members = ["packages/*"]
-
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Description

Remove the unused `[tool.uv.workspace]` section from `pyproject.toml`. This project has no `packages/` directory, so the workspace members configuration is unnecessary.

## Type of Change

- [x] Refactoring (no functional changes)

## Motivation and Context

The `[tool.uv.workspace]` section referenced `packages/*` but no such directory exists in the repository. Removing it eliminates a misleading configuration entry.

## Checklist

- [x] My code follows the code style of this project
- [x] My changes generate no new warnings

## Additional Notes

Configuration only change, no code affected.