### PR TITLE
fix(interval): override observe_predict_interval in SplitConformalForecaster

### DIFF
--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -622,6 +622,103 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             **params,
         )
 
+    def observe_predict_interval(
+        self,
+        y: pl.DataFrame,
+        X_actual: pl.DataFrame | None = None,
+        forecasting_horizon: StrictInt | None = None,
+        coverage_rates: list[float] | None = None,
+        strategy: Literal["mean", "median", "point"] | None = None,
+        groups: list[str] | None = None,
+        stride: StrictInt | None = None,
+        X_future: pl.DataFrame | None = None,
+        X_forecast: pl.DataFrame | None = None,
+        **params,
+    ) -> pl.DataFrame:
+        """Alternate recursive observe and predict_interval.
+
+        Equivalent to calling ``observe(y, X_actual)`` then
+        ``predict_interval()``.  Returns interval predictions.
+
+        Overrides the parent implementation to pass ``observe_fn`` so that
+        the wrapped ``point_forecaster_`` observation state is correctly
+        advanced at each stride step.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            Target time series with a ``"time"`` column (datetime) and one
+            or more numeric value columns.
+        X_actual : pl.DataFrame or None, default=None
+            Actual feature observations with a ``"time"`` column aligned
+            with ``y``. Sliced and observed incrementally at each step
+            of the rolling loop.
+        forecasting_horizon : int or None, default=None
+            Number of time steps to forecast into the future.  If ``None``,
+            uses the horizon specified at fit time.
+        coverage_rates : list of float or None, default=None
+            Coverage levels for prediction intervals (e.g., ``[0.9, 0.95]``
+            for 90 % and 95 % intervals).  If ``None``, defaults to the rates
+            used at fit time.
+        strategy : {"mean", "median", "point"} or None, default=None
+            Strategy for deriving point predictions from prediction intervals
+            during recursive multi-step forecasting.
+        groups : list of str or None, default=None
+            Panel group prefixes to operate on.  If ``None``, all groups
+            are used.
+        stride : int or None, default=None
+            Step size for rolling update-predict.  If ``None``, defaults to
+            ``forecasting_horizon``.
+        X_future : pl.DataFrame or None, default=None
+            Known future features with a ``"time"`` column.
+        X_forecast : pl.DataFrame or None, default=None
+            External forecasts with ``"vintage_time"`` and ``"time"``
+            columns.
+        **params : dict
+            Metadata to route to nested estimators.
+
+        Returns
+        -------
+        pl.DataFrame
+            Interval predictions with ``"vintage_time"``, ``"time"``, and
+            lower/upper bound columns for each target at each coverage rate.
+
+        """
+        check_is_fitted(
+            self,
+            ["local_y_schema_", "local_X_actual_schema_", "shared_X_actual_schema_", "groups_"],
+        )
+
+        y, X_actual, groups = validate_forecaster_data(
+            self,
+            y=y,
+            X_actual=X_actual,
+            reset=False,
+            groups=groups,
+            X_future=X_future,
+            X_forecast=X_forecast,
+        )
+
+        forecasting_horizon, _ = self._validate_predict_params(forecasting_horizon, coverage_rates)
+
+        if stride is None:
+            stride = self.fit_forecasting_horizon_
+
+        return self._observe_predict_loop(
+            predict_fn=self.predict_interval,
+            y=y,
+            X_actual=X_actual,
+            X_future=X_future,
+            X_forecast=X_forecast,
+            groups=groups,
+            stride=stride,
+            observe_fn=self.observe,
+            forecasting_horizon=forecasting_horizon,
+            coverage_rates=coverage_rates,
+            strategy=strategy,
+            **params,
+        )
+
     def _weighted_inverse_score(
         self,
         y_pred_step: pl.DataFrame,

--- a/src/yohou/testing/forecaster.py
+++ b/src/yohou/testing/forecaster.py
@@ -26,6 +26,7 @@ __all__ = [
     "check_requires_exogenous_warns_on_X_future_X_forecast",
     "check_observe_auto_rederives_step_columns",
     "check_observe_extends_observations",
+    "check_observe_predict_interval_with_step_columns",
     "check_observe_predict_with_step_columns",
     "check_predict_time_columns",
     "check_predict_X_forecast_override",
@@ -1323,6 +1324,83 @@ def check_observe_predict_with_step_columns(
     assert "time" in y_pred.columns, "observe_predict() output must contain 'time' column"
     assert "vintage_time" in y_pred.columns, "observe_predict() output must contain 'vintage_time' column"
     assert len(y_pred) > 0, "observe_predict() must return non-empty DataFrame"
+
+
+def check_observe_predict_interval_with_step_columns(
+    forecaster,
+    y_train: pl.DataFrame,
+    X_actual_train: pl.DataFrame | None,
+    y_test: pl.DataFrame,
+    X_actual_test: pl.DataFrame | None = None,
+    X_future: pl.DataFrame | None = None,
+    X_forecast: pl.DataFrame | None = None,
+    forecasting_horizon: int = 3,
+    coverage_rates: list[float] | None = None,
+) -> None:
+    """Check observe_predict_interval works with step columns (lightweight).
+
+    Runs observe_predict_interval with stride=len(y_test)//2 (2 iterations)
+    and validates output structure and per-vintage time sorting.
+
+    Parameters
+    ----------
+    forecaster : BaseForecaster
+        Unfitted interval forecaster instance.
+    y_train : pl.DataFrame
+        Training target data.
+    X_actual_train : pl.DataFrame or None
+        Training features.
+    y_test : pl.DataFrame
+        Test target data (at least 10 rows).
+    X_actual_test : pl.DataFrame or None
+        Test features.
+    X_future : pl.DataFrame or None
+        Known-future features.
+    X_forecast : pl.DataFrame or None
+        External forecasts.
+    forecasting_horizon : int, default=3
+        Number of steps ahead.
+    coverage_rates : list of float or None, default=None
+        Coverage rates for prediction intervals. Defaults to [0.9].
+
+    """
+    if coverage_rates is None:
+        coverage_rates = [0.9]
+
+    forecaster_clone = clone(forecaster)
+    forecaster_clone.fit(
+        y_train,
+        X_actual_train,
+        forecasting_horizon=forecasting_horizon,
+        coverage_rates=coverage_rates,
+        X_future=X_future,
+        X_forecast=X_forecast,
+    )
+
+    stride = max(1, len(y_test) // 2)
+    y_pred = forecaster_clone.observe_predict_interval(
+        y_test,
+        X_actual=X_actual_test,
+        forecasting_horizon=forecasting_horizon,
+        coverage_rates=coverage_rates,
+        stride=stride,
+        X_future=X_future,
+        X_forecast=X_forecast,
+    )
+
+    assert isinstance(y_pred, pl.DataFrame), (
+        f"observe_predict_interval() must return pl.DataFrame, got {type(y_pred).__name__}"
+    )
+    assert "time" in y_pred.columns, "observe_predict_interval() output must contain 'time' column"
+    assert "vintage_time" in y_pred.columns, "observe_predict_interval() output must contain 'vintage_time' column"
+    assert len(y_pred) > 0, "observe_predict_interval() must return non-empty DataFrame"
+
+    # Validate per-vintage time sorting (catches stale observation state bugs)
+    for vt in y_pred["vintage_time"].unique():
+        vintage = y_pred.filter(pl.col("vintage_time") == vt)
+        assert vintage["time"].is_sorted(), (
+            f"'time' column within vintage_time={vt} is not sorted in ascending order"
+        )
 
 
 def check_requires_exogenous_warns_on_X_future_X_forecast(

--- a/src/yohou/testing/forecaster.py
+++ b/src/yohou/testing/forecaster.py
@@ -1398,9 +1398,7 @@ def check_observe_predict_interval_with_step_columns(
     # Validate per-vintage time sorting (catches stale observation state bugs)
     for vt in y_pred["vintage_time"].unique():
         vintage = y_pred.filter(pl.col("vintage_time") == vt)
-        assert vintage["time"].is_sorted(), (
-            f"'time' column within vintage_time={vt} is not sorted in ascending order"
-        )
+        assert vintage["time"].is_sorted(), f"'time' column within vintage_time={vt} is not sorted in ascending order"
 
 
 def check_requires_exogenous_warns_on_X_future_X_forecast(

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -240,9 +240,7 @@ class TestSplitConformalObserveRewind:
         # Each vintage must have sorted time (regression test for stale point_forecaster_ state)
         for vt in y_pred["vintage_time"].unique():
             vintage = y_pred.filter(pl.col("vintage_time") == vt)
-            assert vintage["time"].is_sorted(), (
-                f"'time' within vintage_time={vt} is not sorted"
-            )
+            assert vintage["time"].is_sorted(), f"'time' within vintage_time={vt} is not sorted"
 
     def test_rewind(self, conformal_data):
         """Test that rewind delegates to the wrapped forecaster."""

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -221,6 +221,29 @@ class TestSplitConformalObserveRewind:
         assert isinstance(y_pred, pl.DataFrame)
         assert len(y_pred) >= 1
 
+    def test_observe_predict_interval_multi_step(self, conformal_data):
+        """Test observe_predict_interval with forecasting_horizon > 1 produces sorted vintages."""
+        scf = SplitConformalForecaster(calibration_size=50)
+        fh = 3
+        scf.fit(conformal_data[:200], forecasting_horizon=fh, coverage_rates=[0.9])
+
+        y_test = conformal_data[200:210]
+        y_pred = scf.observe_predict_interval(
+            y=y_test,
+            forecasting_horizon=fh,
+            coverage_rates=[0.9],
+        )
+        assert isinstance(y_pred, pl.DataFrame)
+        assert "vintage_time" in y_pred.columns
+        assert len(y_pred) > fh
+
+        # Each vintage must have sorted time (regression test for stale point_forecaster_ state)
+        for vt in y_pred["vintage_time"].unique():
+            vintage = y_pred.filter(pl.col("vintage_time") == vt)
+            assert vintage["time"].is_sorted(), (
+                f"'time' within vintage_time={vt} is not sorted"
+            )
+
     def test_rewind(self, conformal_data):
         """Test that rewind delegates to the wrapped forecaster."""
         scf = SplitConformalForecaster(calibration_size=50)

--- a/tests/testing/test_forecaster.py
+++ b/tests/testing/test_forecaster.py
@@ -24,6 +24,7 @@ from yohou.testing.forecaster import (
     check_forecasting_horizon_validation,
     check_observe_auto_rederives_step_columns,
     check_observe_extends_observations,
+    check_observe_predict_interval_with_step_columns,
     check_observe_predict_with_step_columns,
     check_predict_time_columns,
     check_predict_X_forecast_override,
@@ -394,6 +395,29 @@ class TestStepColumnChecks:
         )
         forecaster = PointReductionForecaster()
         check_observe_predict_with_step_columns(
+            forecaster,
+            y[:60],
+            X[:60],
+            y[60:80],
+            X_actual_test=X[60:80],
+            X_future=X_future,
+            X_forecast=X_forecast,
+            forecasting_horizon=3,
+        )
+
+    def test_check_observe_predict_interval_with_step_columns(self, y_X_factory):
+        """check_observe_predict_interval_with_step_columns passes for a conformal forecaster."""
+        y, X, X_future, X_forecast = y_X_factory(
+            length=80,
+            n_targets=1,
+            n_features=2,
+            seed=42,
+            n_future_features=2,
+            n_forecast_features=2,
+            return_exogenous=True,
+        )
+        forecaster = SplitConformalForecaster(calibration_size=20)
+        check_observe_predict_interval_with_step_columns(
             forecaster,
             y[:60],
             X[:60],


### PR DESCRIPTION
## Description

Override `observe_predict_interval` in `SplitConformalForecaster` to pass `observe_fn=self.observe`, ensuring the wrapped `point_forecaster_` observation state advances correctly at each stride step.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

The parent `IntervalForecaster.observe_predict_interval` uses `_observe_predict_loop` without passing `observe_fn`. This causes the loop to use the precomputed steps path that updates `self` directly but leaves `self.point_forecaster_` stale. Every subsequent `predict_interval` call produces predictions from the same `observed_time_`, resulting in duplicate `vintage_time` values with unsorted time columns within each vintage.

The `observe_predict` method already had this fix (passing `observe_fn=self.observe`), but `observe_predict_interval` was missing the same override.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Also adds `check_observe_predict_interval_with_step_columns` to the systematic testing module and a `test_observe_predict_interval_multi_step` regression test that validates per-vintage time sorting with `forecasting_horizon > 1`.