### PR TITLE
fix: extend See Also numpydoc patch to handle MkDocs link syntax

### DIFF
--- a/src/yohou/__init__.py
+++ b/src/yohou/__init__.py
@@ -21,13 +21,14 @@ set_config(enable_metadata_routing=True)
 # render the HTML repr.  This patch normalizes content lines *before*
 # parsing, leaving the original __doc__ strings (and therefore mkdocs
 # output) untouched.
+_MKDOCS_LINK_RE = re.compile(r"\[`?[^\]]*`?\]\[([A-Za-z_][A-Za-z0-9_.]*)\]")
+_BULLET_PREFIX_RE = re.compile(r"^(\s*)-\s+")
+_BACKTICK_NAME_RE = re.compile(r"`([A-Za-z_][A-Za-z0-9_.]*)`")
+
 try:
     from sklearn.externals._numpydoc.docscrape import NumpyDocString
 
     _original_parse_see_also = NumpyDocString._parse_see_also
-    _MKDOCS_LINK_RE = re.compile(r"\[`?[^\]]*`?\]\[([A-Za-z_][A-Za-z0-9_.]*)\]")
-    _BULLET_PREFIX_RE = re.compile(r"^(\s*)-\s+")
-    _BACKTICK_NAME_RE = re.compile(r"`([A-Za-z_][A-Za-z0-9_.]*)`")
 
     def _parse_see_also_strip_backticks(self, content):  # noqa: ANN001, ANN202
         """Normalize MkDocs links and backticks before delegating to the original parser."""

--- a/src/yohou/__init__.py
+++ b/src/yohou/__init__.py
@@ -12,24 +12,28 @@ __version__ = version(__name__)
 # Enable metadata routing globally for all Yohou estimators
 set_config(enable_metadata_routing=True)
 
-# Patch numpydoc's See Also parser to tolerate backtick-wrapped names.
-# Yohou docstrings use `ClassName` in See Also sections so that
-# mkdocs-autorefs can generate hyperlinks in the rendered docs.  The
-# numpydoc parser bundled with sklearn only accepts bare names or
-# Sphinx :role:`name` syntax, so backtick-only references cause a
-# ValueError when sklearn tries to render the HTML repr.  This patch
-# strips the backticks from the content lines *before* parsing,
-# leaving the original __doc__ strings (and therefore mkdocs output)
-# untouched.
+# Patch numpydoc's See Also parser to tolerate MkDocs link syntax.
+# Yohou docstrings use `[`Name`][qualified.path]` in See Also sections
+# so that mkdocs-autorefs can generate hyperlinks in the rendered docs.
+# The numpydoc parser bundled with sklearn only accepts bare names or
+# Sphinx :role:`name` syntax, so MkDocs links, bullet markers, and
+# backtick-only references cause a ValueError when sklearn tries to
+# render the HTML repr.  This patch normalizes content lines *before*
+# parsing, leaving the original __doc__ strings (and therefore mkdocs
+# output) untouched.
 try:
     from sklearn.externals._numpydoc.docscrape import NumpyDocString
 
     _original_parse_see_also = NumpyDocString._parse_see_also
+    _MKDOCS_LINK_RE = re.compile(r"\[`?[^\]]*`?\]\[([A-Za-z_][A-Za-z0-9_.]*)\]")
+    _BULLET_PREFIX_RE = re.compile(r"^(\s*)-\s+")
     _BACKTICK_NAME_RE = re.compile(r"`([A-Za-z_][A-Za-z0-9_.]*)`")
 
     def _parse_see_also_strip_backticks(self, content):  # noqa: ANN001, ANN202
-        """Strip backtick-wrapped names before delegating to the original parser."""
-        cleaned = [_BACKTICK_NAME_RE.sub(r"\1", line) for line in content]
+        """Normalize MkDocs links and backticks before delegating to the original parser."""
+        cleaned = [_MKDOCS_LINK_RE.sub(r"\1", line) for line in content]
+        cleaned = [_BULLET_PREFIX_RE.sub(r"\1", line) for line in cleaned]
+        cleaned = [_BACKTICK_NAME_RE.sub(r"\1", line) for line in cleaned]
         return _original_parse_see_also(self, cleaned)
 
     NumpyDocString._parse_see_also = _parse_see_also_strip_backticks  # ty: ignore[invalid-assignment]

--- a/tests/test_see_also_repr.py
+++ b/tests/test_see_also_repr.py
@@ -1,0 +1,105 @@
+"""Tests for the numpydoc See Also parser patch in yohou/__init__.py."""
+
+import pytest
+
+# The patch is applied at import time, so just importing yohou activates it.
+import yohou  # noqa: F401
+from yohou import _BACKTICK_NAME_RE, _BULLET_PREFIX_RE, _MKDOCS_LINK_RE
+
+_has_repr_html = hasattr(__import__("sklearn.utils", fromlist=["_repr_html"]), "_repr_html")
+
+
+class TestSeeAlsoRegexTransformations:
+    """Unit tests for the regex transformations applied to See Also lines."""
+
+    def test_mkdocs_link_with_backticks_collapsed_to_path(self):
+        """MkDocs link with backtick display name becomes qualified path."""
+        line = (
+            "- [`FeaturePipeline`][yohou.compose.feature_pipeline.FeaturePipeline] : Sequential transformer chaining."
+        )
+        result = _MKDOCS_LINK_RE.sub(r"\1", line)
+        assert result == "- yohou.compose.feature_pipeline.FeaturePipeline : Sequential transformer chaining."
+
+    def test_mkdocs_link_without_backticks_collapsed_to_path(self):
+        """MkDocs link without backticks in display name becomes qualified path."""
+        line = "- [FeaturePipeline][yohou.compose.feature_pipeline.FeaturePipeline] : Description"
+        result = _MKDOCS_LINK_RE.sub(r"\1", line)
+        assert result == "- yohou.compose.feature_pipeline.FeaturePipeline : Description"
+
+    def test_bullet_prefix_stripped_preserving_indent(self):
+        """Leading '- ' is removed while preserving indentation."""
+        line = "    - yohou.compose.FeaturePipeline : Description"
+        result = _BULLET_PREFIX_RE.sub(r"\1", line)
+        assert result == "    yohou.compose.FeaturePipeline : Description"
+
+    def test_bullet_prefix_no_indent(self):
+        """Leading '- ' at column 0 is removed."""
+        line = "- yohou.path.Class : Desc"
+        result = _BULLET_PREFIX_RE.sub(r"\1", line)
+        assert result == "yohou.path.Class : Desc"
+
+    def test_backtick_name_stripped(self):
+        """Backtick-wrapped names become bare names."""
+        line = "`sklearn.pipeline.FeatureUnion` : Description"
+        result = _BACKTICK_NAME_RE.sub(r"\1", line)
+        assert result == "sklearn.pipeline.FeatureUnion : Description"
+
+    def test_full_pipeline_bullet_mkdocs_link(self):
+        """Full three-step pipeline transforms bullet MkDocs link to numpydoc format."""
+        line = "    - [`BaseTransformer`][yohou.base.transformer.BaseTransformer] : Base class."
+        # Step 1: collapse MkDocs link
+        result = _MKDOCS_LINK_RE.sub(r"\1", line)
+        # Step 2: strip bullet
+        result = _BULLET_PREFIX_RE.sub(r"\1", result)
+        # Step 3: strip backticks (no-op in this case since step 1 removed them)
+        result = _BACKTICK_NAME_RE.sub(r"\1", result)
+        assert result == "    yohou.base.transformer.BaseTransformer : Base class."
+
+    def test_backtick_only_line_unchanged_by_mkdocs_and_bullet_regexes(self):
+        """A backtick-only line (no bullet, no MkDocs link) passes through steps 1-2 unchanged."""
+        line = "`sklearn.preprocessing.PowerTransformer` : sklearn's power transforms."
+        result = _MKDOCS_LINK_RE.sub(r"\1", line)
+        result = _BULLET_PREFIX_RE.sub(r"\1", result)
+        assert result == "`sklearn.preprocessing.PowerTransformer` : sklearn's power transforms."
+        # Step 3 handles it
+        result = _BACKTICK_NAME_RE.sub(r"\1", result)
+        assert result == "sklearn.preprocessing.PowerTransformer : sklearn's power transforms."
+
+
+@pytest.mark.skipif(not _has_repr_html, reason="sklearn.utils._repr_html not available (sklearn < 1.8)")
+class TestSeeAlsoHtmlRepr:
+    """Integration tests that HTML repr works for estimators with various See Also formats."""
+
+    def test_bullet_mkdocs_see_also_repr(self):
+        """Estimator with bullet-style MkDocs See Also links renders HTML without error."""
+        from sklearn.utils._repr_html.estimator import estimator_html_repr
+
+        from yohou.stationarity import PatternSeasonalityForecaster
+
+        obj = PatternSeasonalityForecaster(seasonality=7)
+        html = estimator_html_repr(obj)
+        assert len(html) > 0
+
+    def test_mixed_format_see_also_repr(self):
+        """Estimator with mixed See Also (backtick-only + bullet MkDocs links) renders HTML."""
+        from sklearn.utils._repr_html.estimator import estimator_html_repr
+
+        from yohou.compose import FeatureUnion
+
+        obj = FeatureUnion(transformer_list=[])
+        html = estimator_html_repr(obj)
+        assert len(html) > 0
+
+    def test_docstrings_unchanged_after_import(self):
+        """The __doc__ attributes retain original MkDocs link syntax."""
+        from yohou.compose import FeatureUnion
+
+        doc = FeatureUnion.__doc__
+        assert "[`FeaturePipeline`][yohou.compose.feature_pipeline.FeaturePipeline]" in doc
+
+    def test_docstrings_unchanged_stationarity(self):
+        """Stationarity docstrings retain original format."""
+        from yohou.stationarity import PatternSeasonalityForecaster
+
+        doc = PatternSeasonalityForecaster.__doc__
+        assert "[`FourierSeasonalityForecaster`]" in doc


### PR DESCRIPTION
## Description

Extend the `_parse_see_also_strip_backticks` monkey-patch to handle MkDocs cross-reference link syntax and bullet markers, fixing `ValueError` when sklearn renders the HTML repr of yohou estimators in notebooks.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Yohou docstrings use MkDocs cross-reference syntax in See Also sections (`- [`Name`][qualified.path] : Desc`). The existing numpydoc patch only stripped backticks, leaving bracket syntax and bullet markers that numpydoc cannot parse. This caused `ValueError` in `sklearn.utils._repr_html` when rendering any estimator with bullet-style See Also entries in Jupyter/marimo.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

The patch applies three sequential regex transformations before delegating to the original parser:
1. Collapse MkDocs links `[display][path]` to the qualified path
2. Strip leading bullet markers (`- `) preserving indentation
3. Strip backtick-wrapped names (existing behavior)

Original `__doc__` strings remain untouched (MkDocs rendering unaffected).