### PR TITLE
feat(datasets): add WASM/Pyodide support for dataset fetchers

### DIFF
--- a/scripts/generate_dataset_parquets.py
+++ b/scripts/generate_dataset_parquets.py
@@ -1,0 +1,79 @@
+"""Generate pre-processed parquet files for all datasets.
+
+These parquets are hosted on the orphan `datasets` branch and served
+via jsDelivr for WASM/Pyodide environments where Zenodo CORS blocks
+direct downloads.
+
+Usage:
+    uv run python scripts/generate_dataset_parquets.py [output_dir]
+
+Default output directory: ./dataset_parquets/
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from yohou.datasets import (
+    fetch_air_quality_classification,
+    fetch_demand_classification,
+    fetch_dominick,
+    fetch_electricity_demand,
+    fetch_hospital,
+    fetch_kdd_cup,
+    fetch_pedestrian_counts,
+    fetch_sunspot,
+    fetch_tourism_monthly,
+    fetch_tourism_quarterly,
+)
+
+
+def main() -> None:  # noqa: D103
+    output_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("dataset_parquets")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    standard_datasets = {
+        "sunspot": fetch_sunspot,
+        "tourism_monthly": fetch_tourism_monthly,
+        "tourism_quarterly": fetch_tourism_quarterly,
+        "hospital": fetch_hospital,
+        "electricity_demand": fetch_electricity_demand,
+        "dominick": fetch_dominick,
+        "pedestrian_counts": fetch_pedestrian_counts,
+        "kdd_cup": fetch_kdd_cup,
+    }
+
+    for name, fetcher in standard_datasets.items():
+        print(f"Generating {name}...")  # noqa: T201
+        bunch = fetcher()
+        path = output_dir / f"{name}.parquet"
+        bunch.frame.write_parquet(path, compression="zstd", compression_level=9)
+        size_kb = path.stat().st_size / 1000
+        print(f"  {path} ({size_kb:.0f} KB, shape={bunch.frame.shape})")  # noqa: T201
+
+    # Classification datasets: separate y and X_actual parquets
+    print("Generating air_quality_classification...")  # noqa: T201
+    aq = fetch_air_quality_classification()
+    aq_y_path = output_dir / "air_quality_classification_y.parquet"
+    aq_x_path = output_dir / "air_quality_classification_X.parquet"
+    aq.y.write_parquet(aq_y_path, compression="zstd", compression_level=9)
+    aq.X_actual.write_parquet(aq_x_path, compression="zstd", compression_level=9)
+    print(f"  {aq_y_path} ({aq_y_path.stat().st_size / 1000:.0f} KB)")  # noqa: T201
+    print(f"  {aq_x_path} ({aq_x_path.stat().st_size / 1000:.0f} KB)")  # noqa: T201
+
+    print("Generating demand_classification...")  # noqa: T201
+    dc = fetch_demand_classification()
+    dc_y_path = output_dir / "demand_classification_y.parquet"
+    dc_x_path = output_dir / "demand_classification_X.parquet"
+    dc.y.write_parquet(dc_y_path, compression="zstd", compression_level=9)
+    dc.X_actual.write_parquet(dc_x_path, compression="zstd", compression_level=9)
+    print(f"  {dc_y_path} ({dc_y_path.stat().st_size / 1000:.0f} KB)")  # noqa: T201
+    print(f"  {dc_x_path} ({dc_x_path.stat().st_size / 1000:.0f} KB)")  # noqa: T201
+
+    total_bytes = sum(f.stat().st_size for f in output_dir.glob("*.parquet"))
+    print(f"\nTotal: {total_bytes / 1_000_000:.1f} MB across {len(list(output_dir.glob('*.parquet')))} files")  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/src/yohou/datasets/_fetchers.py
+++ b/src/yohou/datasets/_fetchers.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import io
 import os
 import shutil
+import sys
 import zipfile
 from pathlib import Path
+from urllib.request import urlopen
 
 import polars as pl
 from sklearn.datasets import fetch_file
@@ -25,6 +28,47 @@ from yohou.datasets._registry import (
 from yohou.datasets._tsf_parser import parse_tsf
 
 _KDD_CUP_MEASUREMENTS = frozenset({"pm2.5", "pm10", "no2", "co", "o3", "so2"})
+
+_CDN_BASE_URL = "https://cdn.jsdelivr.net/gh/stateful-y/yohou@datasets"
+
+
+def _is_wasm() -> bool:
+    """Return True when running inside Pyodide/WASM."""
+    return sys.platform == "emscripten"
+
+
+def _fetch_dataset_wasm(dataset_name: str, metadata: RemoteFileMetadata) -> Bunch:
+    """Download a pre-processed parquet from jsDelivr and return a Bunch."""
+    url = f"{_CDN_BASE_URL}/{dataset_name}.parquet"
+    data = urlopen(url).read()  # noqa: S310
+    frame = pl.read_parquet(io.BytesIO(data))
+    feature_names = [c for c in frame.columns if c != "time"]
+    return Bunch(
+        frame=frame,
+        feature_names=feature_names,
+        DESCR=metadata.descr,
+        frequency=metadata.frequency,
+        n_series=len(feature_names),
+        filename=url,
+    )
+
+
+def _fetch_classification_wasm(dataset_name: str) -> Bunch:
+    """Download pre-computed classification parquets from jsDelivr."""
+    y_url = f"{_CDN_BASE_URL}/{dataset_name}_y.parquet"
+    x_url = f"{_CDN_BASE_URL}/{dataset_name}_X.parquet"
+    y = pl.read_parquet(io.BytesIO(urlopen(y_url).read()))  # noqa: S310
+    X_actual = pl.read_parquet(io.BytesIO(urlopen(x_url).read()))  # noqa: S310
+    target_col = [c for c in y.columns if c != "time"][0]
+    classes = sorted(y[target_col].unique().to_list())
+    return Bunch(
+        y=y,
+        X_actual=X_actual,
+        feature_names=[c for c in X_actual.columns if c != "time"],
+        target_names=[target_col],
+        classes=classes,
+        DESCR=f"Classification dataset ({dataset_name}) loaded from CDN.",
+    )
 
 
 def get_data_home(data_home: str | os.PathLike | None = None) -> str:
@@ -118,6 +162,9 @@ def _fetch_dataset(
         ``DESCR``, ``frequency``, ``n_series``, ``filename`` keys.
 
     """
+    if _is_wasm():
+        return _fetch_dataset_wasm(dataset_name, metadata)
+
     data_home_str = get_data_home(data_home)
     dataset_dir = os.path.join(data_home_str, dataset_name)
 
@@ -945,6 +992,9 @@ def fetch_air_quality_classification(
     ['good', 'hazardous', 'moderate', 'unhealthy']
 
     """
+    if _is_wasm():
+        return _fetch_classification_wasm("air_quality_classification")
+
     bunch = fetch_kdd_cup(
         n_groups=1,
         data_home=data_home,
@@ -1063,6 +1113,9 @@ def fetch_demand_classification(
     ['high', 'low', 'medium']
 
     """
+    if _is_wasm():
+        return _fetch_classification_wasm("demand_classification")
+
     bunch = fetch_electricity_demand(
         data_home=data_home,
         download_if_missing=download_if_missing,

--- a/tests/datasets/test_wasm_fetchers.py
+++ b/tests/datasets/test_wasm_fetchers.py
@@ -1,0 +1,183 @@
+"""Tests for WASM dataset loading path."""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime
+from unittest.mock import patch
+
+import polars as pl
+import pytest
+from sklearn.utils import Bunch
+
+from yohou.datasets._fetchers import (
+    _CDN_BASE_URL,
+    _fetch_classification_wasm,
+    _fetch_dataset_wasm,
+    _is_wasm,
+)
+from yohou.datasets._registry import SUNSPOT
+
+
+class TestIsWasm:
+    def test_returns_false_in_native_python(self):
+        assert _is_wasm() is False
+
+    def test_returns_true_when_emscripten(self):
+        with patch("yohou.datasets._fetchers.sys") as mock_sys:
+            mock_sys.platform = "emscripten"
+            from yohou.datasets import _fetchers
+
+            assert _fetchers._is_wasm() is True
+
+
+class TestFetchDatasetWasmRouting:
+    def test_wasm_path_called_when_emscripten(self):
+        with (
+            patch("yohou.datasets._fetchers._is_wasm", return_value=True),
+            patch("yohou.datasets._fetchers._fetch_dataset_wasm") as mock_wasm,
+        ):
+            mock_wasm.return_value = Bunch(frame=pl.DataFrame())
+            from yohou.datasets._fetchers import _fetch_dataset
+            from yohou.datasets._registry import SUNSPOT
+
+            _fetch_dataset(SUNSPOT, "sunspot", value_column_name="sunspot_number")
+            mock_wasm.assert_called_once_with("sunspot", SUNSPOT)
+
+    def test_wasm_url_is_correct(self):
+        expected_url = f"{_CDN_BASE_URL}/sunspot.parquet"
+        assert "cdn.jsdelivr.net" in expected_url
+        assert "stateful-y/yohou@datasets" in expected_url
+        assert expected_url.endswith("/sunspot.parquet")
+
+
+class TestFetchDatasetWasmBunch:
+    @pytest.fixture()
+    def sample_parquet_bytes(self):
+        df = pl.DataFrame(
+            {
+                "time": [
+                    datetime(2020, 1, 1),
+                    datetime(2020, 2, 1),
+                    datetime(2020, 3, 1),
+                ],
+                "sunspot_number": [10.0, 20.0, 30.0],
+            },
+            schema={"time": pl.Datetime, "sunspot_number": pl.Float64},
+        )
+        buf = io.BytesIO()
+        df.write_parquet(buf, compression="zstd")
+        return buf.getvalue()
+
+    def test_returns_bunch_with_correct_keys(self, sample_parquet_bytes):
+        mock_response = io.BytesIO(sample_parquet_bytes)
+        mock_response.read = lambda: sample_parquet_bytes
+
+        with patch("yohou.datasets._fetchers.urlopen", return_value=mock_response):
+            result = _fetch_dataset_wasm("sunspot", SUNSPOT)
+
+        assert isinstance(result, Bunch)
+        assert "frame" in result
+        assert "feature_names" in result
+        assert "DESCR" in result
+        assert "frequency" in result
+        assert "n_series" in result
+        assert "filename" in result
+
+    def test_frame_is_polars_dataframe(self, sample_parquet_bytes):
+        mock_response = io.BytesIO(sample_parquet_bytes)
+        mock_response.read = lambda: sample_parquet_bytes
+
+        with patch("yohou.datasets._fetchers.urlopen", return_value=mock_response):
+            result = _fetch_dataset_wasm("sunspot", SUNSPOT)
+
+        assert isinstance(result.frame, pl.DataFrame)
+        assert "time" in result.frame.columns
+        assert "sunspot_number" in result.frame.columns
+
+    def test_feature_names_excludes_time(self, sample_parquet_bytes):
+        mock_response = io.BytesIO(sample_parquet_bytes)
+        mock_response.read = lambda: sample_parquet_bytes
+
+        with patch("yohou.datasets._fetchers.urlopen", return_value=mock_response):
+            result = _fetch_dataset_wasm("sunspot", SUNSPOT)
+
+        assert result.feature_names == ["sunspot_number"]
+        assert result.n_series == 1
+
+    def test_metadata_from_registry(self, sample_parquet_bytes):
+        mock_response = io.BytesIO(sample_parquet_bytes)
+        mock_response.read = lambda: sample_parquet_bytes
+
+        with patch("yohou.datasets._fetchers.urlopen", return_value=mock_response):
+            result = _fetch_dataset_wasm("sunspot", SUNSPOT)
+
+        assert SUNSPOT.descr == result.DESCR
+        assert result.frequency == SUNSPOT.frequency
+
+
+class TestFetchClassificationWasm:
+    @pytest.fixture()
+    def classification_parquet_bytes(self):
+        y_df = pl.DataFrame(
+            {
+                "time": [
+                    datetime(2020, 1, 1),
+                    datetime(2020, 2, 1),
+                    datetime(2020, 3, 1),
+                ],
+                "air_quality": ["good", "moderate", "unhealthy"],
+            },
+            schema={"time": pl.Datetime, "air_quality": pl.String},
+        )
+        x_df = pl.DataFrame(
+            {
+                "time": [
+                    datetime(2020, 1, 1),
+                    datetime(2020, 2, 1),
+                    datetime(2020, 3, 1),
+                ],
+                "pm10": [10.0, 20.0, 30.0],
+                "no2": [5.0, 10.0, 15.0],
+            },
+            schema={"time": pl.Datetime, "pm10": pl.Float64, "no2": pl.Float64},
+        )
+        y_buf = io.BytesIO()
+        y_df.write_parquet(y_buf, compression="zstd")
+        x_buf = io.BytesIO()
+        x_df.write_parquet(x_buf, compression="zstd")
+        return y_buf.getvalue(), x_buf.getvalue()
+
+    def test_returns_bunch_with_classification_keys(self, classification_parquet_bytes):
+        y_bytes, x_bytes = classification_parquet_bytes
+
+        def mock_urlopen(url):
+            data = y_bytes if "_y.parquet" in url else x_bytes
+            response = io.BytesIO(data)
+            return response
+
+        with patch("yohou.datasets._fetchers.urlopen", side_effect=mock_urlopen):
+            result = _fetch_classification_wasm("air_quality_classification")
+
+        assert isinstance(result, Bunch)
+        assert "y" in result
+        assert "X_actual" in result
+        assert "feature_names" in result
+        assert "target_names" in result
+        assert "classes" in result
+        assert "DESCR" in result
+
+    def test_classes_are_sorted(self, classification_parquet_bytes):
+        y_bytes, x_bytes = classification_parquet_bytes
+
+        def mock_urlopen(url):
+            data = y_bytes if "_y.parquet" in url else x_bytes
+            response = io.BytesIO(data)
+            return response
+
+        with patch("yohou.datasets._fetchers.urlopen", side_effect=mock_urlopen):
+            result = _fetch_classification_wasm("air_quality_classification")
+
+        assert result.classes == sorted(result.classes)
+        assert result.target_names == ["air_quality"]
+        assert result.feature_names == ["pm10", "no2"]

--- a/tests/datasets/test_wasm_fetchers.py
+++ b/tests/datasets/test_wasm_fetchers.py
@@ -15,6 +15,8 @@ from yohou.datasets._fetchers import (
     _fetch_classification_wasm,
     _fetch_dataset_wasm,
     _is_wasm,
+    fetch_air_quality_classification,
+    fetch_demand_classification,
 )
 from yohou.datasets._registry import SUNSPOT
 
@@ -181,3 +183,31 @@ class TestFetchClassificationWasm:
         assert result.classes == sorted(result.classes)
         assert result.target_names == ["air_quality"]
         assert result.feature_names == ["pm10", "no2"]
+
+
+class TestClassificationWasmRouting:
+    def test_fetch_air_quality_routes_to_wasm(self):
+        mock_bunch = Bunch(y=pl.DataFrame(), X_actual=pl.DataFrame())
+        with (
+            patch("yohou.datasets._fetchers._is_wasm", return_value=True),
+            patch(
+                "yohou.datasets._fetchers._fetch_classification_wasm",
+                return_value=mock_bunch,
+            ) as mock_cls_wasm,
+        ):
+            result = fetch_air_quality_classification()
+            mock_cls_wasm.assert_called_once_with("air_quality_classification")
+            assert result is mock_bunch
+
+    def test_fetch_demand_classification_routes_to_wasm(self):
+        mock_bunch = Bunch(y=pl.DataFrame(), X_actual=pl.DataFrame())
+        with (
+            patch("yohou.datasets._fetchers._is_wasm", return_value=True),
+            patch(
+                "yohou.datasets._fetchers._fetch_classification_wasm",
+                return_value=mock_bunch,
+            ) as mock_cls_wasm,
+        ):
+            result = fetch_demand_classification()
+            mock_cls_wasm.assert_called_once_with("demand_classification")
+            assert result is mock_bunch


### PR DESCRIPTION
## Description

Add runtime detection of Pyodide/WASM environments and fetch pre-processed parquets from jsDelivr CDN instead of Zenodo (which does not serve CORS headers).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Marimo WASM notebooks fail on dataset fetch because Zenodo does not serve CORS headers, causing `pyodide_http` to report `BadStatusLine: HTTP/1.1 0`. This adds a transparent fallback that detects `sys.platform == "emscripten"` and routes requests to jsDelivr CDN serving parquets from an orphan `datasets` branch.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Remaining work (can be follow-up PRs):
- Create the orphan `datasets` branch with generated parquets (requires running `scripts/generate_dataset_parquets.py`)
- Add CI workflow for dataset regeneration on registry changes
