### PR TITLE
feat: make y_test optional in plot_forecast and fix weighted_quantile normalization

### DIFF
--- a/src/yohou/base/panel.py
+++ b/src/yohou/base/panel.py
@@ -692,7 +692,7 @@ class BasePanelForecaster:
             # Store X_t_observed for this group
             if X_t_observed is not None and X_t is not None:
                 X_t_group = X_t.get(panel_group_name)
-                X_t_observed[panel_group_name] = X_t_group[[-1]] if X_t_group is not None else None
+                X_t_observed[panel_group_name] = X_t_group.tail(1) if X_t_group is not None else None
 
         self._y_observed = y_observed
         self._X_t_observed = X_t_observed

--- a/src/yohou/base/reduction.py
+++ b/src/yohou/base/reduction.py
@@ -1062,11 +1062,11 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         assert self.local_X_t_schema_ is not None
         if panel_group_name is None:
             assert isinstance(self._X_t_observed, pl.DataFrame)
-            X_t = self._X_t_observed[[-1]].select(~cs.by_name("time"))
+            X_t = self._X_t_observed.tail(1).select(~cs.by_name("time"))
         else:
             assert isinstance(self._X_t_observed, dict)
             X_t_dict = typing_cast(dict[str, pl.DataFrame], self._X_t_observed)
-            X_t = X_t_dict[panel_group_name][[-1]].select(~cs.by_name("time"))
+            X_t = X_t_dict[panel_group_name].tail(1).select(~cs.by_name("time"))
         return X_t.select(list(self.local_X_t_schema_.keys()))
 
     def _reshape_predictions(

--- a/src/yohou/base/standard.py
+++ b/src/yohou/base/standard.py
@@ -157,7 +157,7 @@ class BaseStandardForecaster:
 
         self._X_t_observed = None
         if X_t is not None:
-            self._X_t_observed = X_t[[-1]]
+            self._X_t_observed = X_t.tail(1)
 
         # Store untransformed data for inverse_transform
         y_observed = None

--- a/src/yohou/base/utils.py
+++ b/src/yohou/base/utils.py
@@ -297,7 +297,7 @@ def _rewind_transformers_one(
         # directly on them raises NotFittedError because their fit() does
         # not set the base-class fitted attributes.
         X_t_all = feature_transformer.rewind_transform(X_feat_in)
-        X_t = X_t_all[[-1]]
+        X_t = X_t_all.tail(1)
 
     return X_t
 

--- a/src/yohou/interval/reduction.py
+++ b/src/yohou/interval/reduction.py
@@ -499,7 +499,7 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
         if self.groups_ is None:
             # Global data
             assert isinstance(self._X_t_observed, pl.DataFrame)
-            X_t = self._X_t_observed[[-1]].select(~cs.by_name("time"))
+            X_t = self._X_t_observed.tail(1).select(~cs.by_name("time"))
             assert self.local_X_t_schema_ is not None
             X_tab = X_t.select(list(self.local_X_t_schema_.keys())).to_numpy()
             y_raw = estimator.predict(X_tab)  # ty: ignore[unresolved-attribute]
@@ -521,7 +521,7 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
             panel_frames: list[pl.DataFrame] = []
             for group_name in groups:
                 assert isinstance(self._X_t_observed, dict)
-                X_t_group = self._X_t_observed[group_name][[-1]].select(~cs.by_name("time"))
+                X_t_group = self._X_t_observed[group_name].tail(1).select(~cs.by_name("time"))
                 X_tab = X_t_group.select(list(self.local_X_t_schema_.keys())).to_numpy()
                 y_raw = estimator.predict(X_tab)
 

--- a/src/yohou/interval/similarity.py
+++ b/src/yohou/interval/similarity.py
@@ -280,7 +280,8 @@ class DistanceSimilarity(BaseSimilarity):
         XA = X_features.select(pl.exclude("time")).to_numpy()
         XB = self._X_observed.select(pl.exclude("time")).to_numpy()
         distances: np.ndarray = cdist(XA, XB, metric=self.metric, **self.metric_params)  # ty: ignore[no-matching-overload]
-        weights = np.reciprocal(np.exp(distances))
+        neg_d = -distances
+        weights = np.exp(neg_d - np.max(neg_d, axis=1, keepdims=True))
 
         weights = weights / np.sum(weights, axis=1)[:, np.newaxis] * self._X_observed.shape[1]
         weights = weights / (1 + np.sum(weights, axis=1)[:, np.newaxis])

--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -771,13 +771,13 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             scale = (pred_val + epsilon) if multiplicative else 1.0
 
             if symmetric:
-                q = weighted_quantile(scores_col, coverage_rate, weights)
+                q = weighted_quantile(scores_col, 1.0 - coverage_rate, weights)
                 lower_data[col] = [pred_val - q * scale]
                 upper_data[col] = [pred_val + q * scale]
             else:
                 alpha = 1.0 - coverage_rate
-                lower_q = weighted_quantile(scores_col, alpha / 2.0, weights)
-                upper_q = weighted_quantile(scores_col, 1.0 - alpha / 2.0, weights)
+                lower_q = weighted_quantile(scores_col, 1.0 - alpha / 2.0, weights)
+                upper_q = weighted_quantile(scores_col, alpha / 2.0, weights)
                 lower_data[col] = [pred_val + lower_q * scale]
                 upper_data[col] = [pred_val + upper_q * scale]
 

--- a/src/yohou/interval/utils.py
+++ b/src/yohou/interval/utils.py
@@ -9,13 +9,19 @@ __all__ = ["weighted_quantile"]
 def weighted_quantile(x: npt.NDArray[np.float64], q: float, weights: npt.NDArray[np.float64]) -> float:
     """Compute weighted quantile using cumulative sum approach.
 
+    Weights are normalized to sum to 1 internally so that all quantile
+    levels are computable regardless of the raw weight magnitude.
+
     Parameters
     ----------
     x : np.ndarray
         Input array of values.
 
     q : float
-        Quantile to compute (between 0 and 1).
+        Quantile level to compute (between 0 and 1).  The function
+        returns the smallest value ``x[i]`` (in sorted order) such that
+        the cumulative normalized weight up to ``x[i]`` is at least
+        ``1 - q``.
 
     weights : np.ndarray
         Weights for each value in x (must match length of x).
@@ -23,17 +29,20 @@ def weighted_quantile(x: npt.NDArray[np.float64], q: float, weights: npt.NDArray
     Returns
     -------
     float
-        The weighted quantile value, or infinity if insufficient weight.
+        The weighted quantile value.
 
     """
     if len(x) != len(weights):
         raise ValueError(f"x and weights must have the same length, got {len(x)} and {len(weights)}")
-    if np.sum(weights) >= 1 - q:
-        x_ordered = np.argsort(x)
-        index_threshold = np.min(np.where(np.cumsum(weights[x_ordered]) >= 1 - q))
-        quantile = np.sort(x)[index_threshold]
 
-    else:
-        quantile = float("inf")
+    w_sum = np.sum(weights)
+    if w_sum == 0:
+        return float("inf")
 
-    return float(quantile)
+    # Normalize so the weighted CDF reaches 1, making all quantile levels computable
+    w_norm = weights / w_sum
+    # Sort scores ascending and reorder weights to match
+    x_ordered = np.argsort(x)
+    # Walk up the sorted scores until cumulative weight reaches the (1-q)-th level
+    index_threshold = np.min(np.where(np.cumsum(w_norm[x_ordered]) >= 1 - q))
+    return float(np.sort(x)[index_threshold])

--- a/src/yohou/plotting/forecasting.py
+++ b/src/yohou/plotting/forecasting.py
@@ -245,7 +245,7 @@ def plot_forecast(
     prediction_mode = _detect_prediction_mode(_first_pred)  # ty: ignore[invalid-argument-type]
 
     # Detect panel data (fall back to y_pred when y_test is not provided)
-    _panel_source = y_test if y_test is not None else _first_pred
+    _panel_source: pl.DataFrame = y_test if y_test is not None else _first_pred  # ty: ignore[invalid-assignment]
     _, _panels = inspect_panel(_panel_source)
     is_panel = bool(_panels)
 
@@ -338,11 +338,7 @@ def plot_forecast(
     # Non-panel, single-model case
     interval_pattern = re.compile(r"^.+_(lower|upper)_[\d.]+$")
     pred_value_cols = [c for c in y_pred.columns if c not in ("time", "vintage_time") and not interval_pattern.match(c)]
-
-    if y_test is not None:
-        test_value_cols = [c for c in y_test.columns if c != "time"]
-    else:
-        test_value_cols = list(pred_value_cols)
+    test_value_cols = [c for c in y_test.columns if c != "time"] if y_test is not None else list(pred_value_cols)
 
     # Apply columns filter
     if columns is not None:
@@ -1096,7 +1092,9 @@ def _plot_forecast_multi_model(
         test_value_cols = [c for c in y_test.columns if c != "time"]
     else:
         _any_pred = next(iter(y_preds.values()))
-        test_value_cols = [c for c in _any_pred.columns if c not in ("time", "vintage_time") and not interval_pattern.match(c)]
+        test_value_cols = [
+            c for c in _any_pred.columns if c not in ("time", "vintage_time") and not interval_pattern.match(c)
+        ]
 
     if columns is not None:
         col_list = [columns] if isinstance(columns, str) else list(columns)
@@ -1745,6 +1743,9 @@ def _plot_forecast_panel(
 
     """
     if prediction_mode != "numeric":
+        if y_test is None:
+            msg = "y_test is required for non-numeric panel predictions"
+            raise ValueError(msg)
         return _plot_forecast_panel_typed(
             y_test,
             y_pred,
@@ -1769,7 +1770,7 @@ def _plot_forecast_panel(
     _model_pal = eff_palette[3:] or eff_palette
 
     _first_pred = next(iter(y_pred.values())) if isinstance(y_pred, dict) else y_pred
-    _panel_source = y_test if y_test is not None else _first_pred
+    _panel_source: pl.DataFrame = y_test if y_test is not None else _first_pred  # ty: ignore[invalid-assignment]
     _, test_panels = inspect_panel(_panel_source)
 
     # Group panel columns by group prefix

--- a/src/yohou/plotting/forecasting.py
+++ b/src/yohou/plotting/forecasting.py
@@ -72,8 +72,8 @@ def _detect_prediction_mode(df: pl.DataFrame) -> str:
 
 
 def plot_forecast(
-    y_test: pl.DataFrame,
-    y_pred: pl.DataFrame | dict[str, pl.DataFrame],
+    y_test: pl.DataFrame | None = None,
+    y_pred: pl.DataFrame | dict[str, pl.DataFrame] | None = None,
     *,
     y_train: pl.DataFrame | None = None,
     columns: str | list[str] | None = None,
@@ -113,8 +113,9 @@ def plot_forecast(
 
     Parameters
     ----------
-    y_test : pl.DataFrame
-        Actual test values with 'time' column.
+    y_test : pl.DataFrame | None, default=None
+        Actual test values with 'time' column.  When ``None``, only
+        the forecast and interval traces are rendered (no "Actual" line).
     y_pred : pl.DataFrame | dict[str, pl.DataFrame]
         Forecast values with 'time' column. May also contain interval columns
         named ``{col}_lower_{rate}`` and ``{col}_upper_{rate}``.
@@ -220,7 +221,10 @@ def plot_forecast(
     [`plot_score_per_step`][yohou.plotting.plot_score_per_step] : Score by horizon step.
     """
     # Validate inputs
-    validate_plotting_data(y_test)
+    if y_pred is None:
+        raise TypeError("y_pred is required")
+    if y_test is not None:
+        validate_plotting_data(y_test)
     if isinstance(y_pred, dict):
         for _name, pred_df in y_pred.items():
             validate_plotting_data(pred_df)  # ty: ignore[invalid-argument-type]
@@ -236,13 +240,14 @@ def plot_forecast(
     forecast_color = eff_palette[1 % len(eff_palette)]
     actual_color = eff_palette[2 % len(eff_palette)]
 
-    # Detect panel data
-    _, y_test_panels = inspect_panel(y_test)
-    is_panel = bool(y_test_panels)
-
     # Auto-detect prediction type from the first prediction DataFrame
     _first_pred = next(iter(y_pred.values())) if isinstance(y_pred, dict) else y_pred
     prediction_mode = _detect_prediction_mode(_first_pred)  # ty: ignore[invalid-argument-type]
+
+    # Detect panel data (fall back to y_pred when y_test is not provided)
+    _panel_source = y_test if y_test is not None else _first_pred
+    _, _panels = inspect_panel(_panel_source)
+    is_panel = bool(_panels)
 
     # For panel data, delegate to faceted handler (single or multi-model)
     if is_panel:
@@ -272,6 +277,8 @@ def plot_forecast(
 
     # Non-panel class-probability predictions
     if prediction_mode == "class_proba":
+        if y_test is None:
+            raise ValueError("y_test is required for class-probability predictions")
         return _plot_forecast_class_proba(
             y_test=y_test,
             y_pred=y_pred,
@@ -287,6 +294,8 @@ def plot_forecast(
 
     # Non-panel categorical predictions
     if prediction_mode == "categorical":
+        if y_test is None:
+            raise ValueError("y_test is required for categorical predictions")
         return _plot_forecast_categorical(
             y_test=y_test,
             y_pred=y_pred,
@@ -329,7 +338,11 @@ def plot_forecast(
     # Non-panel, single-model case
     interval_pattern = re.compile(r"^.+_(lower|upper)_[\d.]+$")
     pred_value_cols = [c for c in y_pred.columns if c not in ("time", "vintage_time") and not interval_pattern.match(c)]
-    test_value_cols = [c for c in y_test.columns if c != "time"]
+
+    if y_test is not None:
+        test_value_cols = [c for c in y_test.columns if c != "time"]
+    else:
+        test_value_cols = list(pred_value_cols)
 
     # Apply columns filter
     if columns is not None:
@@ -413,25 +426,26 @@ def plot_forecast(
                         )
 
         # Actual test data (prepend last train point to close the gap)
-        _x_actual = y_test["time"]
-        _y_actual = y_test[col]
-        if y_train is not None and col in y_train.columns:
-            _x_actual = pl.concat([pl.Series("time", [y_train["time"][-1]]), _x_actual])
-            _y_actual = pl.concat([pl.Series([y_train[col][-1]], dtype=_y_actual.dtype), _y_actual])
-        ctx.fig.add_trace(
-            go.Scatter(
-                x=_x_actual,
-                y=_y_actual,
-                mode="lines",
-                line={"color": actual_color, "width": line_width},
-                connectgaps=connect_gaps,
-                name=f"{col} (Actual)",
-                legendrank=1,
-                hovertemplate=_make_hovertemplate(f"{col} Actual", "Time", "Value"),
-            ),
-            row=ctx.row,
-            col=ctx.col,
-        )
+        if y_test is not None and col in y_test.columns:
+            _x_actual = y_test["time"]
+            _y_actual = y_test[col]
+            if y_train is not None and col in y_train.columns:
+                _x_actual = pl.concat([pl.Series("time", [y_train["time"][-1]]), _x_actual])
+                _y_actual = pl.concat([pl.Series([y_train[col][-1]], dtype=_y_actual.dtype), _y_actual])
+            ctx.fig.add_trace(
+                go.Scatter(
+                    x=_x_actual,
+                    y=_y_actual,
+                    mode="lines",
+                    line={"color": actual_color, "width": line_width},
+                    connectgaps=connect_gaps,
+                    name=f"{col} (Actual)",
+                    legendrank=1,
+                    hovertemplate=_make_hovertemplate(f"{col} Actual", "Time", "Value"),
+                ),
+                row=ctx.row,
+                col=ctx.col,
+            )
 
         # Forecast
         if pred_col is not None and pred_col in y_pred.columns:
@@ -458,7 +472,7 @@ def plot_forecast(
             )
 
     fig = facet_figure(
-        y_test,
+        y_test if y_test is not None else y_pred,
         _render_forecast,
         columns=plot_columns,
         facet_n_cols=facet_n_cols,
@@ -1008,7 +1022,7 @@ def _plot_forecast_categorical(
 
 
 def _plot_forecast_multi_model(
-    y_test: pl.DataFrame,
+    y_test: pl.DataFrame | None,
     y_preds: dict[str, pl.DataFrame],
     *,
     y_train: pl.DataFrame | None,
@@ -1077,7 +1091,12 @@ def _plot_forecast_multi_model(
     _model_pal = eff_palette[3:] or eff_palette
 
     interval_pattern = re.compile(r"^.+_(lower|upper)_[\d.]+$")
-    test_value_cols = [c for c in y_test.columns if c != "time"]
+
+    if y_test is not None:
+        test_value_cols = [c for c in y_test.columns if c != "time"]
+    else:
+        _any_pred = next(iter(y_preds.values()))
+        test_value_cols = [c for c in _any_pred.columns if c not in ("time", "vintage_time") and not interval_pattern.match(c)]
 
     if columns is not None:
         col_list = [columns] if isinstance(columns, str) else list(columns)
@@ -1167,25 +1186,26 @@ def _plot_forecast_multi_model(
                         )
 
         # Actual test data (prepend last train point to close the gap)
-        _x_actual = y_test["time"]
-        _y_actual = y_test[col]
-        if y_train is not None and col in y_train.columns:
-            _x_actual = pl.concat([pl.Series("time", [y_train["time"][-1]]), _x_actual])
-            _y_actual = pl.concat([pl.Series([y_train[col][-1]], dtype=_y_actual.dtype), _y_actual])
-        ctx.fig.add_trace(
-            go.Scatter(
-                x=_x_actual,
-                y=_y_actual,
-                mode="lines",
-                line={"color": actual_color, "width": line_width},
-                connectgaps=connect_gaps,
-                name=f"{col} (Actual)",
-                legendrank=1,
-                hovertemplate=_make_hovertemplate("Actual", "Time", "Value"),
-            ),
-            row=ctx.row,
-            col=ctx.col,
-        )
+        if y_test is not None and col in y_test.columns:
+            _x_actual = y_test["time"]
+            _y_actual = y_test[col]
+            if y_train is not None and col in y_train.columns:
+                _x_actual = pl.concat([pl.Series("time", [y_train["time"][-1]]), _x_actual])
+                _y_actual = pl.concat([pl.Series([y_train[col][-1]], dtype=_y_actual.dtype), _y_actual])
+            ctx.fig.add_trace(
+                go.Scatter(
+                    x=_x_actual,
+                    y=_y_actual,
+                    mode="lines",
+                    line={"color": actual_color, "width": line_width},
+                    connectgaps=connect_gaps,
+                    name=f"{col} (Actual)",
+                    legendrank=1,
+                    hovertemplate=_make_hovertemplate("Actual", "Time", "Value"),
+                ),
+                row=ctx.row,
+                col=ctx.col,
+            )
 
         # Forecast lines per model (on top)
         for model_idx, (model_name, y_pred) in enumerate(y_preds.items()):
@@ -1219,7 +1239,7 @@ def _plot_forecast_multi_model(
             )
 
     fig = facet_figure(
-        y_test,
+        y_test if y_test is not None else next(iter(y_preds.values())),
         _render_multi_model,
         columns=plot_columns,
         facet_n_cols=facet_n_cols,
@@ -1645,7 +1665,7 @@ def _plot_forecast_panel_typed(
 
 
 def _plot_forecast_panel(
-    y_test: pl.DataFrame,
+    y_test: pl.DataFrame | None,
     y_pred: pl.DataFrame | dict[str, pl.DataFrame],
     *,
     y_train: pl.DataFrame | None,
@@ -1748,7 +1768,9 @@ def _plot_forecast_panel(
     forecast_color = eff_palette[1 % len(eff_palette)]
     _model_pal = eff_palette[3:] or eff_palette
 
-    _, test_panels = inspect_panel(y_test)
+    _first_pred = next(iter(y_pred.values())) if isinstance(y_pred, dict) else y_pred
+    _panel_source = y_test if y_test is not None else _first_pred
+    _, test_panels = inspect_panel(_panel_source)
 
     # Group panel columns by group prefix
     group_map: dict[str, list[str]] = {}
@@ -1927,7 +1949,7 @@ def _plot_forecast_panel(
             )
 
             # Actual
-            if col in y_test.columns:
+            if y_test is not None and col in y_test.columns:
                 if group_title is not None:
                     legend_kw = grouped_legend_kwargs(group_title, "Actual", legend_tracker, is_first_in_group=False)
                 else:

--- a/tests/interval/test_utils.py
+++ b/tests/interval/test_utils.py
@@ -44,13 +44,19 @@ class TestWeightedQuantile:
         result = weighted_quantile(x, q=0.5, weights=weights)
         assert isinstance(result, float)
 
-    def test_insufficient_weight_returns_inf(self):
-        """Test that insufficient weight returns infinity."""
+    def test_zero_weights_returns_inf(self):
+        """Test that all-zero weights returns infinity."""
         x = np.array([1.0, 2.0, 3.0])
-        # Sum of weights < 1 - q → insufficient
-        weights = np.array([0.01, 0.01, 0.01])
+        weights = np.array([0.0, 0.0, 0.0])
         result = weighted_quantile(x, q=0.1, weights=weights)
         assert result == float("inf")
+
+    def test_small_weights_normalizes(self):
+        """Test that small (but non-zero) weights are normalized and produce a finite result."""
+        x = np.array([1.0, 2.0, 3.0])
+        weights = np.array([0.01, 0.01, 0.01])
+        result = weighted_quantile(x, q=0.1, weights=weights)
+        assert np.isfinite(result)
 
     def test_single_element(self):
         """Test with single element array."""

--- a/tests/plotting/test_forecasting.py
+++ b/tests/plotting/test_forecasting.py
@@ -2812,3 +2812,64 @@ class TestPlotForecastPanelLegendGroups:
             lg = getattr(t, "legendgroup", None)
             if lg:
                 assert lg in ("x", "y"), f"Unexpected legendgroup: {lg}"
+
+
+class TestPlotForecastOptionalYTest:
+    """Tests for plot_forecast with y_test=None."""
+
+    def test_no_actual_trace(self):
+        """No 'Actual' trace is rendered when y_test is None."""
+        y_pred = pl.DataFrame({
+            "time": pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 30), "1d", eager=True),
+            "y": [190 + i for i in range(30)],
+        })
+        fig = plot_forecast(y_pred=y_pred)
+        actual_traces = [t for t in fig.data if t.name is not None and "Actual" in t.name]
+        assert len(actual_traces) == 0
+        forecast_traces = [t for t in fig.data if t.name is not None and "Forecast" in t.name]
+        assert len(forecast_traces) > 0
+
+    def test_with_intervals(self):
+        """Intervals render without y_test."""
+        y_pred = pl.DataFrame({
+            "time": pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 30), "1d", eager=True),
+            "y": [190 + i for i in range(30)],
+            "y_lower_0.9": [185 + i for i in range(30)],
+            "y_upper_0.9": [195 + i for i in range(30)],
+        })
+        fig = plot_forecast(y_pred=y_pred, coverage_rates=[0.9])
+        pi_traces = [t for t in fig.data if t.name is not None and "PI" in t.name]
+        assert len(pi_traces) == 1
+
+    def test_panel_data(self):
+        """Panel data without y_test produces faceted subplots."""
+        times = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 10), "1d", eager=True)
+        y_pred = pl.DataFrame({
+            "time": times,
+            "g__a": list(range(10)),
+            "g__b": list(range(10, 20)),
+        })
+        fig = plot_forecast(y_pred=y_pred, facet_by="member")
+        assert isinstance(fig, go.Figure)
+        assert len(fig.data) > 0
+
+    def test_categorical_raises(self):
+        """ValueError raised for categorical predictions without y_test."""
+        times = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 10), "1d", eager=True)
+        y_pred = pl.DataFrame({
+            "time": times,
+            "weather": ["sunny"] * 10,
+        })
+        with pytest.raises(ValueError, match="y_test is required"):
+            plot_forecast(y_pred=y_pred)
+
+    def test_class_proba_raises(self):
+        """ValueError raised for class-probability predictions without y_test."""
+        times = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 10), "1d", eager=True)
+        y_pred = pl.DataFrame({
+            "time": times,
+            "weather_proba_sunny": [0.7] * 10,
+            "weather_proba_rainy": [0.3] * 10,
+        })
+        with pytest.raises(ValueError, match="y_test is required"):
+            plot_forecast(y_pred=y_pred)

--- a/tests/plotting/test_forecasting.py
+++ b/tests/plotting/test_forecasting.py
@@ -2890,6 +2890,51 @@ class TestPlotForecastOptionalYTest:
         assert isinstance(fig, go.Figure)
         assert len(fig.data) > 0
 
+    def test_panel_show_transition(self):
+        """Panel forecast with show_transition=True prepends last train point."""
+        dates_train = pl.date_range(pl.date(2020, 1, 1), pl.date(2020, 3, 31), "1d", eager=True)
+        dates_test = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 10), "1d", eager=True)
+        y_train = pl.DataFrame({
+            "time": dates_train,
+            "y__a": [100.0 + i for i in range(91)],
+            "y__b": [200.0 + i for i in range(91)],
+        })
+        y_test = pl.DataFrame({
+            "time": dates_test,
+            "y__a": [191.0 + i for i in range(10)],
+            "y__b": [291.0 + i for i in range(10)],
+        })
+        y_pred = pl.DataFrame({
+            "time": dates_test,
+            "y__a": [190.0 + i for i in range(10)],
+            "y__b": [289.0 + i for i in range(10)],
+        })
+        fig = plot_forecast(
+            y_test,
+            y_pred,
+            y_train=y_train,
+            show_transition=True,
+            groups=["y"],
+        )
+        assert_figure_valid(fig)
+
+    def test_show_transition_column_not_in_train(self):
+        """show_transition=True with y_train missing forecast column skips prepend."""
+        y_train = pl.DataFrame({
+            "time": pl.date_range(pl.date(2020, 1, 1), pl.date(2020, 3, 31), "1d", eager=True),
+            "other": [100.0 + i for i in range(91)],
+        })
+        y_test = pl.DataFrame({
+            "time": pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 10), "1d", eager=True),
+            "y": [191.0 + i for i in range(10)],
+        })
+        y_pred = pl.DataFrame({
+            "time": y_test["time"],
+            "y": [190.0 + i for i in range(10)],
+        })
+        fig = plot_forecast(y_test, y_pred, y_train=y_train, show_transition=True)
+        assert_figure_valid(fig)
+
     def test_class_proba_raises(self):
         """ValueError raised for class-probability predictions without y_test."""
         times = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 10), "1d", eager=True)

--- a/tests/plotting/test_forecasting.py
+++ b/tests/plotting/test_forecasting.py
@@ -2863,6 +2863,33 @@ class TestPlotForecastOptionalYTest:
         with pytest.raises(ValueError, match="y_test is required"):
             plot_forecast(y_pred=y_pred)
 
+    def test_multi_model(self):
+        """Multi-model predictions render without y_test."""
+        times = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 30), "1d", eager=True)
+        y_preds = {
+            "model_a": pl.DataFrame({"time": times, "y": [190 + i for i in range(30)]}),
+            "model_b": pl.DataFrame({"time": times, "y": [195 + i for i in range(30)]}),
+        }
+        fig = plot_forecast(y_pred=y_preds)
+        actual_traces = [t for t in fig.data if t.name is not None and "Actual" in t.name]
+        assert len(actual_traces) == 0
+        assert len(fig.data) > 0
+
+    def test_multi_model_with_intervals(self):
+        """Multi-model with intervals renders without y_test."""
+        times = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 30), "1d", eager=True)
+        y_preds = {
+            "model_a": pl.DataFrame({
+                "time": times,
+                "y": [190 + i for i in range(30)],
+                "y_lower_0.9": [185 + i for i in range(30)],
+                "y_upper_0.9": [195 + i for i in range(30)],
+            }),
+        }
+        fig = plot_forecast(y_pred=y_preds, coverage_rates=[0.9])
+        assert isinstance(fig, go.Figure)
+        assert len(fig.data) > 0
+
     def test_class_proba_raises(self):
         """ValueError raised for class-probability predictions without y_test."""
         times = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 10), "1d", eager=True)

--- a/tests/plotting/test_forecasting.py
+++ b/tests/plotting/test_forecasting.py
@@ -2853,6 +2853,22 @@ class TestPlotForecastOptionalYTest:
         assert isinstance(fig, go.Figure)
         assert len(fig.data) > 0
 
+    def test_y_pred_none_raises(self):
+        """TypeError raised when y_pred is None."""
+        with pytest.raises(TypeError, match="y_pred is required"):
+            plot_forecast(y_pred=None)
+
+    def test_panel_non_numeric_no_y_test_raises(self):
+        """ValueError raised for non-numeric panel predictions without y_test."""
+        times = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 10), "1d", eager=True)
+        y_pred = pl.DataFrame({
+            "time": times,
+            "a__weather": ["sunny"] * 10,
+            "b__weather": ["rainy"] * 10,
+        })
+        with pytest.raises(ValueError, match="y_test is required for non-numeric panel"):
+            plot_forecast(y_pred=y_pred)
+
     def test_categorical_raises(self):
         """ValueError raised for categorical predictions without y_test."""
         times = pl.date_range(pl.date(2020, 4, 1), pl.date(2020, 4, 10), "1d", eager=True)


### PR DESCRIPTION
## Description

Make `y_test` optional in `plot_forecast` so forecasts can be plotted without actuals. Fix `weighted_quantile` to normalize weights internally, resolving infeasible quantile results with small or unnormalized weights.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

`plot_forecast` required `y_test` even when only predictions were available (e.g. production inference without ground truth). `weighted_quantile` could return `inf` when weights did not sum to 1, causing incorrect prediction intervals in `SplitConformalForecaster`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

- `plot_forecast(y_pred=y_pred)` now works; the Actual trace is simply omitted
- `ValueError` is raised for `class_proba` and `categorical` modes when `y_test is None` (those modes require ground truth labels)
- `weighted_quantile` now normalizes weights to sum to 1 internally
- `SplitConformalForecaster._weighted_inverse_score` passes `1.0 - coverage_rate` for symmetric scorers instead of `coverage_rate`
