### PR TITLE
feat(forecaster): replace exact vintage matching with as-of selection

### DIFF
--- a/docs/pages/how-to/exogenous-features.md
+++ b/docs/pages/how-to/exogenous-features.md
@@ -198,6 +198,59 @@ forecaster.observe(y=y_new, X_actual=X_actual_new)
 pred = forecaster.predict(X_future=holidays_new, X_forecast=weather_new)
 ```
 
+## As-of Vintage Selection
+
+`X_forecast` uses **as-of (backward) matching**: for each observation time
+$T$, the forecaster selects the latest vintage $V$ where $V \leq T$, then
+extracts forecast values at $T + 1 \cdot \Delta t$ through
+$T + H \cdot \Delta t$ from that vintage's rows. This means vintage times
+do not need to align exactly with observation times.
+
+### Sparse vintage schedules
+
+External forecast providers often publish on a coarser schedule than your
+observation frequency. For example, a weather model might issue forecasts
+every 6 hours while you observe hourly. With as-of matching, each hourly
+observation automatically picks up the most recent 6-hourly vintage:
+
+```text
+Vintages:     V0=00:00          V1=06:00          V2=12:00
+              |                 |                 |
+Observations: 00 01 02 03 04 05 06 07 08 09 10 11 12 ...
+              ↑                 ↑
+              uses V0            uses V1
+```
+
+Observation at 03:00 uses vintage V0 (00:00) because that is the latest
+vintage at or before 03:00. Observation at 09:00 uses vintage V1 (06:00).
+
+### Step alignment
+
+Step columns are always relative to the **observation time**, not the
+vintage time. For observation $T$ with a matched vintage $V$:
+
+- `step_1` = forecast value at $T + 1 \cdot \Delta t$
+- `step_2` = forecast value at $T + 2 \cdot \Delta t$
+- ...
+- `step_H` = forecast value at $T + H \cdot \Delta t$
+
+If the vintage does not cover a particular target time (because the
+forecast did not extend that far), the corresponding step column is null.
+
+### Null step columns
+
+Null step columns are expected in two situations:
+
+1. **No vintage available**: the observation time is before all vintage
+   times in `X_forecast`. All step columns are null for that row.
+2. **Partial coverage**: the matched vintage's forecast horizon does not
+   reach $T + h \cdot \Delta t$. Later step columns are null.
+
+Tree-based estimators (XGBoost, LightGBM, HistGradientBoosting) handle
+null features natively. For estimators that require complete data, set
+`nan_handling="drop"` so rows with null step features are excluded from
+training.
+
 ## Pickle and Restore
 
 The three-parameter state (step column names, observation window) survives
@@ -250,3 +303,5 @@ pred = restored.predict(X_forecast=new_vintage)
   introduction
 - [`pivot_forecasts` API Reference](../api/utils.md): utility for manual
   forecast pivoting
+- [`window_forecasts` API Reference](../api/utils.md): utility for as-of
+  vintage matching with step alignment

--- a/src/yohou/base/forecaster.py
+++ b/src/yohou/base/forecaster.py
@@ -444,7 +444,9 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
             Bypasses the feature transformer.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"``
-            columns. Pivoted by ordinal rank within each vintage group.
+            columns. Vintage times do not need to align exactly with
+            observation times; the latest vintage at or before each
+            observation time is selected automatically (as-of matching).
             Bypasses the feature transformer.
         **params : dict
             Metadata to route to nested estimators.
@@ -563,6 +565,9 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
             Known future features with a ``"time"`` column.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"`` columns.
+            Vintage times do not need to align exactly with observation
+            times; the latest vintage at or before ``observed_time_`` is
+            selected automatically (as-of matching).
 
         Returns
         -------
@@ -638,6 +643,9 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
             Known future features with a ``"time"`` column.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"`` columns.
+            Vintage times do not need to align exactly with observation
+            times; the latest vintage at or before ``observed_time_`` is
+            selected automatically (as-of matching).
 
         Returns
         -------

--- a/src/yohou/base/forecaster.py
+++ b/src/yohou/base/forecaster.py
@@ -273,7 +273,8 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
         X_future : pl.DataFrame or None, default=None
             Known future features with a ``"time"`` column.
         X_forecast : pl.DataFrame or None, default=None
-            External forecasts with ``"vintage_time"`` and ``"time"`` columns.
+            External forecasts. See ``fit()`` for full parameter
+            description.
 
         Returns
         -------
@@ -369,8 +370,8 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
         X_future : pl.DataFrame or None, default=None
             Known future features with a ``"time"`` column.
         X_forecast : pl.DataFrame or None, default=None
-            External forecasts with ``"vintage_time"`` and ``"time"``
-            columns.
+            External forecasts. See ``fit()`` for full parameter
+            description.
 
         Returns
         -------
@@ -711,7 +712,8 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
         X_future : pl.DataFrame or None
             Known future features override. If None, uses stored raw.
         X_forecast : pl.DataFrame or None
-            External forecast override. If None, uses stored raw.
+            External forecast override. See ``predict()`` for full
+            parameter description. If None, uses stored raw.
         predict_fn : callable
             ``predict_fn() -> pl.DataFrame``. Called with overridden state.
 

--- a/src/yohou/base/panel.py
+++ b/src/yohou/base/panel.py
@@ -449,6 +449,9 @@ class BasePanelForecaster:
             Known future features. If None, re-derived from stored raws.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"`` columns.
+            The latest vintage at or before the observation time is
+            selected (as-of matching), so vintage times do not need
+            to align exactly with observation times.
 
         Returns
         -------
@@ -549,7 +552,14 @@ class BasePanelForecaster:
         if X_future is not None:
             self._X_future_raw_ = X_future
         if X_forecast is not None:
-            self._X_forecast_raw_ = X_forecast.filter(pl.col("vintage_time") == obs_time)
+            # Select the latest vintage at or before observed_time_ (as-of selection)
+            latest_vintage = (
+                X_forecast.filter(pl.col("vintage_time") <= obs_time)["vintage_time"].max()
+            )
+            if latest_vintage is not None:
+                self._X_forecast_raw_ = X_forecast.filter(pl.col("vintage_time") == latest_vintage)
+            else:
+                self._X_forecast_raw_ = X_forecast.clear()
 
     def _observe_with_precomputed_steps_panel(
         self,

--- a/src/yohou/base/panel.py
+++ b/src/yohou/base/panel.py
@@ -553,9 +553,7 @@ class BasePanelForecaster:
             self._X_future_raw_ = X_future
         if X_forecast is not None:
             # Select the latest vintage at or before observed_time_ (as-of selection)
-            latest_vintage = (
-                X_forecast.filter(pl.col("vintage_time") <= obs_time)["vintage_time"].max()
-            )
+            latest_vintage = X_forecast.filter(pl.col("vintage_time") <= obs_time)["vintage_time"].max()
             if latest_vintage is not None:
                 self._X_forecast_raw_ = X_forecast.filter(pl.col("vintage_time") == latest_vintage)
             else:

--- a/src/yohou/base/standard.py
+++ b/src/yohou/base/standard.py
@@ -361,9 +361,7 @@ class BaseStandardForecaster:
             self._X_future_raw_ = X_future
         if X_forecast is not None:
             # Select the latest vintage at or before observed_time_ (as-of selection)
-            latest_vintage = (
-                X_forecast.filter(pl.col("vintage_time") <= self.observed_time_)["vintage_time"].max()
-            )
+            latest_vintage = X_forecast.filter(pl.col("vintage_time") <= self.observed_time_)["vintage_time"].max()
             if latest_vintage is not None:
                 self._X_forecast_raw_ = X_forecast.filter(pl.col("vintage_time") == latest_vintage)
             else:

--- a/src/yohou/base/standard.py
+++ b/src/yohou/base/standard.py
@@ -296,6 +296,9 @@ class BaseStandardForecaster:
             Known future features. If None, re-derived from stored raws.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts. If None, re-derived from stored raws.
+            The latest vintage at or before ``observed_time_`` is
+            selected (as-of matching), so vintage times do not need
+            to align exactly with observation times.
 
         Returns
         -------
@@ -357,7 +360,14 @@ class BaseStandardForecaster:
         if X_future is not None:
             self._X_future_raw_ = X_future
         if X_forecast is not None:
-            self._X_forecast_raw_ = X_forecast.filter(pl.col("vintage_time") == self.observed_time_)
+            # Select the latest vintage at or before observed_time_ (as-of selection)
+            latest_vintage = (
+                X_forecast.filter(pl.col("vintage_time") <= self.observed_time_)["vintage_time"].max()
+            )
+            if latest_vintage is not None:
+                self._X_forecast_raw_ = X_forecast.filter(pl.col("vintage_time") == latest_vintage)
+            else:
+                self._X_forecast_raw_ = X_forecast.clear()
 
     def _observe_with_precomputed_steps_standard(
         self,

--- a/src/yohou/base/utils.py
+++ b/src/yohou/base/utils.py
@@ -356,8 +356,7 @@ def _derive_step_columns(
         or appears in both X_future and X_forecast sources.
 
     """
-    from yohou.utils.pivot import pivot_forecasts, window_forecasts, window_futures  # noqa: PLC0415
-    from yohou.utils.validation import add_interval  # noqa: PLC0415
+    from yohou.utils.pivot import window_forecasts, window_futures  # noqa: PLC0415
 
     if X_future is None and X_forecast is None:
         return None
@@ -376,7 +375,10 @@ def _derive_step_columns(
         # Use as-of vintage selection: for each observation time T, select
         # the latest vintage V <= T, then extract values at T+1..T+H.
         forecast_pivoted = window_forecasts(
-            X_forecast, observation_times, forecasting_horizon, interval,
+            X_forecast,
+            observation_times,
+            forecasting_horizon,
+            interval,
         )
 
         # Determine value columns and their dtypes for padding

--- a/src/yohou/base/utils.py
+++ b/src/yohou/base/utils.py
@@ -356,7 +356,7 @@ def _derive_step_columns(
         or appears in both X_future and X_forecast sources.
 
     """
-    from yohou.utils.pivot import pivot_forecasts, window_futures  # noqa: PLC0415
+    from yohou.utils.pivot import pivot_forecasts, window_forecasts, window_futures  # noqa: PLC0415
     from yohou.utils.validation import add_interval  # noqa: PLC0415
 
     if X_future is None and X_forecast is None:
@@ -373,40 +373,32 @@ def _derive_step_columns(
         parts.append(future_pivoted)
 
     if X_forecast is not None:
-        # Filter each vintage to timestamps within its forecasting horizon
-        # window: (vintage_time, vintage_time + H * interval].
-        # The predict path remaps vintage_time to observed_time_ before
-        # calling, so this correctly clips to the model's prediction window.
-        unique_vintages = X_forecast["vintage_time"].unique().to_list()
-        cutoffs = {vt: add_interval(vt, interval, n=forecasting_horizon) for vt in unique_vintages}
-        cutoff_df = pl.DataFrame({
-            "vintage_time": list(cutoffs.keys()),
-            "_cutoff": list(cutoffs.values()),
-        })
-        X_forecast_filtered = (
-            X_forecast
-            .join(cutoff_df, on="vintage_time", how="left")
-            .filter((pl.col("time") > pl.col("vintage_time")) & (pl.col("time") <= pl.col("_cutoff")))
-            .drop("_cutoff")
+        # Use as-of vintage selection: for each observation time T, select
+        # the latest vintage V <= T, then extract values at T+1..T+H.
+        forecast_pivoted = window_forecasts(
+            X_forecast, observation_times, forecasting_horizon, interval,
         )
-
-        forecast_pivoted = pivot_forecasts(X_forecast_filtered)
 
         # Determine value columns and their dtypes for padding
         value_cols_info = {c: X_forecast[c].dtype for c in X_forecast.columns if c not in ("vintage_time", "time")}
 
-        # Warn if any vintage has fewer steps than the forecasting horizon
+        # Warn if any value column has step columns that are entirely null,
+        # indicating the matched vintage(s) don't cover the full horizon.
         import re  # noqa: PLC0415
 
         step_cols_forecast = [c for c in forecast_pivoted.columns if c != "time" and re.search(r"_step_\d+$", c)]
         if step_cols_forecast:
-            step_nums = [int(m.group(1)) for c in step_cols_forecast if (m := re.search(r"_step_(\d+)$", c))]
-            max_step = max(step_nums) if step_nums else 0
-            if max_step < forecasting_horizon:
+            # Find the highest step number that has at least one non-null value
+            max_covered = 0
+            for c in step_cols_forecast:
+                m = re.search(r"_step_(\d+)$", c)
+                if m and forecast_pivoted[c].null_count() < len(forecast_pivoted):
+                    max_covered = max(max_covered, int(m.group(1)))
+            if max_covered < forecasting_horizon:
                 import warnings  # noqa: PLC0415
 
                 warnings.warn(
-                    f"X_forecast covers {max_step} of {forecasting_horizon} "
+                    f"X_forecast covers {max_covered} of {forecasting_horizon} "
                     f"forecast steps. The remaining step features will be null. "
                     f"This is normal for short-range forecasts or when the "
                     f"observation point has advanced past some forecast "
@@ -426,14 +418,6 @@ def _derive_step_columns(
         if missing_exprs:
             forecast_pivoted = forecast_pivoted.with_columns(missing_exprs)
 
-        # Drop raw value columns (present when pivot input was empty)
-        raw_in_pivot = [c for c in value_cols_info if c in forecast_pivoted.columns]
-        if raw_in_pivot:
-            forecast_pivoted = forecast_pivoted.drop(raw_in_pivot)
-
-        # Filter to observation_times only (left join preserves order)
-        obs_df = pl.DataFrame({"time": observation_times})
-        forecast_pivoted = obs_df.join(forecast_pivoted, on="time", how="left")
         step_cols = [c for c in forecast_pivoted.columns if c != "time"]
         for c in step_cols:
             if c in source_names:

--- a/src/yohou/interval/base.py
+++ b/src/yohou/interval/base.py
@@ -280,7 +280,10 @@ class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             values available for past and future dates.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"``
-            columns.
+            columns. Vintage times do not need to align exactly with
+            observation times; the latest vintage at or before each
+            observation time is selected automatically (as-of matching).
+            Bypasses the feature transformer.
         **params : dict
             Metadata to route to nested estimators.
 
@@ -400,8 +403,8 @@ class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             without mutating forecaster state.
         X_forecast : pl.DataFrame or None, default=None
             External forecast override with ``"vintage_time"`` and
-            ``"time"`` columns. Re-derives step columns without mutating
-            forecaster state.
+            ``"time"`` columns. Re-derives step columns using as-of
+            matching without mutating forecaster state.
         forecasting_horizon : int or None, default=None
             Number of time steps to forecast into the future.  If ``None``,
             uses the horizon specified at fit time.

--- a/src/yohou/point/base.py
+++ b/src/yohou/point/base.py
@@ -87,7 +87,10 @@ class BasePointForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             feature transformer.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"``
-            columns. Bypasses the feature transformer.
+            columns. Vintage times do not need to align exactly with
+            observation times; the latest vintage at or before each
+            observation time is selected automatically (as-of matching).
+            Bypasses the feature transformer.
         **params : dict
             Metadata to route to nested estimators.
 
@@ -158,8 +161,8 @@ class BasePointForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             without mutating forecaster state.
         X_forecast : pl.DataFrame or None, default=None
             External forecast override with ``"vintage_time"`` and
-            ``"time"`` columns. Re-derives step columns without mutating
-            forecaster state.
+            ``"time"`` columns. Re-derives step columns using as-of
+            matching without mutating forecaster state.
         forecasting_horizon : int or None, default=None
             Number of time steps to forecast into the future.  If ``None``,
             uses the horizon specified at fit time.
@@ -279,7 +282,9 @@ class BasePointForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             Known future features with a ``"time"`` column.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"``
-            columns.
+            columns. Vintage times do not need to align exactly with
+            observation times; the latest vintage at or before each
+            observation time is selected automatically (as-of matching).
         **params : dict
             Metadata to route to nested estimators.
 

--- a/src/yohou/stationarity/base.py
+++ b/src/yohou/stationarity/base.py
@@ -92,7 +92,8 @@ class _BaseTrendForecaster(BasePointForecaster):
         X_future : pl.DataFrame or None, default=None
             Known future features.
         X_forecast : pl.DataFrame or None, default=None
-            External forecasts.
+            External forecasts. See ``fit()`` for full parameter
+            description.
 
         Returns
         -------
@@ -148,7 +149,9 @@ class _BaseTrendForecaster(BasePointForecaster):
             Known future features with a ``"time"`` column.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"``
-            columns.
+            columns. Vintage times do not need to align exactly with
+            observation times; the latest vintage at or before each
+            observation time is selected automatically (as-of matching).
 
         Returns
         -------

--- a/src/yohou/utils/pivot.py
+++ b/src/yohou/utils/pivot.py
@@ -8,7 +8,7 @@ import polars as pl
 
 from yohou.utils.validation import add_interval
 
-__all__ = ["pivot_forecasts", "window_futures"]
+__all__ = ["pivot_forecasts", "window_forecasts", "window_futures"]
 
 
 def pivot_forecasts(
@@ -243,5 +243,194 @@ def window_futures(
 
     result = joined.group_by("vintage_time", maintain_order=True).agg(pivot_exprs)
     result = result.rename({"vintage_time": "time"})
+
+    return result
+
+
+def window_forecasts(
+    X_forecast: pl.DataFrame,
+    observation_times: pl.Series,
+    forecasting_horizon: int,
+    interval: str | timedelta,
+    *,
+    vintage_col: str = "vintage_time",
+    time_col: str = "time",
+) -> pl.DataFrame:
+    """Window forecast data into step-indexed columns using as-of vintage selection.
+
+    For each observation time T, selects the latest vintage V where V <= T
+    (as-of / backward match), then extracts forecast values at
+    ``T + 1*interval`` through ``T + H*interval`` from that vintage's rows.
+    The result is a wide DataFrame with step columns aligned to observation
+    times, not vintage times.
+
+    This differs from `pivot_forecasts` which assigns steps by ordinal rank
+    within each vintage group. ``window_forecasts`` aligns steps to the
+    observation time, making it suitable for training with sparse vintage
+    schedules (e.g., 6-hourly weather forecasts with hourly observations).
+
+    Parameters
+    ----------
+    X_forecast : pl.DataFrame
+        Tidy forecast DataFrame with ``vintage_col``, ``time_col``, and one
+        or more value columns. Each row is a single forecast value at a
+        specific target time from a specific vintage.
+    observation_times : pl.Series
+        Series of observation timestamps. One output row per observation time.
+    forecasting_horizon : int
+        Number of forward steps (H) to extract per observation time.
+    interval : str or timedelta
+        Time frequency between steps (e.g., ``"1h"``, ``"1d"``).
+    vintage_col : str, default="vintage_time"
+        Name of the column identifying when the forecast was issued.
+    time_col : str, default="time"
+        Name of the column identifying the target time of each forecast value.
+
+    Returns
+    -------
+    pl.DataFrame
+        Wide DataFrame with ``[time, <col>_step_1, ..., <col>_step_H]``.
+        One row per observation time. Step columns are null when no vintage
+        is available at or before the observation time, or when the matched
+        vintage does not cover that step's target time.
+
+    Raises
+    ------
+    ValueError
+        If ``vintage_col`` or ``time_col`` is not in ``X_forecast``.
+    ValueError
+        If ``forecasting_horizon`` is not positive.
+    ValueError
+        If no value columns remain after removing ``vintage_col`` and ``time_col``.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from datetime import datetime
+    >>> X_forecast = pl.DataFrame({
+    ...     "vintage_time": [datetime(2020, 1, 1, 0)] * 3 + [datetime(2020, 1, 1, 6)] * 3,
+    ...     "time": [datetime(2020, 1, 1, 1), datetime(2020, 1, 1, 2), datetime(2020, 1, 1, 3)] * 2,
+    ...     "temp": [10.0, 11.0, 12.0, 15.0, 16.0, 17.0],
+    ... })
+    >>> obs = pl.Series([datetime(2020, 1, 1, 0), datetime(2020, 1, 1, 3)])
+    >>> window_forecasts(X_forecast, obs, forecasting_horizon=2, interval="1h")
+    shape: (2, 3)
+    ┌─────────────────────┬─────────────┬─────────────┐
+    │ time                ┆ temp_step_1 ┆ temp_step_2 │
+    │ ---                 ┆ ---         ┆ ---         │
+    │ datetime[μs]        ┆ f64         ┆ f64         │
+    ╞═════════════════════╪═════════════╪═════════════╡
+    │ 2020-01-01 00:00:00 ┆ 10.0        ┆ 11.0        │
+    │ 2020-01-01 03:00:00 ┆ null        ┆ null        │
+    └─────────────────────┴─────────────┴─────────────┘
+
+    """
+    if vintage_col not in X_forecast.columns:
+        msg = f"Column '{vintage_col}' not found in DataFrame. Available columns: {X_forecast.columns}"
+        raise ValueError(msg)
+    if time_col not in X_forecast.columns:
+        msg = f"Column '{time_col}' not found in DataFrame. Available columns: {X_forecast.columns}"
+        raise ValueError(msg)
+    if forecasting_horizon < 1:
+        msg = f"forecasting_horizon must be positive, got {forecasting_horizon}."
+        raise ValueError(msg)
+
+    value_cols = [c for c in X_forecast.columns if c not in (vintage_col, time_col)]
+    if not value_cols:
+        msg = (
+            f"No value columns found. DataFrame has only '{vintage_col}' and "
+            f"'{time_col}'. At least one value column is required."
+        )
+        raise ValueError(msg)
+
+    # Build null result schema for empty / no-match cases
+    def _null_result() -> pl.DataFrame:
+        cols: dict[str, pl.Series] = {"time": observation_times}
+        for col in value_cols:
+            for step in range(1, forecasting_horizon + 1):
+                cols[f"{col}_step_{step}"] = pl.Series(
+                    [None] * len(observation_times),
+                    dtype=X_forecast[col].dtype,
+                )
+        return pl.DataFrame(cols)
+
+    if X_forecast.is_empty() or observation_times.is_empty():
+        return _null_result()
+
+    # As-of join: for each observation time, find the latest vintage <= T
+    obs_df = pl.DataFrame({"time": observation_times}).sort("time")
+    vintage_keys = (
+        X_forecast.select(vintage_col)
+        .unique()
+        .sort(vintage_col)
+        .rename({vintage_col: "_vintage"})
+    )
+
+    matched = obs_df.join_asof(
+        vintage_keys,
+        left_on="time",
+        right_on="_vintage",
+        strategy="backward",
+    )
+    # matched has columns: time, _vintage (the matched vintage or null)
+
+    # Build lookup rows: for each (obs_time, matched_vintage), target times T+1..T+H
+    rows: list[dict] = []
+    for obs_time, vintage in zip(
+        matched["time"].to_list(),
+        matched["_vintage"].to_list(),
+    ):
+        if vintage is None:
+            continue
+        for step in range(1, forecasting_horizon + 1):
+            target_time = add_interval(obs_time, interval, n=step)
+            rows.append({
+                "_obs_time": obs_time,
+                vintage_col: vintage,
+                time_col: target_time,
+                "_step": step,
+            })
+
+    if not rows:
+        return _null_result()
+
+    lookup = pl.DataFrame(rows)
+
+    # Join lookup with X_forecast to get values at each target time from the matched vintage
+    joined = lookup.join(
+        X_forecast,
+        on=[vintage_col, time_col],
+        how="left",
+    )
+
+    # Pivot to wide format
+    pivot_exprs: list[pl.Expr] = []
+    for step in range(1, forecasting_horizon + 1):
+        for col in value_cols:
+            pivot_exprs.append(
+                pl.when(pl.col("_step") == step)
+                .then(pl.col(col))
+                .otherwise(None)
+                .max()
+                .alias(f"{col}_step_{step}")
+            )
+
+    result = joined.group_by("_obs_time", maintain_order=True).agg(pivot_exprs)
+    result = result.rename({"_obs_time": "time"})
+
+    # Left join back to observation_times to ensure all obs times are present
+    # (some may have had no matching vintage)
+    obs_all = pl.DataFrame({"time": observation_times})
+    result = obs_all.join(result, on="time", how="left")
+
+    # Ensure all step columns exist (fill missing with null for unmatched obs times)
+    missing_exprs = []
+    for col in value_cols:
+        for step in range(1, forecasting_horizon + 1):
+            step_name = f"{col}_step_{step}"
+            if step_name not in result.columns:
+                missing_exprs.append(pl.lit(None).cast(X_forecast[col].dtype).alias(step_name))
+    if missing_exprs:
+        result = result.with_columns(missing_exprs)
 
     return result

--- a/src/yohou/utils/pivot.py
+++ b/src/yohou/utils/pivot.py
@@ -345,6 +345,7 @@ def window_forecasts(
 
     # Build null result schema for empty / no-match cases
     def _null_result() -> pl.DataFrame:
+        """Return an all-null DataFrame with the expected step column schema."""
         cols: dict[str, pl.Series] = {"time": observation_times}
         for col in value_cols:
             for step in range(1, forecasting_horizon + 1):
@@ -359,12 +360,7 @@ def window_forecasts(
 
     # As-of join: for each observation time, find the latest vintage <= T
     obs_df = pl.DataFrame({"time": observation_times}).sort("time")
-    vintage_keys = (
-        X_forecast.select(vintage_col)
-        .unique()
-        .sort(vintage_col)
-        .rename({vintage_col: "_vintage"})
-    )
+    vintage_keys = X_forecast.select(vintage_col).unique().sort(vintage_col).rename({vintage_col: "_vintage"})
 
     matched = obs_df.join_asof(
         vintage_keys,
@@ -379,6 +375,7 @@ def window_forecasts(
     for obs_time, vintage in zip(
         matched["time"].to_list(),
         matched["_vintage"].to_list(),
+        strict=True,
     ):
         if vintage is None:
             continue
@@ -408,11 +405,7 @@ def window_forecasts(
     for step in range(1, forecasting_horizon + 1):
         for col in value_cols:
             pivot_exprs.append(
-                pl.when(pl.col("_step") == step)
-                .then(pl.col(col))
-                .otherwise(None)
-                .max()
-                .alias(f"{col}_step_{step}")
+                pl.when(pl.col("_step") == step).then(pl.col(col)).otherwise(None).max().alias(f"{col}_step_{step}")
             )
 
     result = joined.group_by("_obs_time", maintain_order=True).agg(pivot_exprs)
@@ -422,15 +415,5 @@ def window_forecasts(
     # (some may have had no matching vintage)
     obs_all = pl.DataFrame({"time": observation_times})
     result = obs_all.join(result, on="time", how="left")
-
-    # Ensure all step columns exist (fill missing with null for unmatched obs times)
-    missing_exprs = []
-    for col in value_cols:
-        for step in range(1, forecasting_horizon + 1):
-            step_name = f"{col}_step_{step}"
-            if step_name not in result.columns:
-                missing_exprs.append(pl.lit(None).cast(X_forecast[col].dtype).alias(step_name))
-    if missing_exprs:
-        result = result.with_columns(missing_exprs)
 
     return result

--- a/tests/base/test_derive_step_columns.py
+++ b/tests/base/test_derive_step_columns.py
@@ -289,14 +289,8 @@ class TestDeriveStepColumns:
     def test_sparse_vintage_asof_selection(self):
         """6-hourly vintages with hourly observations use as-of matching."""
         X_forecast = pl.DataFrame({
-            "vintage_time": (
-                [datetime(2020, 1, 1, 0)] * 3
-                + [datetime(2020, 1, 1, 6)] * 3
-            ),
-            "time": (
-                [datetime(2020, 1, 1, h) for h in range(1, 4)]
-                + [datetime(2020, 1, 1, h) for h in range(7, 10)]
-            ),
+            "vintage_time": ([datetime(2020, 1, 1, 0)] * 3 + [datetime(2020, 1, 1, 6)] * 3),
+            "time": ([datetime(2020, 1, 1, h) for h in range(1, 4)] + [datetime(2020, 1, 1, h) for h in range(7, 10)]),
             "temp": [10.0, 11.0, 12.0, 20.0, 21.0, 22.0],
         })
         obs = pl.Series([

--- a/tests/base/test_derive_step_columns.py
+++ b/tests/base/test_derive_step_columns.py
@@ -283,3 +283,50 @@ class TestDeriveStepColumns:
 
         user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
         assert len(user_warnings) == 0
+
+    # --- Sparse vintage schedules (as-of selection) ---
+
+    def test_sparse_vintage_asof_selection(self):
+        """6-hourly vintages with hourly observations use as-of matching."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": (
+                [datetime(2020, 1, 1, 0)] * 3
+                + [datetime(2020, 1, 1, 6)] * 3
+            ),
+            "time": (
+                [datetime(2020, 1, 1, h) for h in range(1, 4)]
+                + [datetime(2020, 1, 1, h) for h in range(7, 10)]
+            ),
+            "temp": [10.0, 11.0, 12.0, 20.0, 21.0, 22.0],
+        })
+        obs = pl.Series([
+            datetime(2020, 1, 1, 0),  # uses vintage 00:00
+            datetime(2020, 1, 1, 3),  # uses vintage 00:00 (latest <= 03:00)
+            datetime(2020, 1, 1, 6),  # uses vintage 06:00
+        ])
+        result = _derive_step_columns(None, X_forecast, obs, 2, "1h")
+
+        assert result is not None
+        assert result.shape == (3, 3)
+        # obs 00:00 → vintage 00:00 → step_1=val@01:00=10, step_2=val@02:00=11
+        assert result["temp_step_1"][0] == 10.0
+        assert result["temp_step_2"][0] == 11.0
+        # obs 03:00 → vintage 00:00 → step_1=val@04:00=null (not in forecast)
+        assert result["temp_step_1"][1] is None
+        # obs 06:00 → vintage 06:00 → step_1=val@07:00=20, step_2=val@08:00=21
+        assert result["temp_step_1"][2] == 20.0
+        assert result["temp_step_2"][2] == 21.0
+
+    def test_no_vintage_before_observation_produces_nulls(self):
+        """Observation before all vintages gets null step columns."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1, 6)] * 2,
+            "time": [datetime(2020, 1, 1, 7), datetime(2020, 1, 1, 8)],
+            "temp": [10.0, 11.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1, 3)])
+        result = _derive_step_columns(None, X_forecast, obs, 2, "1h")
+
+        assert result is not None
+        assert result["temp_step_1"][0] is None
+        assert result["temp_step_2"][0] is None

--- a/tests/base/test_observe_asof_vintage.py
+++ b/tests/base/test_observe_asof_vintage.py
@@ -1,0 +1,137 @@
+"""Tests for as-of vintage selection in observe() / _inject_step_columns_after_update."""
+
+from datetime import datetime, timedelta
+
+import polars as pl
+import pytest
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+from yohou.point import PointReductionForecaster
+from yohou.preprocessing import LagTransformer
+
+
+FREQ = "1h"
+H = 3
+N_TRAIN = 50
+SEED = 42
+
+
+def _make_y(times: pl.Series) -> pl.DataFrame:
+    return pl.DataFrame({"time": times, "y": [float(i) for i in range(len(times))]})
+
+
+def _make_x_forecast(
+    vintage_times: list[datetime],
+    forecast_start_offsets: list[int],
+    n_steps: int,
+) -> pl.DataFrame:
+    """Build X_forecast with given vintage times and forecast target times.
+
+    Each vintage covers n_steps hourly timestamps starting from the vintage time
+    plus the corresponding offset.
+    """
+    rows = []
+    for vt, offset in zip(vintage_times, forecast_start_offsets):
+        for s in range(n_steps):
+            rows.append({
+                "vintage_time": vt,
+                "time": vt + timedelta(hours=offset + s),
+                "temp": float(100 * vt.hour + s),
+            })
+    return pl.DataFrame(rows)
+
+
+def _make_x_forecast_aligned(times: pl.Series, h: int) -> pl.DataFrame:
+    """Build X_forecast with one vintage per observation time, each covering h steps."""
+    rows = []
+    for i in range(len(times)):
+        vt = times[i]
+        for s in range(1, h + 1):
+            rows.append({
+                "vintage_time": vt,
+                "time": vt + timedelta(hours=s),
+                "temp": float(100 * i + s),
+            })
+    return pl.DataFrame(rows)
+
+
+def _fit_forecaster() -> PointReductionForecaster:
+    """Fit a minimal forecaster with X_forecast support."""
+    train_times = pl.Series("time", [datetime(2020, 1, 1) + timedelta(hours=i) for i in range(N_TRAIN)])
+    y_train = _make_y(train_times)
+    x_fc = _make_x_forecast_aligned(train_times, H)
+
+    f = PointReductionForecaster(
+        estimator=HistGradientBoostingRegressor(max_iter=10, random_state=SEED),
+        feature_transformer=LagTransformer([1, 2]),
+        reduction_strategy="direct",
+    )
+    f.fit(y_train, forecasting_horizon=H, X_forecast=x_fc)
+    return f
+
+
+class TestObserveAsofVintageSelection:
+    """Verify _X_forecast_raw_ stores the as-of vintage (latest V <= obs_time)."""
+
+    def test_exact_match_vintage(self):
+        """When vintage_time == observed_time_, exact vintage is selected."""
+        f = _fit_forecaster()
+        # Observe the next hour after training ends (hour 49 is last train)
+        obs_time = datetime(2020, 1, 1) + timedelta(hours=N_TRAIN)
+        y_obs = pl.DataFrame({"time": [obs_time], "y": [999.0]})
+        x_fc = _make_x_forecast([obs_time], [1], H)
+
+        f.observe(y_obs, X_forecast=x_fc)
+
+        assert f._X_forecast_raw_ is not None
+        assert len(f._X_forecast_raw_) == H
+        assert f._X_forecast_raw_["vintage_time"][0] == obs_time
+
+    def test_earlier_vintage_selected(self):
+        """When no exact match, latest vintage before obs_time is selected."""
+        f = _fit_forecaster()
+        obs_time = datetime(2020, 1, 1) + timedelta(hours=N_TRAIN)
+        # Vintage 2 hours earlier than observation
+        vintage = obs_time - timedelta(hours=2)
+        x_fc = _make_x_forecast([vintage], [1], H)
+
+        f.observe(
+            pl.DataFrame({"time": [obs_time], "y": [999.0]}),
+            X_forecast=x_fc,
+        )
+
+        assert f._X_forecast_raw_ is not None
+        assert len(f._X_forecast_raw_) == H
+        assert f._X_forecast_raw_["vintage_time"][0] == vintage
+
+    def test_multiple_vintages_picks_latest_before_obs(self):
+        """With multiple vintages, the latest one at or before obs_time is used."""
+        f = _fit_forecaster()
+        obs_time = datetime(2020, 1, 1) + timedelta(hours=N_TRAIN)
+        v1 = obs_time - timedelta(hours=6)
+        v2 = obs_time - timedelta(hours=1)
+        v3 = obs_time + timedelta(hours=6)  # future, should not be selected
+        x_fc = _make_x_forecast([v1, v2, v3], [1, 1, 1], H)
+
+        f.observe(
+            pl.DataFrame({"time": [obs_time], "y": [999.0]}),
+            X_forecast=x_fc,
+        )
+
+        assert f._X_forecast_raw_ is not None
+        assert f._X_forecast_raw_["vintage_time"][0] == v2
+
+    def test_no_vintage_before_obs_produces_empty(self):
+        """When all vintages are after obs_time, _X_forecast_raw_ is empty."""
+        f = _fit_forecaster()
+        obs_time = datetime(2020, 1, 1) + timedelta(hours=N_TRAIN)
+        future_vintage = obs_time + timedelta(hours=6)
+        x_fc = _make_x_forecast([future_vintage], [1], H)
+
+        f.observe(
+            pl.DataFrame({"time": [obs_time], "y": [999.0]}),
+            X_forecast=x_fc,
+        )
+
+        assert f._X_forecast_raw_ is not None
+        assert len(f._X_forecast_raw_) == 0

--- a/tests/base/test_observe_asof_vintage.py
+++ b/tests/base/test_observe_asof_vintage.py
@@ -135,3 +135,85 @@ class TestObserveAsofVintageSelection:
 
         assert f._X_forecast_raw_ is not None
         assert len(f._X_forecast_raw_) == 0
+
+
+class TestPanelObserveAsofVintageSelection:
+    """Verify as-of vintage selection works for panel forecasters."""
+
+    @staticmethod
+    def _fit_panel_forecaster() -> PointReductionForecaster:
+        """Fit a minimal panel forecaster with X_forecast."""
+        train_times = pl.Series(
+            "time",
+            [datetime(2020, 1, 1) + timedelta(hours=i) for i in range(N_TRAIN)],
+        )
+        y_train = pl.DataFrame({
+            "time": train_times,
+            "store_a__sales": [float(i) for i in range(N_TRAIN)],
+            "store_b__sales": [float(i + 100) for i in range(N_TRAIN)],
+        })
+        # Build panel X_forecast with one vintage per observation
+        rows = []
+        for i in range(N_TRAIN):
+            vt = train_times[i]
+            for s in range(1, H + 1):
+                rows.append({
+                    "vintage_time": vt,
+                    "time": vt + timedelta(hours=s),
+                    "store_a__temp": float(100 * i + s),
+                    "store_b__temp": float(200 * i + s),
+                })
+        x_fc = pl.DataFrame(rows)
+
+        f = PointReductionForecaster(
+            estimator=HistGradientBoostingRegressor(max_iter=10, random_state=SEED),
+            feature_transformer=LagTransformer([1, 2]),
+            reduction_strategy="direct",
+        )
+        f.fit(y_train, forecasting_horizon=H, X_forecast=x_fc)
+        return f
+
+    def test_panel_no_vintage_before_obs_produces_empty(self):
+        """Panel: all vintages after obs_time produces empty _X_forecast_raw_."""
+        f = self._fit_panel_forecaster()
+        obs_time = datetime(2020, 1, 1) + timedelta(hours=N_TRAIN)
+        y_obs = pl.DataFrame({
+            "time": [obs_time],
+            "store_a__sales": [999.0],
+            "store_b__sales": [888.0],
+        })
+        future_vintage = obs_time + timedelta(hours=6)
+        x_fc = pl.DataFrame({
+            "vintage_time": [future_vintage] * H,
+            "time": [future_vintage + timedelta(hours=s) for s in range(1, H + 1)],
+            "store_a__temp": [1.0] * H,
+            "store_b__temp": [2.0] * H,
+        })
+
+        f.observe(y_obs, X_forecast=x_fc)
+
+        assert f._X_forecast_raw_ is not None
+        assert len(f._X_forecast_raw_) == 0
+
+    def test_panel_earlier_vintage_selected(self):
+        """Panel: latest vintage before obs_time is selected."""
+        f = self._fit_panel_forecaster()
+        obs_time = datetime(2020, 1, 1) + timedelta(hours=N_TRAIN)
+        vintage = obs_time - timedelta(hours=2)
+        y_obs = pl.DataFrame({
+            "time": [obs_time],
+            "store_a__sales": [999.0],
+            "store_b__sales": [888.0],
+        })
+        x_fc = pl.DataFrame({
+            "vintage_time": [vintage] * H,
+            "time": [vintage + timedelta(hours=s) for s in range(1, H + 1)],
+            "store_a__temp": [1.0] * H,
+            "store_b__temp": [2.0] * H,
+        })
+
+        f.observe(y_obs, X_forecast=x_fc)
+
+        assert f._X_forecast_raw_ is not None
+        assert len(f._X_forecast_raw_) == H
+        assert f._X_forecast_raw_["vintage_time"][0] == vintage

--- a/tests/base/test_observe_asof_vintage.py
+++ b/tests/base/test_observe_asof_vintage.py
@@ -3,12 +3,10 @@
 from datetime import datetime, timedelta
 
 import polars as pl
-import pytest
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 from yohou.point import PointReductionForecaster
 from yohou.preprocessing import LagTransformer
-
 
 FREQ = "1h"
 H = 3
@@ -31,7 +29,7 @@ def _make_x_forecast(
     plus the corresponding offset.
     """
     rows = []
-    for vt, offset in zip(vintage_times, forecast_start_offsets):
+    for vt, offset in zip(vintage_times, forecast_start_offsets, strict=True):
         for s in range(n_steps):
             rows.append({
                 "vintage_time": vt,

--- a/tests/integration/test_exogenous_forecast_e2e.py
+++ b/tests/integration/test_exogenous_forecast_e2e.py
@@ -886,3 +886,65 @@ class TestMismatchedVintageOverride:
         assert step_before.equals(step_after), (
             "Step columns in _X_t_observed were not restored after predict(X_forecast=...) returned"
         )
+
+
+@pytest.mark.integration
+class TestSparseVintageSchedule:
+    """Integration test: 6h vintage schedule with hourly observations."""
+
+    def test_fit_observe_predict_with_sparse_vintages(self):
+        """Fit with 6h vintages, observe hourly, predict with non-null step columns."""
+        rng = np.random.default_rng(SEED)
+        n_train = 200
+        n_test = 12
+        h = 6
+        vintage_interval_hours = 6
+        n_total = n_train + n_test
+
+        times = pl.Series("time", [datetime(2024, 1, 1) + timedelta(hours=i) for i in range(n_total)])
+        t = np.arange(n_total, dtype=float)
+        y_vals = 50.0 + 2.0 * np.sin(2 * np.pi * t / 24) + rng.normal(0, 0.5, n_total)
+        y = pl.DataFrame({"time": times, "price": y_vals})
+
+        # Build X_forecast with 6h vintage schedule (vintages at hours 0, 6, 12, 18, ...)
+        forecast_rows = []
+        for i in range(0, n_total, vintage_interval_hours):
+            vt = times[i]
+            for step in range(1, h + 1):
+                target_idx = i + step
+                if target_idx < n_total:
+                    forecast_rows.append({
+                        "vintage_time": vt,
+                        "time": times[target_idx],
+                        "wx_temp": float(np.sin(2 * np.pi * target_idx / 24) + rng.normal(0, 0.3)),
+                    })
+        x_forecast = pl.DataFrame(forecast_rows)
+
+        y_train = y[:n_train]
+        x_fc_train = x_forecast.filter(pl.col("vintage_time").is_in(times[:n_train]))
+
+        f = PointReductionForecaster(
+            estimator=HistGradientBoostingRegressor(max_iter=50, max_depth=3, random_state=SEED),
+            feature_transformer=LagTransformer([1, 2, 3]),
+            reduction_strategy="direct",
+        )
+        f.fit(y=y_train, forecasting_horizon=h, X_forecast=x_fc_train)
+
+        assert len(f._step_column_names_) > 0
+        assert f._X_forecast_raw_ is not None
+
+        # Observe hourly for the test period (sparse vintages mean as-of matching)
+        obs_time = times[n_train]
+        y_obs = pl.DataFrame({"time": [obs_time], "price": [y_vals[n_train]]})
+        x_fc_obs = x_forecast.filter(
+            pl.col("vintage_time").is_in(times[n_train - vintage_interval_hours : n_train + 1])
+        )
+        f.observe(y=y_obs, X_forecast=x_fc_obs)
+
+        # Step columns should be non-null (as-of should find a vintage)
+        step_cols_in_X = [c for c in f._X_t_observed.columns if "_step_" in c]
+        assert len(step_cols_in_X) > 0
+
+        pred = f.predict()
+        assert len(pred) == h
+        assert "price" in pred.columns

--- a/tests/utils/test_window_forecasts.py
+++ b/tests/utils/test_window_forecasts.py
@@ -219,3 +219,19 @@ class TestWindowForecasts:
 
         assert "store_A__temp_step_1" in result.columns
         assert "store_A__temp_step_2" in result.columns
+
+    def test_all_obs_before_all_vintages_produces_all_nulls(self):
+        """Non-empty X_forecast but all obs before all vintages returns all nulls."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1, 6)] * 2,
+            "time": [datetime(2020, 1, 1, 7), datetime(2020, 1, 1, 8)],
+            "temp": [10.0, 11.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1, 0), datetime(2020, 1, 1, 3)])
+        result = window_forecasts(X_forecast, obs, forecasting_horizon=2, interval="1h")
+
+        assert result.shape == (2, 3)
+        assert result["temp_step_1"][0] is None
+        assert result["temp_step_1"][1] is None
+        assert result["temp_step_2"][0] is None
+        assert result["temp_step_2"][1] is None

--- a/tests/utils/test_window_forecasts.py
+++ b/tests/utils/test_window_forecasts.py
@@ -16,9 +16,12 @@ class TestWindowForecasts:
         X_forecast = pl.DataFrame({
             "vintage_time": [datetime(2020, 1, 1, h) for h in range(3) for _ in range(2)],
             "time": [
-                datetime(2020, 1, 1, 1), datetime(2020, 1, 1, 2),
-                datetime(2020, 1, 1, 2), datetime(2020, 1, 1, 3),
-                datetime(2020, 1, 1, 3), datetime(2020, 1, 1, 4),
+                datetime(2020, 1, 1, 1),
+                datetime(2020, 1, 1, 2),
+                datetime(2020, 1, 1, 2),
+                datetime(2020, 1, 1, 3),
+                datetime(2020, 1, 1, 3),
+                datetime(2020, 1, 1, 4),
             ],
             "temp": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
         })
@@ -33,14 +36,8 @@ class TestWindowForecasts:
         """6-hourly vintages with hourly observation times."""
         # Vintage at 00:00 covers hours 1..48, vintage at 06:00 covers hours 7..54
         X_forecast = pl.DataFrame({
-            "vintage_time": (
-                [datetime(2020, 1, 1, 0)] * 10
-                + [datetime(2020, 1, 1, 6)] * 10
-            ),
-            "time": (
-                [datetime(2020, 1, 1, h) for h in range(1, 11)]
-                + [datetime(2020, 1, 1, h) for h in range(7, 17)]
-            ),
+            "vintage_time": ([datetime(2020, 1, 1, 0)] * 10 + [datetime(2020, 1, 1, 6)] * 10),
+            "time": ([datetime(2020, 1, 1, h) for h in range(1, 11)] + [datetime(2020, 1, 1, h) for h in range(7, 17)]),
             "temp": list(range(20)),
         })
         obs = pl.Series([

--- a/tests/utils/test_window_forecasts.py
+++ b/tests/utils/test_window_forecasts.py
@@ -1,0 +1,221 @@
+"""Tests for window_forecasts utility."""
+
+from datetime import datetime, timedelta
+
+import polars as pl
+import pytest
+
+from yohou.utils.pivot import window_forecasts
+
+
+class TestWindowForecasts:
+    """Tests for the window_forecasts utility function."""
+
+    def test_exact_vintage_match_backward_compat(self):
+        """1:1 vintage alignment produces same result as exact match."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1, h) for h in range(3) for _ in range(2)],
+            "time": [
+                datetime(2020, 1, 1, 1), datetime(2020, 1, 1, 2),
+                datetime(2020, 1, 1, 2), datetime(2020, 1, 1, 3),
+                datetime(2020, 1, 1, 3), datetime(2020, 1, 1, 4),
+            ],
+            "temp": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1, h) for h in range(3)])
+        result = window_forecasts(X_forecast, obs, forecasting_horizon=2, interval="1h")
+
+        assert result.shape == (3, 3)
+        assert result["temp_step_1"].to_list() == [10.0, 12.0, 14.0]
+        assert result["temp_step_2"].to_list() == [11.0, 13.0, 15.0]
+
+    def test_sparse_6h_vintages_with_hourly_observations(self):
+        """6-hourly vintages with hourly observation times."""
+        # Vintage at 00:00 covers hours 1..48, vintage at 06:00 covers hours 7..54
+        X_forecast = pl.DataFrame({
+            "vintage_time": (
+                [datetime(2020, 1, 1, 0)] * 10
+                + [datetime(2020, 1, 1, 6)] * 10
+            ),
+            "time": (
+                [datetime(2020, 1, 1, h) for h in range(1, 11)]
+                + [datetime(2020, 1, 1, h) for h in range(7, 17)]
+            ),
+            "temp": list(range(20)),
+        })
+        obs = pl.Series([
+            datetime(2020, 1, 1, 0),  # uses vintage 00:00
+            datetime(2020, 1, 1, 3),  # uses vintage 00:00 (latest <= 03:00)
+            datetime(2020, 1, 1, 6),  # uses vintage 06:00
+            datetime(2020, 1, 1, 9),  # uses vintage 06:00
+        ])
+        result = window_forecasts(X_forecast, obs, forecasting_horizon=2, interval="1h")
+
+        assert result.shape == (4, 3)
+        # obs 00:00 → vintage 00:00 → step_1=value at 01:00, step_2=value at 02:00
+        assert result["temp_step_1"][0] == 0.0  # hour 1 from vintage 00:00
+        assert result["temp_step_2"][0] == 1.0  # hour 2 from vintage 00:00
+        # obs 03:00 → vintage 00:00 → step_1=value at 04:00, step_2=value at 05:00
+        assert result["temp_step_1"][1] == 3.0  # hour 4 from vintage 00:00
+        assert result["temp_step_2"][1] == 4.0  # hour 5 from vintage 00:00
+        # obs 06:00 → vintage 06:00 → step_1=value at 07:00, step_2=value at 08:00
+        assert result["temp_step_1"][2] == 10.0  # hour 7 from vintage 06:00
+        assert result["temp_step_2"][2] == 11.0  # hour 8 from vintage 06:00
+        # obs 09:00 → vintage 06:00 → step_1=value at 10:00, step_2=value at 11:00
+        assert result["temp_step_1"][3] == 13.0  # hour 10 from vintage 06:00
+        assert result["temp_step_2"][3] == 14.0  # hour 11 from vintage 06:00
+
+    def test_no_vintage_before_observation_produces_nulls(self):
+        """Observation time before all vintages produces null steps."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1, 6)] * 2,
+            "time": [datetime(2020, 1, 1, 7), datetime(2020, 1, 1, 8)],
+            "temp": [10.0, 11.0],
+        })
+        obs = pl.Series([
+            datetime(2020, 1, 1, 3),  # before vintage 06:00 → null
+            datetime(2020, 1, 1, 6),  # at vintage 06:00 → has values
+        ])
+        result = window_forecasts(X_forecast, obs, forecasting_horizon=2, interval="1h")
+
+        assert result.shape == (2, 3)
+        assert result["temp_step_1"][0] is None
+        assert result["temp_step_2"][0] is None
+        assert result["temp_step_1"][1] == 10.0
+        assert result["temp_step_2"][1] == 11.0
+
+    def test_empty_x_forecast_produces_all_nulls(self):
+        """Empty X_forecast produces all-null step columns."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": pl.Series([], dtype=pl.Datetime("us")),
+            "time": pl.Series([], dtype=pl.Datetime("us")),
+            "temp": pl.Series([], dtype=pl.Float64),
+        })
+        obs = pl.Series([datetime(2020, 1, 1, 0), datetime(2020, 1, 1, 1)])
+        result = window_forecasts(X_forecast, obs, forecasting_horizon=2, interval="1h")
+
+        assert result.shape == (2, 3)
+        assert result["temp_step_1"][0] is None
+        assert result["temp_step_1"][1] is None
+        assert result["temp_step_2"][0] is None
+        assert result["temp_step_2"][1] is None
+
+    def test_partial_coverage_produces_partial_nulls(self):
+        """Vintage with fewer steps than horizon produces nulls for missing steps."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1, 0)] * 2,
+            "time": [datetime(2020, 1, 1, 1), datetime(2020, 1, 1, 2)],
+            "temp": [10.0, 11.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1, 0)])
+        result = window_forecasts(X_forecast, obs, forecasting_horizon=4, interval="1h")
+
+        assert result.shape == (1, 5)
+        assert result["temp_step_1"][0] == 10.0
+        assert result["temp_step_2"][0] == 11.0
+        assert result["temp_step_3"][0] is None
+        assert result["temp_step_4"][0] is None
+
+    def test_multiple_value_columns(self):
+        """Multiple value columns produce separate step columns."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1, 0)] * 2,
+            "time": [datetime(2020, 1, 1, 1), datetime(2020, 1, 1, 2)],
+            "temp": [10.0, 11.0],
+            "wind": [5.0, 6.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1, 0)])
+        result = window_forecasts(X_forecast, obs, forecasting_horizon=2, interval="1h")
+
+        assert result.shape == (1, 5)
+        assert result["temp_step_1"][0] == 10.0
+        assert result["wind_step_1"][0] == 5.0
+        assert result["temp_step_2"][0] == 11.0
+        assert result["wind_step_2"][0] == 6.0
+
+    def test_timedelta_interval(self):
+        """Accepts timedelta as interval."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1, 0)] * 2,
+            "time": [datetime(2020, 1, 1, 1), datetime(2020, 1, 1, 2)],
+            "temp": [10.0, 11.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1, 0)])
+        result = window_forecasts(X_forecast, obs, forecasting_horizon=2, interval=timedelta(hours=1))
+
+        assert result["temp_step_1"][0] == 10.0
+        assert result["temp_step_2"][0] == 11.0
+
+    def test_daily_interval(self):
+        """Works with daily interval."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1)] * 3,
+            "time": [datetime(2020, 1, 2), datetime(2020, 1, 3), datetime(2020, 1, 4)],
+            "temp": [10.0, 11.0, 12.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1)])
+        result = window_forecasts(X_forecast, obs, forecasting_horizon=3, interval="1d")
+
+        assert result["temp_step_1"][0] == 10.0
+        assert result["temp_step_2"][0] == 11.0
+        assert result["temp_step_3"][0] == 12.0
+
+    def test_observation_order_preserved(self):
+        """Output row order matches observation_times order."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1, 0)] * 3,
+            "time": [datetime(2020, 1, 1, h) for h in range(1, 4)],
+            "temp": [10.0, 11.0, 12.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1, 2), datetime(2020, 1, 1, 0), datetime(2020, 1, 1, 1)])
+        result = window_forecasts(X_forecast, obs, forecasting_horizon=1, interval="1h")
+
+        assert result["time"].to_list() == obs.to_list()
+
+    def test_missing_vintage_col_raises(self):
+        """Missing vintage_col raises ValueError."""
+        X_forecast = pl.DataFrame({"time": [datetime(2020, 1, 1)], "temp": [10.0]})
+        obs = pl.Series([datetime(2020, 1, 1)])
+        with pytest.raises(ValueError, match="vintage_time"):
+            window_forecasts(X_forecast, obs, forecasting_horizon=1, interval="1h")
+
+    def test_missing_time_col_raises(self):
+        """Missing time_col raises ValueError."""
+        X_forecast = pl.DataFrame({"vintage_time": [datetime(2020, 1, 1)], "temp": [10.0]})
+        obs = pl.Series([datetime(2020, 1, 1)])
+        with pytest.raises(ValueError, match="time"):
+            window_forecasts(X_forecast, obs, forecasting_horizon=1, interval="1h")
+
+    def test_no_value_columns_raises(self):
+        """No value columns raises ValueError."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1)],
+            "time": [datetime(2020, 1, 2)],
+        })
+        obs = pl.Series([datetime(2020, 1, 1)])
+        with pytest.raises(ValueError, match="No value columns"):
+            window_forecasts(X_forecast, obs, forecasting_horizon=1, interval="1h")
+
+    def test_invalid_forecasting_horizon_raises(self):
+        """Non-positive forecasting_horizon raises ValueError."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1)],
+            "time": [datetime(2020, 1, 2)],
+            "temp": [10.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1)])
+        with pytest.raises(ValueError, match="positive"):
+            window_forecasts(X_forecast, obs, forecasting_horizon=0, interval="1h")
+
+    def test_panel_prefixed_columns(self):
+        """Panel-prefixed value columns produce prefixed step names."""
+        X_forecast = pl.DataFrame({
+            "vintage_time": [datetime(2020, 1, 1, 0)] * 2,
+            "time": [datetime(2020, 1, 1, 1), datetime(2020, 1, 1, 2)],
+            "store_A__temp": [10.0, 11.0],
+        })
+        obs = pl.Series([datetime(2020, 1, 1, 0)])
+        result = window_forecasts(X_forecast, obs, forecasting_horizon=2, interval="1h")
+
+        assert "store_A__temp_step_1" in result.columns
+        assert "store_A__temp_step_2" in result.columns


### PR DESCRIPTION
## Description

Replace exact vintage matching with backward (as-of) selection across the fit and observe paths. Vintage times in `X_forecast` no longer need to align exactly with observation times; the latest vintage at or before each observation time is selected automatically via `join_asof(strategy="backward")`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

External forecast providers often publish vintages on a coarser schedule than the observation frequency (e.g. every 6 hours vs hourly observations). With exact matching, observation times without a matching vintage received no forecast features. As-of matching resolves this by carrying the most recent vintage forward.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

**Changes:**
- `pivot.py`: add `window_forecasts()` utility (14 unit tests)
- `utils.py`: replace `pivot_forecasts` + exact join in `_derive_step_columns` with `window_forecasts()` call; switch warning detection from column name based to null count based (2 new tests)
- `standard.py` / `panel.py`: change `observe()` vintage filter from `== observed_time_` to as-of selection (4 unit tests)
- `forecaster.py`: update `X_forecast` parameter docstrings for `fit()`, `observe()`, and `rewind()`
- Integration: add sparse vintage schedule test (1 test); all 32 existing integration tests pass unchanged