### PR TITLE
feat: add `nan_handling` parameter to reduction forecasters

### DIFF
--- a/docs/pages/explanation/reduction-forecasting.md
+++ b/docs/pages/explanation/reduction-forecasting.md
@@ -267,6 +267,41 @@ sum equals the number of samples. The combined weight vector is passed to the
 estimator as `sample_weight` during fitting, so the estimator must support that
 parameter (most sklearn regressors do).
 
+## NaN Handling
+
+After tabularization, the training matrix may contain NaN values. These can originate
+from several sources:
+
+1. **Target lags**: if `y` contains NaN at position $t$, the lag feature
+   `value_lag_k` will carry that NaN into every row whose window includes $t$.
+2. **X_future step columns**: if `X_future` has a gap at time $t$, the step column
+   `feature_step_h` will be NaN for any row whose horizon lands on $t$.
+3. **X_forecast step columns**: similarly, missing vintages in `X_forecast` propagate
+   as NaN into the pivoted step columns.
+4. **Target columns (y_tab)**: if `y` itself has NaN at the positions that become
+   the supervised target after tabularization.
+
+The `nan_handling` parameter on
+[`PointReductionForecaster`](/pages/api/generated/yohou.point.reduction.PointReductionForecaster/)
+(and all other reduction forecasters) controls what happens next:
+
+| Value | Behavior |
+|-------|----------|
+| `"pass"` (default) | NaN values are left in place. The estimator receives them as-is. Tree-based models (LightGBM, XGBoost, CatBoost, HistGradientBoosting) handle NaN natively, so this is the zero-effort path for those estimators. |
+| `"drop"` | Any tabularized row where X or y contains at least one NaN is removed before fitting. A warning is emitted with the count and percentage of dropped rows. `sample_weight` is filtered in lockstep. |
+
+For the **direct** strategy, NaN filtering happens per step: step 1's estimator may
+retain rows that step 3's estimator drops (because step 3's features reference
+different future positions). This maximizes the training data available to each
+individual model.
+
+For the **multi-output** and **dir-rec** strategies, a single unified mask is applied
+across all steps, since all steps share one model (multi-output) or the same initial
+feature matrix (dir-rec).
+
+If `nan_handling="drop"` removes all rows, a `ValueError` is raised indicating that
+no training samples remain.
+
 ## References
 
 - Bontempi, G., Ben Taieb, S., & Le Borgne, Y.-A. (2013). Machine learning strategies

--- a/docs/pages/how-to/handle-missing-data.md
+++ b/docs/pages/how-to/handle-missing-data.md
@@ -134,6 +134,49 @@ def clamp_and_fill(df: pl.DataFrame) -> pl.DataFrame:
 imputer = FunctionTransformer(func=clamp_and_fill)
 ```
 
+## Skip NaN Instances During Training
+
+When your estimator cannot handle NaN natively (e.g. `LinearRegression`,
+`Ridge`, `SVR`), you can skip the imputation step entirely and let the
+reduction forecaster drop any training row that contains NaN:
+
+```python
+from sklearn.linear_model import Ridge
+from yohou.point import PointReductionForecaster
+
+forecaster = PointReductionForecaster(
+    estimator=Ridge(),
+    nan_handling="drop",
+)
+forecaster.fit(y=y_with_gaps, forecasting_horizon=3)
+```
+
+The forecaster emits a warning reporting how many rows were removed.
+If the gaps are sparse, this is often simpler than building an imputation
+pipeline and avoids introducing imputation artifacts into the training signal.
+
+For tree-based estimators that handle NaN natively (LightGBM, XGBoost,
+CatBoost, `HistGradientBoostingRegressor`), keep the default
+`nan_handling="pass"` and let the estimator learn split decisions around
+missing values directly:
+
+```python
+from sklearn.ensemble import HistGradientBoostingRegressor
+from yohou.point import PointReductionForecaster
+
+forecaster = PointReductionForecaster(
+    estimator=HistGradientBoostingRegressor(),
+    nan_handling="pass",  # default, tree handles NaN internally
+)
+forecaster.fit(y=y_with_gaps, forecasting_horizon=3)
+```
+
+!!! tip
+    Use `nan_handling="drop"` as a quick baseline when gaps are rare.
+    Switch to a proper imputation transformer (see sections above) when
+    you need to preserve every training sample or when the gap pattern
+    is systematic.
+
 ## See Also
 
 - [Handle Outliers](handle-outliers.md) for detecting and treating anomalous values

--- a/examples/data-features/advanced_imputation.py
+++ b/examples/data-features/advanced_imputation.py
@@ -361,9 +361,6 @@ def _(mo):
         Instead of imputing, you can let the reduction forecaster drop any
         tabularized training row that contains NaN. This is useful when gaps
         are sparse and you want to avoid imputation artifacts.
-
-        Tree-based estimators handle NaN natively (`nan_handling="pass"`),
-        while linear models need the rows removed (`nan_handling="drop"`).
         """
     )
     return
@@ -376,10 +373,11 @@ def _(tourism_missing):
 
     from yohou.point import PointReductionForecaster
 
-    # Tree-based: pass NaN through (default behavior)
+    # Tree-based: drop NaN rows before fitting
     tree_forecaster = PointReductionForecaster(
         estimator=HistGradientBoostingRegressor(),
-        nan_handling="pass",
+        nan_handling="drop",
+        reduction_strategy="direct",
     )
     tree_forecaster.fit(y=tourism_missing, forecasting_horizon=3)
     tree_pred = tree_forecaster.predict(forecasting_horizon=3)
@@ -388,6 +386,7 @@ def _(tourism_missing):
     linear_forecaster = PointReductionForecaster(
         estimator=Ridge(),
         nan_handling="drop",
+        reduction_strategy="direct",
     )
     linear_forecaster.fit(y=tourism_missing, forecasting_horizon=3)
     linear_pred = linear_forecaster.predict(forecasting_horizon=3)
@@ -396,9 +395,7 @@ def _(tourism_missing):
 
 
 @app.cell
-def _(linear_pred, tree_pred):
-    import polars as pl
-
+def _(linear_pred, pl, tree_pred):
     comparison = pl.DataFrame({
         "time": tree_pred["time"],
         "tree_prediction": tree_pred["tourists"],

--- a/examples/data-features/advanced_imputation.py
+++ b/examples/data-features/advanced_imputation.py
@@ -356,6 +356,62 @@ def _(
 def _(mo):
     mo.md(
         r"""
+        ## Alternative: Skip NaN Rows with `nan_handling`
+
+        Instead of imputing, you can let the reduction forecaster drop any
+        tabularized training row that contains NaN. This is useful when gaps
+        are sparse and you want to avoid imputation artifacts.
+
+        Tree-based estimators handle NaN natively (`nan_handling="pass"`),
+        while linear models need the rows removed (`nan_handling="drop"`).
+        """
+    )
+    return
+
+
+@app.cell
+def _(tourism_missing):
+    from sklearn.ensemble import HistGradientBoostingRegressor
+    from sklearn.linear_model import Ridge
+
+    from yohou.point import PointReductionForecaster
+
+    # Tree-based: pass NaN through (default behavior)
+    tree_forecaster = PointReductionForecaster(
+        estimator=HistGradientBoostingRegressor(),
+        nan_handling="pass",
+    )
+    tree_forecaster.fit(y=tourism_missing, forecasting_horizon=3)
+    tree_pred = tree_forecaster.predict(forecasting_horizon=3)
+
+    # Linear: drop NaN rows before fitting
+    linear_forecaster = PointReductionForecaster(
+        estimator=Ridge(),
+        nan_handling="drop",
+    )
+    linear_forecaster.fit(y=tourism_missing, forecasting_horizon=3)
+    linear_pred = linear_forecaster.predict(forecasting_horizon=3)
+
+    return linear_pred, tree_pred
+
+
+@app.cell
+def _(linear_pred, tree_pred):
+    import polars as pl
+
+    comparison = pl.DataFrame({
+        "time": tree_pred["time"],
+        "tree_prediction": tree_pred["tourists"],
+        "linear_prediction": linear_pred["tourists"],
+    })
+    comparison
+    return (comparison,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
         ## Next Steps
 
         - [Handle Missing Data](/pages/how-to/handle-missing-data/) for the full guide

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,9 +81,6 @@ Documentation = "https://yohou.readthedocs.io"
 Repository = "https://github.com/stateful-y/yohou"
 "Bug Tracker" = "https://github.com/stateful-y/yohou/issues"
 
-[tool.uv.workspace]
-members = ["packages/*"]
-
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/src/yohou/base/forecaster.py
+++ b/src/yohou/base/forecaster.py
@@ -785,7 +785,7 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
                             updated = group_df.drop(cols_to_drop)  # ty: ignore[unresolved-attribute]
                             self._X_t_observed[group_name] = pl.concat([updated, new_group_step], how="horizontal")  # ty: ignore[invalid-assignment]
                         else:
-                            self._X_t_observed[group_name] = pl.concat([group_df, new_group_step], how="horizontal")  # ty: ignore[invalid-assignment,unresolved-attribute]
+                            self._X_t_observed[group_name] = pl.concat([group_df, new_group_step], how="horizontal")  # ty: ignore[invalid-assignment]
                 else:
                     new_step_only = X_step_new.select(~cs.by_name("time"))
                     cols_to_drop = [c for c in local_step_cols if c in self._X_t_observed.columns]  # ty: ignore[unresolved-attribute]

--- a/src/yohou/base/reduction.py
+++ b/src/yohou/base/reduction.py
@@ -3,6 +3,7 @@
 import abc
 import inspect
 import numbers
+import warnings
 from collections.abc import Callable
 from typing import Any, Literal
 from typing import cast as typing_cast
@@ -56,6 +57,13 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
           columns. Cleanest signal, no cross-horizon leakage.
         - ``"cumulative"``: estimator for step h receives columns
           ``*_step_1..h``. All information up to horizon h.
+    nan_handling : {"drop", "pass"}, default="pass"
+        How to handle NaN values in the tabularized training data.
+        ``"pass"`` leaves NaN in place (suitable for estimators that
+        handle NaN natively, such as tree-based models). ``"drop"``
+        removes any training instance where X or y contains NaN before
+        fitting the estimator, and emits a warning with the count of
+        dropped rows.
     n_jobs : int or None, default=None
         Number of jobs to run in parallel for the ``"direct"`` strategy
         (fitting and predicting H independent models). ``None`` means 1
@@ -98,6 +106,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         "estimator": [HasMethods(["fit", "predict"])],
         "reduction_strategy": [StrOptions({"direct", "dir-rec", "multi-output"})],
         "step_feature_alignment": [StrOptions({"all", "matched", "cumulative"})],
+        "nan_handling": [StrOptions({"drop", "pass"})],
         "n_jobs": [Interval(numbers.Integral, -1, None, closed="left"), None],
     }
 
@@ -110,6 +119,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         feature_transformer: BaseTransformer | None = None,
         panel_strategy: Literal["global", "multivariate"] = "global",
         step_feature_alignment: Literal["all", "matched", "cumulative"] = "all",
+        nan_handling: Literal["drop", "pass"] = "pass",
         n_jobs: int | None = None,
     ):
         BaseForecaster.__init__(
@@ -123,6 +133,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         self.estimator = estimator
         self.reduction_strategy = reduction_strategy
         self.step_feature_alignment = step_feature_alignment
+        self.nan_handling = nan_handling
         self.n_jobs = n_jobs
 
     def __sklearn_tags__(self) -> Tags:
@@ -564,6 +575,90 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             vintage_weight=vintage_weight,
         )
 
+    def _apply_nan_handling(
+        self,
+        X_tab: pl.DataFrame,
+        y_tab: pl.DataFrame | pl.Series,
+        sample_weight: np.ndarray | None,
+        *,
+        context: str = "",
+    ) -> tuple[pl.DataFrame, pl.DataFrame | pl.Series, np.ndarray | None]:
+        """Remove rows containing NaN/null from tabularized training data.
+
+        When ``nan_handling="drop"``, removes any row where X_tab or y_tab
+        contains at least one null value. Filters sample_weight in lockstep.
+        Emits a warning reporting the number of dropped rows.
+
+        When ``nan_handling="pass"``, returns inputs unchanged.
+
+        Parameters
+        ----------
+        X_tab : pl.DataFrame
+            Feature matrix.
+        y_tab : pl.DataFrame or pl.Series
+            Target matrix or series.
+        sample_weight : np.ndarray or None
+            Sample weights (filtered in lockstep if rows are dropped).
+        context : str, default=""
+            Additional context for the warning message (e.g., " (step 3)").
+
+        Returns
+        -------
+        X_tab : pl.DataFrame
+            Filtered feature matrix.
+        y_tab : pl.DataFrame or pl.Series
+            Filtered target.
+        sample_weight : np.ndarray or None
+            Filtered sample weights.
+
+        """
+        if self.nan_handling == "pass":
+            return X_tab, y_tab, sample_weight
+
+        # For null: check all columns. For NaN: only float columns.
+        null_free = X_tab.select(pl.all_horizontal(pl.all().is_not_null())).to_series()
+        float_cols = X_tab.select(cs.float())
+        if float_cols.width > 0:
+            nan_free = float_cols.select(pl.all_horizontal(pl.all().is_not_nan())).to_series()
+            x_ok = null_free & nan_free
+        else:
+            x_ok = null_free
+
+        if isinstance(y_tab, pl.Series):
+            y_ok = y_tab.is_not_null()
+            if y_tab.dtype.is_float():
+                y_ok = y_ok & y_tab.is_not_nan()
+        else:
+            y_null_free = y_tab.select(pl.all_horizontal(pl.all().is_not_null())).to_series()
+            y_float_cols = y_tab.select(cs.float())
+            if y_float_cols.width > 0:
+                y_nan_free = y_float_cols.select(pl.all_horizontal(pl.all().is_not_nan())).to_series()
+                y_ok = y_null_free & y_nan_free
+            else:
+                y_ok = y_null_free
+
+        mask = x_ok & y_ok
+        n_total = len(mask)
+        n_dropped = n_total - mask.sum()
+
+        if n_dropped > 0:
+            if n_dropped == n_total:
+                raise ValueError(
+                    f"All {n_total} training instances contain NaN{context}. "
+                    f"Cannot fit with nan_handling='drop' and 0 samples remaining."
+                )
+            pct = 100 * n_dropped / n_total
+            warnings.warn(
+                f"NaN handling dropped {n_dropped} of {n_total} training instances ({pct:.1f}%){context}.",
+                stacklevel=3,
+            )
+            X_tab = X_tab.filter(mask)
+            y_tab = y_tab.filter(mask)
+            if sample_weight is not None:
+                sample_weight = sample_weight[mask.to_numpy()]
+
+        return X_tab, y_tab, sample_weight
+
     def _fit_single_estimator(
         self,
         X_tab: pl.DataFrame,
@@ -665,6 +760,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             forecasting_horizon,
             vintage_weight=vintage_weight,
         )
+        X_tab, y_tab, sample_weight = self._apply_nan_handling(X_tab, y_tab, sample_weight)
         return self._fit_single_estimator(
             X_tab,
             y_tab,
@@ -788,10 +884,13 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             if y_step.shape[1] == 1:
                 y_step = y_step.to_series()
             X_tab_step = self._filter_step_features(X_tab, step + 1)
+            X_tab_step, y_step, sw_step = self._apply_nan_handling(
+                X_tab_step, y_step, sample_weight, context=f" (step {step + 1})"
+            )
             return self._fit_single_estimator(
                 X_tab_step,
                 y_step,
-                sample_weight,
+                sw_step,
                 estimator_params,
                 estimator_fit_params,
             )
@@ -857,6 +956,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             forecasting_horizon,
             vintage_weight=vintage_weight,
         )
+        X_tab, y_tab, sample_weight = self._apply_nan_handling(X_tab, y_tab, sample_weight)
 
         self._dir_rec_n_original_features_ = X_tab.shape[1]
 

--- a/src/yohou/base/reduction.py
+++ b/src/yohou/base/reduction.py
@@ -957,6 +957,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             vintage_weight=vintage_weight,
         )
         X_tab, y_tab, sample_weight = self._apply_nan_handling(X_tab, y_tab, sample_weight)
+        assert isinstance(y_tab, pl.DataFrame)
 
         self._dir_rec_n_original_features_ = X_tab.shape[1]
 

--- a/src/yohou/class_proba/reduction.py
+++ b/src/yohou/class_proba/reduction.py
@@ -48,6 +48,13 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         - ``"all"``: every estimator receives all step columns.
         - ``"matched"``: estimator for step h receives only ``*_step_h``.
         - ``"cumulative"``: estimator for step h receives ``*_step_1..h``.
+    nan_handling : {"drop", "pass"}, default="pass"
+        How to handle NaN values in the tabularized training data.
+        ``"pass"`` leaves NaN in place (suitable for estimators that
+        handle NaN natively, such as tree-based models). ``"drop"``
+        removes any training instance where X or y contains NaN before
+        fitting the estimator, and emits a warning with the count of
+        dropped rows.
     panel_strategy : {"global", "multivariate"}, default="global"
         How to handle panel data. See `BaseForecaster` for details.
     n_jobs : int or None, default=None
@@ -123,6 +130,7 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         feature_transformer: BaseTransformer | None = None,
         target_as_feature: Literal["transformed", "raw"] | None = "transformed",
         step_feature_alignment: Literal["all", "matched", "cumulative"] = "all",
+        nan_handling: Literal["drop", "pass"] = "pass",
         n_jobs: int | None = None,
         panel_strategy: Literal["global", "multivariate"] = "global",
     ) -> None:
@@ -132,6 +140,7 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
             reduction_strategy=reduction_strategy,
             target_as_feature=target_as_feature,
             step_feature_alignment=step_feature_alignment,
+            nan_handling=nan_handling,
             n_jobs=n_jobs,
             panel_strategy=panel_strategy,
         )

--- a/src/yohou/compose/column_forecaster.py
+++ b/src/yohou/compose/column_forecaster.py
@@ -783,7 +783,7 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
             X_forecast=X_forecast,
             groups=groups,
             stride=stride,
-            observe_fn=self.observe,  # ty: ignore[invalid-argument-type]
+            observe_fn=self.observe,
             forecasting_horizon=fh,
             predict_transformed=predict_transformed,
             **params,
@@ -945,7 +945,7 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
             X_forecast=X_forecast,
             groups=groups,
             stride=stride,
-            observe_fn=self.observe,  # ty: ignore[invalid-argument-type]
+            observe_fn=self.observe,
             forecasting_horizon=fh,
             coverage_rates=coverage_rates,
             predict_transformed=predict_transformed,
@@ -1081,7 +1081,7 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
             X_forecast=X_forecast,
             groups=groups,
             stride=stride,
-            observe_fn=self.observe,  # ty: ignore[invalid-argument-type]
+            observe_fn=self.observe,
             forecasting_horizon=fh,
             **params,
         )

--- a/src/yohou/interval/reduction.py
+++ b/src/yohou/interval/reduction.py
@@ -38,6 +38,13 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
         Transformer used to transform the feature time series into features.
     panel_strategy : {"global", "multivariate"}, default="global"
         How to handle panel data. See `BaseForecaster` for details.
+    nan_handling : {"drop", "pass"}, default="pass"
+        How to handle NaN values in the tabularized training data.
+        ``"pass"`` leaves NaN in place (suitable for estimators that
+        handle NaN natively, such as tree-based models). ``"drop"``
+        removes any training instance where X or y contains NaN before
+        fitting the estimator, and emits a warning with the count of
+        dropped rows.
     n_jobs : int or None, default=None
         Number of jobs to run in parallel for the ``"direct"`` strategy
         (fitting and predicting H independent models). ``None`` means 1
@@ -143,6 +150,7 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
         target_as_feature: Literal["transformed", "raw"] | None = "transformed",
         feature_transformer: BaseTransformer | None = None,
         step_feature_alignment: Literal["all", "matched", "cumulative"] = "all",
+        nan_handling: Literal["drop", "pass"] = "pass",
         n_jobs: int | None = None,
         panel_strategy: Literal["global", "multivariate"] = "global",
     ):
@@ -153,6 +161,7 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
             target_as_feature=target_as_feature,
             feature_transformer=feature_transformer,
             step_feature_alignment=step_feature_alignment,
+            nan_handling=nan_handling,
             n_jobs=n_jobs,
             panel_strategy=panel_strategy,
         )

--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -616,7 +616,7 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             X_forecast=X_forecast,
             groups=groups,
             stride=stride,
-            observe_fn=self.observe,  # ty: ignore[invalid-argument-type]
+            observe_fn=self.observe,
             forecasting_horizon=forecasting_horizon,
             predict_transformed=predict_transformed,
             **params,

--- a/src/yohou/metrics/base.py
+++ b/src/yohou/metrics/base.py
@@ -669,7 +669,7 @@ class BaseScorer(BaseEstimator, metaclass=abc.ABCMeta):
         if isinstance(vw_resolved, dict) and context.vintage_time is not None:
             # Panel-aware vintage_weight: all groups share the same vintage_time
             # axis, so use the first group's weights for cross-vintage weighting.
-            first_group_weights = next(iter(vw_resolved.values()))  # ty: ignore[invalid-assignment]
+            first_group_weights = next(iter(vw_resolved.values()))
             context = self._set_vintage_weight_on_context(context, first_group_weights)  # ty: ignore[invalid-argument-type]
             vw_resolved = None
         elif isinstance(vw_resolved, np.ndarray) and context.vintage_time is not None:

--- a/src/yohou/plotting/_utils.py
+++ b/src/yohou/plotting/_utils.py
@@ -18,8 +18,8 @@ except ImportError as e:
     raise ImportError(msg) from e
 
 if TYPE_CHECKING:
-    from plotly_resampler.aggregation.aggregation_interface import AbstractAggregator  # ty: ignore[unresolved-import]
-    from plotly_resampler.aggregation.gap_handler_interface import AbstractGapHandler  # ty: ignore[unresolved-import]
+    from plotly_resampler.aggregation.aggregation_interface import AbstractAggregator
+    from plotly_resampler.aggregation.gap_handler_interface import AbstractGapHandler
 
 from yohou.utils import inspect_panel
 
@@ -336,7 +336,7 @@ def _create_figure(
     mode = _get_resampler_mode(resampler)
     if mode == "widget":  # pragma: no cover
         try:
-            from plotly_resampler import FigureWidgetResampler  # noqa: PLC0415  # ty: ignore[unresolved-import]
+            from plotly_resampler import FigureWidgetResampler  # noqa: PLC0415
         except ImportError as e:
             msg = "plotly-resampler is required for resampler mode. Install: pip install plotly-resampler"
             raise ImportError(msg) from e
@@ -346,7 +346,7 @@ def _create_figure(
         )
     if mode:  # pragma: no cover
         try:
-            from plotly_resampler import FigureResampler  # noqa: PLC0415  # ty: ignore[unresolved-import]
+            from plotly_resampler import FigureResampler  # noqa: PLC0415
         except ImportError as e:
             msg = "plotly-resampler is required for resampler mode. Install: pip install plotly-resampler"
             raise ImportError(msg) from e
@@ -379,7 +379,7 @@ def _create_subplots(
     mode = _get_resampler_mode(resampler)
     if mode == "widget":  # pragma: no cover
         try:
-            from plotly_resampler import FigureWidgetResampler  # noqa: PLC0415  # ty: ignore[unresolved-import]
+            from plotly_resampler import FigureWidgetResampler  # noqa: PLC0415
         except ImportError as e:
             msg = "plotly-resampler is required for resampler mode. Install: pip install plotly-resampler"
             raise ImportError(msg) from e
@@ -389,7 +389,7 @@ def _create_subplots(
         )
     if mode:  # pragma: no cover
         try:
-            from plotly_resampler import FigureResampler  # noqa: PLC0415  # ty: ignore[unresolved-import]
+            from plotly_resampler import FigureResampler  # noqa: PLC0415
         except ImportError as e:
             msg = "plotly-resampler is required for resampler mode. Install: pip install plotly-resampler"
             raise ImportError(msg) from e
@@ -410,10 +410,10 @@ def _fill_trace_kwargs(fig: go.Figure) -> dict:
     Returns an empty dict for plain figures.
     """
     try:
-        from plotly_resampler.aggregation.gap_handlers import (  # noqa: PLC0415  # ty: ignore[unresolved-import]
+        from plotly_resampler.aggregation.gap_handlers import (  # noqa: PLC0415
             NoGapHandler,
         )
-        from plotly_resampler.figure_resampler.figure_resampler_interface import (  # noqa: PLC0415  # ty: ignore[unresolved-import]
+        from plotly_resampler.figure_resampler.figure_resampler_interface import (  # noqa: PLC0415
             AbstractFigureAggregator,
         )
     except ImportError:

--- a/src/yohou/plotting/forecasting.py
+++ b/src/yohou/plotting/forecasting.py
@@ -1529,7 +1529,7 @@ def _plot_forecast_panel_typed(
             test_m = _extract_member_df(y_test, suffix)
             train_m = _extract_member_df(y_train, suffix) if y_train is not None else None
             for pred_df in model_preds.values():
-                pred_m = _extract_member_df(pred_df, suffix)  # ty: ignore[invalid-argument-type]
+                pred_m = _extract_member_df(pred_df, suffix)
                 for cc in pred_m.columns:
                     if cc in ("time", "vintage_time"):
                         continue
@@ -1558,7 +1558,7 @@ def _plot_forecast_panel_typed(
 
         if prediction_mode == "class_proba":
             for model_idx, (model_name, pred_df) in enumerate(model_preds.items()):
-                pred_member = _extract_member_df(pred_df, suffix)  # ty: ignore[invalid-argument-type]
+                pred_member = _extract_member_df(pred_df, suffix)
                 proba_cols = [c for c in pred_member.columns if "_proba_" in c]
                 if not proba_cols:
                     continue
@@ -1588,7 +1588,7 @@ def _plot_forecast_panel_typed(
 
         elif prediction_mode == "categorical":
             first_pred_member = _extract_member_df(
-                next(iter(model_preds.values())),  # ty: ignore[invalid-argument-type]
+                next(iter(model_preds.values())),
                 suffix,
             )
             cat_cols = [
@@ -1598,7 +1598,7 @@ def _plot_forecast_panel_typed(
             ]
 
             for model_idx, (model_name, pred_df) in enumerate(model_preds.items()):
-                pred_member = _extract_member_df(pred_df, suffix)  # ty: ignore[invalid-argument-type]
+                pred_member = _extract_member_df(pred_df, suffix)
                 _render_categorical_traces(
                     fig,
                     pred_member,

--- a/src/yohou/point/reduction.py
+++ b/src/yohou/point/reduction.py
@@ -38,6 +38,13 @@ class PointReductionForecaster(BaseReductionForecaster, BasePointForecaster):
         a feature.
     panel_strategy : {"global", "multivariate"}, default="global"
         How to handle panel data. See `BaseForecaster` for details.
+    nan_handling : {"drop", "pass"}, default="pass"
+        How to handle NaN values in the tabularized training data.
+        ``"pass"`` leaves NaN in place (suitable for estimators that
+        handle NaN natively, such as tree-based models). ``"drop"``
+        removes any training instance where X or y contains NaN before
+        fitting the estimator, and emits a warning with the count of
+        dropped rows.
     n_jobs : int or None, default=None
         Number of jobs to run in parallel for the ``"direct"`` strategy
         (fitting and predicting H independent models). ``None`` means 1
@@ -128,6 +135,7 @@ class PointReductionForecaster(BaseReductionForecaster, BasePointForecaster):
         feature_transformer: BaseTransformer | None = None,
         target_as_feature: Literal["transformed", "raw"] | None = "transformed",
         step_feature_alignment: Literal["all", "matched", "cumulative"] = "all",
+        nan_handling: Literal["drop", "pass"] = "pass",
         n_jobs: int | None = None,
         panel_strategy: Literal["global", "multivariate"] = "global",
     ) -> None:
@@ -137,6 +145,7 @@ class PointReductionForecaster(BaseReductionForecaster, BasePointForecaster):
             reduction_strategy=reduction_strategy,
             target_as_feature=target_as_feature,
             step_feature_alignment=step_feature_alignment,
+            nan_handling=nan_handling,
             n_jobs=n_jobs,
             panel_strategy=panel_strategy,
         )

--- a/tests/base/test_reduction_nan_handling.py
+++ b/tests/base/test_reduction_nan_handling.py
@@ -303,6 +303,52 @@ class TestNanHandlingDrop:
         assert not _has_nan(forecaster.estimator_.y_fit_)
 
 
+class TestNanHandlingEdgeBranches:
+    """Cover edge branches in _apply_nan_handling for non-float data."""
+
+    def test_x_tab_no_float_columns(self):
+        """X_tab with only integer columns uses null-only mask (no NaN check)."""
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        X_tab = pl.DataFrame({"a": [1, 2, None, 4], "b": [10, 20, 30, 40]})
+        y_tab = pl.Series("value", [1.0, 2.0, 3.0, 4.0])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            X_out, y_out, _ = forecaster._apply_nan_handling(X_tab, y_tab, None)
+        assert X_out.shape[0] == 3
+        assert len(y_out) == 3
+
+    def test_y_series_non_float_dtype(self):
+        """y_tab as integer Series skips is_not_nan check."""
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        X_tab = pl.DataFrame({"a": [1.0, 2.0, 3.0, 4.0]})
+        y_tab = pl.Series("value", [10, None, 30, 40])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            X_out, y_out, _ = forecaster._apply_nan_handling(X_tab, y_tab, None)
+        assert X_out.shape[0] == 3
+        assert len(y_out) == 3
+
+    def test_y_dataframe_no_float_columns(self):
+        """y_tab as DataFrame with only integer columns uses null-only mask."""
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        X_tab = pl.DataFrame({"a": [1.0, 2.0, 3.0, 4.0]})
+        y_tab = pl.DataFrame({"t1": [10, 20, None, 40], "t2": [1, 2, 3, 4]})
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            X_out, y_out, _ = forecaster._apply_nan_handling(X_tab, y_tab, None)
+        assert X_out.shape[0] == 3
+        assert y_out.shape[0] == 3
+
+
 class TestParameterValidation:
     def test_invalid_nan_handling_raises(self):
         """4.12: Invalid nan_handling value raises ValueError."""

--- a/tests/base/test_reduction_nan_handling.py
+++ b/tests/base/test_reduction_nan_handling.py
@@ -1,0 +1,311 @@
+"""Tests for nan_handling parameter on BaseReductionForecaster."""
+
+import warnings
+from datetime import datetime
+
+import numpy as np
+import polars as pl
+import pytest
+from sklearn.base import BaseEstimator
+
+from yohou.point import PointReductionForecaster
+
+
+def _has_nan(data) -> bool:
+    """Check if data (Polars or numpy) contains NaN/null."""
+    if isinstance(data, pl.DataFrame):
+        # Check nulls
+        if any(c > 0 for c in data.null_count().row(0)):
+            return True
+        # Check NaN in float columns
+        float_cols = data.select(pl.col(pl.Float32, pl.Float64))
+        if float_cols.width > 0:
+            return float_cols.select(pl.all().is_nan().any()).row(0) != tuple(False for _ in range(float_cols.width))
+        return False
+    elif isinstance(data, pl.Series):
+        if data.null_count() > 0:
+            return True
+        if data.dtype.is_float():
+            return data.is_nan().any()
+        return False
+    else:
+        arr = np.asarray(data, dtype=float)
+        return bool(np.any(np.isnan(arr)))
+
+
+def _nrows(data) -> int:
+    if hasattr(data, "shape"):
+        return data.shape[0]
+    return len(data)
+
+
+def _make_y(length: int = 30) -> pl.DataFrame:
+    return pl.DataFrame({
+        "time": pl.datetime_range(
+            start=datetime(2021, 1, 1),
+            end=datetime(2021, 1, 1, 0, 0, length - 1),
+            interval="1s",
+            eager=True,
+        ),
+        "value": [float(i) for i in range(length)],
+    })
+
+
+def _make_y_with_nan(length: int = 30, nan_positions: list[int] | None = None) -> pl.DataFrame:
+    values = [float(i) for i in range(length)]
+    if nan_positions:
+        for pos in nan_positions:
+            values[pos] = float("nan")
+    return pl.DataFrame({
+        "time": pl.datetime_range(
+            start=datetime(2021, 1, 1),
+            end=datetime(2021, 1, 1, 0, 0, length - 1),
+            interval="1s",
+            eager=True,
+        ),
+        "value": values,
+    })
+
+
+class _RecordingEstimator(BaseEstimator):
+    """Estimator that records what it receives for inspection."""
+
+    def __init__(self):
+        pass
+
+    def fit(self, X, y, sample_weight=None, **kwargs):
+        self.X_fit_ = X
+        self.y_fit_ = y
+        if sample_weight is not None:
+            kwargs["sample_weight"] = sample_weight
+        self.fit_kwargs_ = kwargs
+        return self
+
+    def predict(self, X):
+        return np.zeros(_nrows(X))
+
+
+class TestNanHandlingPass:
+    def test_nan_passes_through_to_estimator(self):
+        """4.1: NaN reaches estimator unchanged when nan_handling='pass'."""
+        y = _make_y_with_nan(30, nan_positions=[10])
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="pass",
+        )
+        forecaster.fit(y=y, forecasting_horizon=2)
+        assert _has_nan(forecaster.estimator_.y_fit_), "NaN should pass through"
+
+
+class TestNanHandlingDrop:
+    def test_drop_removes_nan_in_y(self):
+        """4.2: Rows contaminated by NaN in y are removed."""
+        y = _make_y_with_nan(30, nan_positions=[10])
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, forecasting_horizon=2)
+        assert not _has_nan(forecaster.estimator_.y_fit_), "NaN should be removed"
+
+    def test_drop_removes_nan_in_x_actual(self):
+        """4.3: Rows with NaN in X_actual lag columns are removed."""
+        y = _make_y(30)
+        x_values = [float(i) for i in range(30)]
+        x_values[10] = float("nan")
+        X_actual = pl.DataFrame({"time": y["time"], "feature": x_values})
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+            target_as_feature=None,
+            feature_transformer=None,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, X_actual=X_actual, forecasting_horizon=2)
+        assert not _has_nan(forecaster.estimator_.X_fit_), "NaN from X_actual should be removed"
+
+    def test_drop_removes_nan_in_x_future(self):
+        """4.4: Rows with NaN in X_future step columns are removed."""
+        y = _make_y(30)
+        future_length = 35
+        future_values = [float(i) for i in range(future_length)]
+        future_values[15] = float("nan")
+        X_future = pl.DataFrame({
+            "time": pl.datetime_range(
+                start=datetime(2021, 1, 1),
+                end=datetime(2021, 1, 1, 0, 0, future_length - 1),
+                interval="1s",
+                eager=True,
+            ),
+            "holiday": future_values,
+        })
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, X_future=X_future, forecasting_horizon=2)
+        assert not _has_nan(forecaster.estimator_.X_fit_), "NaN from X_future should be removed"
+
+    def test_drop_removes_nan_in_x_forecast(self):
+        """4.5: Rows with NaN in X_forecast step columns are removed."""
+        y = _make_y(30)
+        vintage_times = []
+        target_times = []
+        temp_values = []
+        for i in range(28):
+            t = datetime(2021, 1, 1, 0, 0, i)
+            for step in range(1, 3):
+                vintage_times.append(t)
+                target_times.append(datetime(2021, 1, 1, 0, 0, i + step))
+                if i == 10 and step == 1:
+                    temp_values.append(float("nan"))
+                else:
+                    temp_values.append(float(i + step))
+        X_forecast = pl.DataFrame({
+            "vintage_time": vintage_times,
+            "time": target_times,
+            "temp": temp_values,
+        })
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, X_forecast=X_forecast, forecasting_horizon=2)
+        assert not _has_nan(forecaster.estimator_.X_fit_), "NaN from X_forecast should be removed"
+
+    def test_sample_weight_aligned_after_nan_removal(self):
+        """4.6: sample_weight is filtered in lockstep with dropped rows."""
+        y = _make_y_with_nan(30, nan_positions=[10])
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        time_weight = pl.DataFrame({"time": y["time"], "weight": [1.0] * len(y)})
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, forecasting_horizon=2, time_weight=time_weight)
+
+        est = forecaster.estimator_
+        sw = est.fit_kwargs_.get("sample_weight")
+        assert sw is not None
+        assert len(sw) == _nrows(est.X_fit_)
+
+    def test_warning_emitted_with_count(self):
+        """4.7: Warning includes count and percentage."""
+        y = _make_y_with_nan(30, nan_positions=[10])
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            forecaster.fit(y=y, forecasting_horizon=2)
+
+        nan_warnings = [x for x in w if "NaN handling" in str(x.message)]
+        assert len(nan_warnings) >= 1, "Should emit a NaN handling warning"
+        assert "%" in str(nan_warnings[0].message)
+
+    def test_no_warning_when_clean(self):
+        """4.8: No warning emitted when data is NaN-free."""
+        y = _make_y(30)
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            forecaster.fit(y=y, forecasting_horizon=2)
+
+        nan_warnings = [x for x in w if "NaN handling" in str(x.message)]
+        assert len(nan_warnings) == 0
+
+    def test_direct_per_step_filtering(self):
+        """4.9: Direct strategy fits all steps even when some have NaN."""
+        y = _make_y(40)
+        future_length = 45
+        future_values = [float(i) for i in range(future_length)]
+        future_values[20] = float("nan")
+        X_future = pl.DataFrame({
+            "time": pl.datetime_range(
+                start=datetime(2021, 1, 1),
+                end=datetime(2021, 1, 1, 0, 0, future_length - 1),
+                interval="1s",
+                eager=True,
+            ),
+            "holiday": future_values,
+        })
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+            reduction_strategy="direct",
+            step_feature_alignment="matched",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, X_future=X_future, forecasting_horizon=3)
+        assert len(forecaster.estimator_) == 3
+
+    def test_valueerror_when_all_nan(self):
+        """4.10: ValueError raised when all rows contain NaN."""
+        y = pl.DataFrame({
+            "time": pl.datetime_range(
+                start=datetime(2021, 1, 1),
+                end=datetime(2021, 1, 1, 0, 0, 9),
+                interval="1s",
+                eager=True,
+            ),
+            "value": [float("nan")] * 10,
+        })
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        with pytest.raises((ValueError, Exception)), warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, forecasting_horizon=2)
+
+    def test_panel_data_nan_handling(self):
+        """4.11: NaN in panel data is handled correctly."""
+        length = 20
+        times = pl.datetime_range(
+            start=datetime(2021, 1, 1),
+            end=datetime(2021, 1, 1, 0, 0, length - 1),
+            interval="1s",
+            eager=True,
+        )
+        y = pl.DataFrame({
+            "time": pl.concat([times, times]),
+            "value": [float(i) for i in range(length)] * 2,
+            "group": ["A"] * length + ["B"] * length,
+        })
+        y = y.with_columns(
+            pl
+            .when((pl.col("group") == "A") & (pl.col("value") == 5.0))
+            .then(None)
+            .otherwise(pl.col("value"))
+            .alias("value")
+        )
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+            panel_strategy="global",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, forecasting_horizon=2)
+        assert not _has_nan(forecaster.estimator_.y_fit_)
+
+
+class TestParameterValidation:
+    def test_invalid_nan_handling_raises(self):
+        """4.12: Invalid nan_handling value raises ValueError."""
+        forecaster = PointReductionForecaster(nan_handling="raise")  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            forecaster.fit(y=_make_y(20), forecasting_horizon=2)


### PR DESCRIPTION
## Description

Add a `nan_handling` parameter (`"drop"` | `"pass"`) to `BaseReductionForecaster` and all child classes (`PointReductionForecaster`, `IntervalReductionForecaster`, `ClassProbaReductionForecaster`). When set to `"drop"`, removes tabularized training rows containing NaN/null before fitting the sklearn estimator.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Estimators like `LinearRegression`, `Ridge`, and `SVR` cannot handle NaN in training data. Previously, users had to build imputation pipelines to fill gaps before fitting. This parameter provides a simpler alternative: drop contaminated rows automatically, which is sufficient when gaps are sparse.

Tree-based estimators (LightGBM, XGBoost, CatBoost, HistGradientBoosting) handle NaN natively, so the default `"pass"` preserves backward compatibility.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [ ] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

- `_apply_nan_handling` helper detects both Polars `null` and float `NaN`
- Direct strategy uses per-step masks (maximizes training data per estimator)
- Multi-output and dir-rec use a unified mask
- `sample_weight` filtered in lockstep; `ValueError` raised if all rows dropped
- 12 new tests in `tests/base/test_reduction_nan_handling.py`
- Docs added to explanation page, how-to guide, and example notebook