### PR TITLE
fix: clip forecast step columns to forecasting horizon window

### DIFF
--- a/docs/pages/explanation/exogenous-features.md
+++ b/docs/pages/explanation/exogenous-features.md
@@ -183,6 +183,14 @@ Similarly, `X_forecast` may not cover all training observation times. Rows
 without matching forecast data produce null step columns. This is common when
 forecast archives start later than the target series.
 
+Conversely, a vintage whose timestamps extend beyond the forecasting horizon
+is clipped before pivoting. Each vintage keeps only timestamps in
+$(T_v,\; T_v + H \cdot \Delta t]$ where $T_v$ is the vintage time. This
+guarantees that step columns always span exactly `1..H` per value column,
+preventing spurious `step_(H+1)` columns from appearing in the feature
+matrix. If clipping leaves fewer than $H$ timestamps, the missing step
+columns are padded with null and a `UserWarning` is emitted.
+
 ## The Observe-Predict Loop
 
 The `observe()` method accepts `X_actual`, `X_future`, and `X_forecast`,

--- a/docs/pages/how-to/exogenous-features.md
+++ b/docs/pages/how-to/exogenous-features.md
@@ -231,6 +231,15 @@ pred = restored.predict(X_forecast=new_vintage)
 : All `X_future` and `X_forecast` columns seen during `fit()` must also be
   present at `predict()` time with the same names.
 
+**Problem: `UserWarning` about X_forecast covering fewer steps than the horizon**
+: The forecast vintage covers fewer future timestamps than `forecasting_horizon`.
+  This is normal for short-range forecasts or when the observation point has
+  advanced past some forecast timestamps (e.g., after `observe()`). The missing
+  step columns are filled with null. Tree-based estimators (XGBoost, LightGBM,
+  HistGradientBoosting) handle null features natively. For estimators that do
+  not support nulls, set `nan_handling="drop"` so null rows are excluded from
+  training, or provide forecasts with full horizon coverage.
+
 ## See Also
 
 - [Work with Forecast Vintages](forecast-vintages.md): X_forecast preparation,

--- a/src/yohou/base/forecaster.py
+++ b/src/yohou/base/forecaster.py
@@ -765,11 +765,9 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
 
         if isinstance(self._X_t_observed, dict):
             # Panel: save per-group step columns (unprefixed)
-            observed_dict = typing_cast(dict[str, pl.DataFrame | None], self._X_t_observed)
+            observed_dict = typing_cast(dict[str, pl.DataFrame], self._X_t_observed)
             saved_step_data: dict[str, pl.DataFrame] = {}
             for group_name, group_df in observed_dict.items():
-                if group_df is None:
-                    continue
                 cols_present = [c for c in local_step_cols if c in group_df.columns]
                 if cols_present:
                     saved_step_data[group_name] = group_df.select(cols_present)
@@ -816,12 +814,10 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
 
             # Restore step columns
             if isinstance(self._X_t_observed, dict) and isinstance(saved_step_data, dict):
-                restore_dict = typing_cast(dict[str, pl.DataFrame | None], self._X_t_observed)
+                restore_dict = typing_cast(dict[str, pl.DataFrame], self._X_t_observed)
                 saved_dict = typing_cast(dict[str, pl.DataFrame], saved_step_data)
                 for group_name, saved_df in saved_dict.items():
                     group_df = restore_dict[group_name]
-                    if group_df is None:
-                        continue
                     cols_to_drop = [c for c in local_step_cols if c in group_df.columns]
                     if cols_to_drop:
                         restored = group_df.drop(cols_to_drop)

--- a/src/yohou/base/forecaster.py
+++ b/src/yohou/base/forecaster.py
@@ -765,11 +765,14 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
 
         if isinstance(self._X_t_observed, dict):
             # Panel: save per-group step columns (unprefixed)
-            saved_step_data = {}
-            for group_name, group_df in self._X_t_observed.items():
-                cols_present = [c for c in local_step_cols if c in group_df.columns]  # ty: ignore[unresolved-attribute]
+            observed_dict = typing_cast(dict[str, pl.DataFrame | None], self._X_t_observed)
+            saved_step_data: dict[str, pl.DataFrame] = {}
+            for group_name, group_df in observed_dict.items():
+                if group_df is None:
+                    continue
+                cols_present = [c for c in local_step_cols if c in group_df.columns]
                 if cols_present:
-                    saved_step_data[group_name] = group_df.select(cols_present)  # ty: ignore[unresolved-attribute]
+                    saved_step_data[group_name] = group_df.select(cols_present)
         else:
             # Standard: save step columns from last row
             cols_present = [c for c in local_step_cols if c in self._X_t_observed.columns]  # ty: ignore[unresolved-attribute]
@@ -812,13 +815,17 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
             self._X_forecast_raw_ = saved_forecast_raw
 
             # Restore step columns
-            if isinstance(self._X_t_observed, dict):
-                for group_name, saved_df in saved_step_data.items():  # ty: ignore[unresolved-attribute]
-                    group_df = self._X_t_observed[group_name]
-                    cols_to_drop = [c for c in local_step_cols if c in group_df.columns]  # ty: ignore[unresolved-attribute]
+            if isinstance(self._X_t_observed, dict) and isinstance(saved_step_data, dict):
+                restore_dict = typing_cast(dict[str, pl.DataFrame | None], self._X_t_observed)
+                saved_dict = typing_cast(dict[str, pl.DataFrame], saved_step_data)
+                for group_name, saved_df in saved_dict.items():
+                    group_df = restore_dict[group_name]
+                    if group_df is None:
+                        continue
+                    cols_to_drop = [c for c in local_step_cols if c in group_df.columns]
                     if cols_to_drop:
-                        restored = group_df.drop(cols_to_drop)  # ty: ignore[unresolved-attribute]
-                        self._X_t_observed[group_name] = pl.concat([restored, saved_df], how="horizontal")
+                        restored = group_df.drop(cols_to_drop)
+                        restore_dict[group_name] = pl.concat([restored, saved_df], how="horizontal")
             elif saved_step_data is not None:
                 cols_to_drop = [c for c in local_step_cols if c in self._X_t_observed.columns]  # ty: ignore[unresolved-attribute]
                 if cols_to_drop:

--- a/src/yohou/base/panel.py
+++ b/src/yohou/base/panel.py
@@ -606,27 +606,25 @@ class BasePanelForecaster:
             )
 
             # Hstack pre-computed step columns for this group
-            if X_t_local is not None and X_step_precomputed is not None:
+            if X_t_local is not None and X_step_precomputed is not None and self._step_schema_per_group_ is not None:
                 # Filter schema to columns available in the precomputed steps
                 # (test folds may have fewer forecast vintages than training).
                 available = set(X_step_precomputed.columns)
                 step_schema = {
-                    k: v for k, v in self._step_schema_per_group_.items()
+                    k: v
+                    for k, v in self._step_schema_per_group_.items()
                     if k in available or f"{panel_group_name}__{k}" in available
                 }
-                step_group = get_group_df(X_step_precomputed, panel_group_name, step_schema).select(  # ty: ignore[invalid-argument-type]
-                    ~cs.by_name("time")
-                )
+                step_group = get_group_df(X_step_precomputed, panel_group_name, step_schema).select(~cs.by_name("time"))
                 X_t_local = pl.concat([X_t_local, step_group], how="horizontal")
-            elif X_t_local is None and X_step_precomputed is not None:
+            elif X_t_local is None and X_step_precomputed is not None and self._step_schema_per_group_ is not None:
                 available = set(X_step_precomputed.columns)
                 step_schema = {
-                    k: v for k, v in self._step_schema_per_group_.items()
+                    k: v
+                    for k, v in self._step_schema_per_group_.items()
                     if k in available or f"{panel_group_name}__{k}" in available
                 }
-                X_t_local = get_group_df(X_step_precomputed, panel_group_name, step_schema).select(  # ty: ignore[invalid-argument-type]
-                    ~cs.by_name("time")
-                )
+                X_t_local = get_group_df(X_step_precomputed, panel_group_name, step_schema).select(~cs.by_name("time"))
 
             X_t_updated[panel_group_name] = X_t_local
 

--- a/src/yohou/base/panel.py
+++ b/src/yohou/base/panel.py
@@ -607,12 +607,24 @@ class BasePanelForecaster:
 
             # Hstack pre-computed step columns for this group
             if X_t_local is not None and X_step_precomputed is not None:
-                step_group = get_group_df(X_step_precomputed, panel_group_name, self._step_schema_per_group_).select(  # ty: ignore[invalid-argument-type]
+                # Filter schema to columns available in the precomputed steps
+                # (test folds may have fewer forecast vintages than training).
+                available = set(X_step_precomputed.columns)
+                step_schema = {
+                    k: v for k, v in self._step_schema_per_group_.items()
+                    if k in available or f"{panel_group_name}__{k}" in available
+                }
+                step_group = get_group_df(X_step_precomputed, panel_group_name, step_schema).select(  # ty: ignore[invalid-argument-type]
                     ~cs.by_name("time")
                 )
                 X_t_local = pl.concat([X_t_local, step_group], how="horizontal")
             elif X_t_local is None and X_step_precomputed is not None:
-                X_t_local = get_group_df(X_step_precomputed, panel_group_name, self._step_schema_per_group_).select(  # ty: ignore[invalid-argument-type]
+                available = set(X_step_precomputed.columns)
+                step_schema = {
+                    k: v for k, v in self._step_schema_per_group_.items()
+                    if k in available or f"{panel_group_name}__{k}" in available
+                }
+                X_t_local = get_group_df(X_step_precomputed, panel_group_name, step_schema).select(  # ty: ignore[invalid-argument-type]
                     ~cs.by_name("time")
                 )
 

--- a/src/yohou/base/utils.py
+++ b/src/yohou/base/utils.py
@@ -393,19 +393,12 @@ def _derive_step_columns(
         forecast_pivoted = pivot_forecasts(X_forecast_filtered)
 
         # Determine value columns and their dtypes for padding
-        value_cols_info = {
-            c: X_forecast[c].dtype
-            for c in X_forecast.columns
-            if c not in ("vintage_time", "time")
-        }
+        value_cols_info = {c: X_forecast[c].dtype for c in X_forecast.columns if c not in ("vintage_time", "time")}
 
         # Warn if any vintage has fewer steps than the forecasting horizon
         import re  # noqa: PLC0415
 
-        step_cols_forecast = [
-            c for c in forecast_pivoted.columns
-            if c != "time" and re.search(r"_step_\d+$", c)
-        ]
+        step_cols_forecast = [c for c in forecast_pivoted.columns if c != "time" and re.search(r"_step_\d+$", c)]
         if step_cols_forecast:
             step_nums = [int(m.group(1)) for c in step_cols_forecast if (m := re.search(r"_step_(\d+)$", c))]
             max_step = max(step_nums) if step_nums else 0
@@ -417,7 +410,7 @@ def _derive_step_columns(
                     f"forecast steps. The remaining step features will be null. "
                     f"This is normal for short-range forecasts or when the "
                     f"observation point has advanced past some forecast "
-                    f"timestamps. Tree-based estimators (XGBoost, LightGBM, "
+                    f"timestamps. Tree-based estimators (e.g. XGBoost, LightGBM, "
                     f"HistGradientBoosting) handle null features natively.",
                     UserWarning,
                     stacklevel=2,

--- a/src/yohou/base/utils.py
+++ b/src/yohou/base/utils.py
@@ -350,6 +350,7 @@ def _derive_step_columns(
 
     """
     from yohou.utils.pivot import pivot_forecasts, window_futures  # noqa: PLC0415
+    from yohou.utils.validation import add_interval  # noqa: PLC0415
 
     if X_future is None and X_forecast is None:
         return None
@@ -365,7 +366,42 @@ def _derive_step_columns(
         parts.append(future_pivoted)
 
     if X_forecast is not None:
-        forecast_pivoted = pivot_forecasts(X_forecast)
+        # Filter each vintage to timestamps within its forecasting horizon
+        # window: (vintage_time, vintage_time + H * interval].
+        # The predict path remaps vintage_time to observed_time_ before
+        # calling, so this correctly clips to the model's prediction window.
+        unique_vintages = X_forecast["vintage_time"].unique().to_list()
+        cutoffs = {vt: add_interval(vt, interval, n=forecasting_horizon) for vt in unique_vintages}
+        cutoff_df = pl.DataFrame({
+            "vintage_time": list(cutoffs.keys()),
+            "_cutoff": list(cutoffs.values()),
+        })
+        X_forecast_filtered = (
+            X_forecast
+            .join(cutoff_df, on="vintage_time", how="left")
+            .filter((pl.col("time") > pl.col("vintage_time")) & (pl.col("time") <= pl.col("_cutoff")))
+            .drop("_cutoff")
+        )
+
+        forecast_pivoted = pivot_forecasts(X_forecast_filtered)
+
+        # Warn if any vintage has fewer steps than the forecasting horizon
+        step_cols_forecast = [c for c in forecast_pivoted.columns if c != "time"]
+        if step_cols_forecast:
+            import re  # noqa: PLC0415
+
+            step_nums = [int(m.group(1)) for c in step_cols_forecast if (m := re.search(r"_step_(\d+)$", c))]
+            max_step = max(step_nums) if step_nums else 0
+            if max_step < forecasting_horizon:
+                import warnings  # noqa: PLC0415
+
+                warnings.warn(
+                    f"X_forecast covers {max_step} steps but forecasting_horizon is "
+                    f"{forecasting_horizon}. Some step features will be null.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
         # Filter to observation_times only (left join preserves order)
         obs_df = pl.DataFrame({"time": observation_times})
         forecast_pivoted = obs_df.join(forecast_pivoted, on="time", how="left")

--- a/src/yohou/base/utils.py
+++ b/src/yohou/base/utils.py
@@ -324,7 +324,12 @@ def _derive_step_columns(
         values that are windowed forward from each observation time.
     X_forecast : pl.DataFrame or None
         External forecasts with ``"vintage_time"`` and ``"time"`` columns.
-        Pivoted by ordinal rank within each vintage group.
+        Before pivoting, each vintage is filtered to timestamps within
+        ``(vintage_time, vintage_time + H * interval]``. Timestamps outside
+        this window are discarded. The remaining timestamps are pivoted by
+        ordinal rank within each vintage group. If filtering produces fewer
+        than H step columns, the missing columns are padded with null and
+        a ``UserWarning`` is emitted.
     observation_times : pl.Series
         Observation timestamps to derive step columns from.
     forecasting_horizon : int
@@ -339,8 +344,10 @@ def _derive_step_columns(
     -------
     pl.DataFrame or None
         Wide DataFrame with ``[time, <col>_step_1, ..., <col>_step_H]``
-        combining step columns from both sources. Returns ``None`` when
-        both ``X_future`` and ``X_forecast`` are ``None``.
+        combining step columns from both sources. Step columns always
+        span exactly ``1..H`` per value column: over-long forecasts are
+        clipped, and under-coverage is padded with null. Returns ``None``
+        when both ``X_future`` and ``X_forecast`` are ``None``.
 
     Raises
     ------
@@ -385,22 +392,51 @@ def _derive_step_columns(
 
         forecast_pivoted = pivot_forecasts(X_forecast_filtered)
 
-        # Warn if any vintage has fewer steps than the forecasting horizon
-        step_cols_forecast = [c for c in forecast_pivoted.columns if c != "time"]
-        if step_cols_forecast:
-            import re  # noqa: PLC0415
+        # Determine value columns and their dtypes for padding
+        value_cols_info = {
+            c: X_forecast[c].dtype
+            for c in X_forecast.columns
+            if c not in ("vintage_time", "time")
+        }
 
+        # Warn if any vintage has fewer steps than the forecasting horizon
+        import re  # noqa: PLC0415
+
+        step_cols_forecast = [
+            c for c in forecast_pivoted.columns
+            if c != "time" and re.search(r"_step_\d+$", c)
+        ]
+        if step_cols_forecast:
             step_nums = [int(m.group(1)) for c in step_cols_forecast if (m := re.search(r"_step_(\d+)$", c))]
             max_step = max(step_nums) if step_nums else 0
             if max_step < forecasting_horizon:
                 import warnings  # noqa: PLC0415
 
                 warnings.warn(
-                    f"X_forecast covers {max_step} steps but forecasting_horizon is "
-                    f"{forecasting_horizon}. Some step features will be null.",
+                    f"X_forecast covers {max_step} of {forecasting_horizon} "
+                    f"forecast steps. The remaining step features will be null. "
+                    f"This is normal for short-range forecasts or when the "
+                    f"observation point has advanced past some forecast "
+                    f"timestamps. Tree-based estimators (XGBoost, LightGBM, "
+                    f"HistGradientBoosting) handle null features natively.",
                     UserWarning,
                     stacklevel=2,
                 )
+
+        # Pad missing step columns to H (partial coverage → null columns)
+        missing_exprs = []
+        for col, dtype in value_cols_info.items():
+            for h in range(1, forecasting_horizon + 1):
+                step_name = f"{col}_step_{h}"
+                if step_name not in forecast_pivoted.columns:
+                    missing_exprs.append(pl.lit(None).cast(dtype).alias(step_name))
+        if missing_exprs:
+            forecast_pivoted = forecast_pivoted.with_columns(missing_exprs)
+
+        # Drop raw value columns (present when pivot input was empty)
+        raw_in_pivot = [c for c in value_cols_info if c in forecast_pivoted.columns]
+        if raw_in_pivot:
+            forecast_pivoted = forecast_pivoted.drop(raw_in_pivot)
 
         # Filter to observation_times only (left join preserves order)
         obs_df = pl.DataFrame({"time": observation_times})

--- a/tests/base/test_derive_step_columns.py
+++ b/tests/base/test_derive_step_columns.py
@@ -190,3 +190,78 @@ class TestDeriveStepColumns:
         assert result.shape == (1, 4)
         assert result["wind_step_1"].to_list() == [5.0]
         assert result["wind_step_3"].to_list() == [7.0]
+
+    # --- Forecast horizon filtering ---
+
+    def test_forecast_timestamps_beyond_horizon_are_filtered(self):
+        """Vintage with more timestamps than fh keeps only those within the window."""
+        # 5 hourly forecasts but fh=3: only the first 3 hours after obs should survive
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1)] * 5,
+            "time": [datetime(2020, 1, 1, h) for h in range(1, 6)],
+            "temp": [10.0, 11.0, 12.0, 13.0, 14.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1)])
+        result = _derive_step_columns(None, X_forecast, obs, 3, "1h")
+
+        assert result is not None
+        step_cols = [c for c in result.columns if c != "time"]
+        assert step_cols == ["temp_step_1", "temp_step_2", "temp_step_3"]
+        assert result["temp_step_1"].to_list() == [10.0]
+        assert result["temp_step_3"].to_list() == [12.0]
+
+    def test_forecast_exactly_h_timestamps_unchanged(self):
+        """Vintage with exactly H timestamps within the window passes through."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1)] * 3,
+            "time": [datetime(2020, 1, 1, h) for h in range(1, 4)],
+            "temp": [10.0, 11.0, 12.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1)])
+        result = _derive_step_columns(None, X_forecast, obs, 3, "1h")
+
+        assert result is not None
+        step_cols = [c for c in result.columns if c != "time"]
+        assert step_cols == ["temp_step_1", "temp_step_2", "temp_step_3"]
+        assert result["temp_step_1"].to_list() == [10.0]
+        assert result["temp_step_3"].to_list() == [12.0]
+
+    def test_short_vintage_emits_warning(self):
+        """Vintage with fewer timestamps than fh emits UserWarning."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1)] * 2,
+            "time": [datetime(2020, 1, 1, 1), datetime(2020, 1, 1, 2)],
+            "temp": [10.0, 11.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1)])
+
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = _derive_step_columns(None, X_forecast, obs, 5, "1h")
+
+        user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
+        assert len(user_warnings) == 1
+        msg = str(user_warnings[0].message)
+        assert "2" in msg
+        assert "5" in msg
+        assert result is not None
+
+    def test_no_warning_when_steps_cover_horizon(self):
+        """No warning emitted when vintages have >= H timestamps."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1)] * 3,
+            "time": [datetime(2020, 1, 1, h) for h in range(1, 4)],
+            "temp": [10.0, 11.0, 12.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1)])
+
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _derive_step_columns(None, X_forecast, obs, 3, "1h")
+
+        user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
+        assert len(user_warnings) == 0

--- a/tests/base/test_derive_step_columns.py
+++ b/tests/base/test_derive_step_columns.py
@@ -248,6 +248,24 @@ class TestDeriveStepColumns:
         assert "5" in msg
         assert result is not None
 
+    def test_all_forecast_timestamps_beyond_horizon_returns_nulls(self):
+        """All timestamps beyond the horizon window → all step columns null."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1)] * 2,
+            "time": [datetime(2020, 1, 1, 10), datetime(2020, 1, 1, 11)],
+            "temp": [99.0, 100.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1)])
+        result = _derive_step_columns(None, X_forecast, obs, 3, "1h")
+
+        assert result is not None
+        step_cols = [c for c in result.columns if c != "time"]
+        assert sorted(step_cols) == ["temp_step_1", "temp_step_2", "temp_step_3"]
+        # All values should be null since nothing survived filtering
+        assert result["temp_step_1"][0] is None
+        assert result["temp_step_2"][0] is None
+        assert result["temp_step_3"][0] is None
+
     def test_no_warning_when_steps_cover_horizon(self):
         """No warning emitted when vintages have >= H timestamps."""
         X_forecast = pl.DataFrame({


### PR DESCRIPTION
## Description

Filter X_forecast rows to timestamps within `(vintage_time, vintage_time + H * interval]` before pivoting in `_derive_step_columns`. Add a safety net schema filter in `_observe_with_precomputed_steps_panel` for per-slice step count variation during walk-forward evaluation. Emit `UserWarning` when forecast vintages cover fewer steps than `forecasting_horizon`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`pivot_forecasts()` determines step column count from data (`max_step = data["_step"].max()`), ignoring `forecasting_horizon`. Vintages with more timestamps than the horizon produce extra step features the model trains on but can never use at prediction time. This also causes schema mismatches during walk-forward evaluation when train and test vintages have different lengths.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly