### PR TITLE
fix(forecaster): remap vintage_time in _predict_with_step_override

### DIFF
--- a/src/yohou/base/forecaster.py
+++ b/src/yohou/base/forecaster.py
@@ -733,12 +733,15 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
             else self.observed_time_
         )
 
-        # When the caller overrides X_forecast (e.g. a single NWP vintage
-        # whose vintage_time differs from observed_time_), remap
-        # vintage_time so pivot_forecasts output joins correctly against
-        # observation_times in _derive_step_columns.
+        # When the caller overrides X_forecast with a single vintage whose
+        # vintage_time differs from observed_time_, remap vintage_time so
+        # pivot_forecasts output joins correctly against observation_times
+        # in _derive_step_columns.  Multi-vintage overrides are left
+        # untouched (one of their vintages should already match obs_time).
         if X_forecast is not None and X_forecast_eff is not None:
-            X_forecast_eff = X_forecast_eff.with_columns(vintage_time=pl.lit(obs_time))
+            vintages = X_forecast_eff["vintage_time"].unique()
+            if len(vintages) == 1 and vintages[0] != obs_time:
+                X_forecast_eff = X_forecast_eff.with_columns(vintage_time=pl.lit(obs_time))
 
         X_step_new = _derive_step_columns(
             X_future_eff,

--- a/src/yohou/base/forecaster.py
+++ b/src/yohou/base/forecaster.py
@@ -732,6 +732,14 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
             if isinstance(self.observed_time_, dict)
             else self.observed_time_
         )
+
+        # When the caller overrides X_forecast (e.g. a single NWP vintage
+        # whose vintage_time differs from observed_time_), remap
+        # vintage_time so pivot_forecasts output joins correctly against
+        # observation_times in _derive_step_columns.
+        if X_forecast is not None and X_forecast_eff is not None:
+            X_forecast_eff = X_forecast_eff.with_columns(vintage_time=pl.lit(obs_time))
+
         X_step_new = _derive_step_columns(
             X_future_eff,
             X_forecast_eff,

--- a/tests/integration/test_exogenous_forecast_e2e.py
+++ b/tests/integration/test_exogenous_forecast_e2e.py
@@ -849,9 +849,7 @@ class TestMismatchedVintageOverride:
         )
         return X_a, X_b
 
-    def test_predict_with_mismatched_vintage_time_produces_different_results(
-        self, electricity_data
-    ):
+    def test_predict_with_mismatched_vintage_time_produces_different_results(self, electricity_data):
         """Two X_forecast overrides with different weather values but
         vintage_time != observed_time_ must produce different predictions."""
         f, fh, d = self._fit_and_observe(electricity_data)
@@ -878,16 +876,12 @@ class TestMismatchedVintageOverride:
         step_cols = sorted(f._step_column_names_)
 
         # Snapshot step columns before override predict
-        step_before = f._X_t_observed.select(
-            [c for c in step_cols if c in f._X_t_observed.columns]
-        )
+        step_before = f._X_t_observed.select([c for c in step_cols if c in f._X_t_observed.columns])
 
         _ = f.predict(X_forecast=X_a)
 
         # Step columns must be identical after predict returns
-        step_after = f._X_t_observed.select(
-            [c for c in step_cols if c in f._X_t_observed.columns]
-        )
+        step_after = f._X_t_observed.select([c for c in step_cols if c in f._X_t_observed.columns])
 
         assert step_before.equals(step_after), (
             "Step columns in _X_t_observed were not restored after predict(X_forecast=...) returned"

--- a/tests/integration/test_exogenous_forecast_e2e.py
+++ b/tests/integration/test_exogenous_forecast_e2e.py
@@ -795,3 +795,100 @@ class TestEdgeCasesExtended:
         # Step columns should still be non-empty (auto-rederived)
         assert len(f._step_column_names_) > 0
         assert f._step_column_names_ == step_cols_before
+
+
+@pytest.mark.integration
+class TestMismatchedVintageOverride:
+    """Tests for X_forecast overrides whose vintage_time differs from observed_time_.
+
+    The existing TestFitPredictWithExogenous.test_multi_vintage_predictions_differ
+    uses vintage_time == observed_time_ (last training timestamp). These tests
+    advance observed_time_ via observe() so that the override vintage_time no
+    longer matches, exercising the remap path in _predict_with_step_override.
+    """
+
+    def _fit_and_observe(self, electricity_data):
+        """Fit a forecaster and observe a few test rows to shift observed_time_."""
+        d = electricity_data
+        f, fh = _build_forecaster()
+        f.fit(
+            y=d["y_train"],
+            X_actual=d["X_actual_train"],
+            forecasting_horizon=fh,
+            X_future=d["X_future_full"],
+            X_forecast=d["X_forecast_train"],
+        )
+
+        # Advance observed_time_ past the last training timestamp
+        n_obs = 3
+        f.observe(
+            y=d["y_test"][:n_obs],
+            X_actual=d["X_actual_test"][:n_obs],
+        )
+        return f, fh, d
+
+    def _make_mismatched_vintages(self, d, fh):
+        """Build two single-vintage X_forecast overrides whose vintage_time
+        differs from the forecaster's observed_time_ (uses the last training
+        timestamp as vintage_time, while observed_time_ has been advanced).
+        """
+        last_train = d["y_train"]["time"].max()
+        test_times = d["all_times"][N_TRAIN : N_TRAIN + fh]
+
+        X_a = _make_weather_forecast(
+            pl.Series("vintage_time", [last_train]),
+            test_times,
+            bias=0.1,
+            rng=np.random.default_rng(500),
+        )
+        X_b = _make_weather_forecast(
+            pl.Series("vintage_time", [last_train]),
+            test_times,
+            bias=5.0,
+            rng=np.random.default_rng(600),
+        )
+        return X_a, X_b
+
+    def test_predict_with_mismatched_vintage_time_produces_different_results(
+        self, electricity_data
+    ):
+        """Two X_forecast overrides with different weather values but
+        vintage_time != observed_time_ must produce different predictions."""
+        f, fh, d = self._fit_and_observe(electricity_data)
+        X_a, X_b = self._make_mismatched_vintages(d, fh)
+
+        # Confirm vintage_time differs from observed_time_
+        assert X_a["vintage_time"][0] != f.observed_time_
+
+        pred_a = f.predict(X_forecast=X_a)
+        pred_b = f.predict(X_forecast=X_b)
+
+        assert not np.allclose(
+            pred_a["price"].to_numpy(),
+            pred_b["price"].to_numpy(),
+            atol=0.01,
+        ), "Predictions with different X_forecast overrides must differ even when vintage_time != observed_time_"
+
+    def test_predict_with_mismatched_vintage_restores_state(self, electricity_data):
+        """predict(X_forecast=X_v) with vintage_time != observed_time_ must
+        restore _X_t_observed step columns to their original values."""
+        f, fh, d = self._fit_and_observe(electricity_data)
+        X_a, _ = self._make_mismatched_vintages(d, fh)
+
+        step_cols = sorted(f._step_column_names_)
+
+        # Snapshot step columns before override predict
+        step_before = f._X_t_observed.select(
+            [c for c in step_cols if c in f._X_t_observed.columns]
+        )
+
+        _ = f.predict(X_forecast=X_a)
+
+        # Step columns must be identical after predict returns
+        step_after = f._X_t_observed.select(
+            [c for c in step_cols if c in f._X_t_observed.columns]
+        )
+
+        assert step_before.equals(step_after), (
+            "Step columns in _X_t_observed were not restored after predict(X_forecast=...) returned"
+        )


### PR DESCRIPTION
## Description

When `predict(X_forecast=...)` is called with a vintage whose `vintage_time` differs from `observed_time_`, `pivot_forecasts` produces rows keyed on `vintage_time` that fail to join against `observation_times` in `_derive_step_columns`. All step columns become null and every vintage yields identical predictions.

Remap `vintage_time` to `obs_time` before deriving step columns so the pivot/join pipeline aligns correctly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

The DAM notebook (`spp_dam_template.py`) advances the forecaster to 23:00 UTC via `observe()`, then calls `predict(X_forecast=X_v)` for each DAM hour with a different NWP vintage. Because each vintage's `vintage_time` equals the original training cutoff (not the advanced `observed_time_`), the left join in `_derive_step_columns` finds no match and all weather step columns are null. The model sees identical (null) features for every vintage and returns identical predictions.

## Checklist

- [x] My code follows the code style of this project
- [ ] I have run `just fix` to format my code
- [ ] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] My changes generate no new warnings

## Additional Notes

Two new regression tests in `TestMismatchedVintageOverride`:
- `test_predict_with_mismatched_vintage_time_produces_different_results`: two different X_forecast overrides with `vintage_time != observed_time_` produce different predictions
- `test_predict_with_mismatched_vintage_restores_state`: `_X_t_observed` step columns are unchanged after predict returns