### PR TITLE
fix(reduction): handle NaN features at predict time when nan_handling='drop'

### DIFF
--- a/src/yohou/base/reduction.py
+++ b/src/yohou/base/reduction.py
@@ -58,12 +58,13 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         - ``"cumulative"``: estimator for step h receives columns
           ``*_step_1..h``. All information up to horizon h.
     nan_handling : {"drop", "pass"}, default="pass"
-        How to handle NaN values in the tabularized training data.
+        How to handle NaN values in tabularized data.
         ``"pass"`` leaves NaN in place (suitable for estimators that
         handle NaN natively, such as tree-based models). ``"drop"``
         removes any training instance where X or y contains NaN before
         fitting the estimator, and emits a warning with the count of
-        dropped rows.
+        dropped rows. At predict time, returns NaN predictions for any
+        time step whose features contain NaN.
     n_jobs : int or None, default=None
         Number of jobs to run in parallel for the ``"direct"`` strategy
         (fitting and predicting H independent models). ``None`` means 1
@@ -659,6 +660,25 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         return X_tab, y_tab, sample_weight
 
+    def _features_have_nan(self, X_tab: pl.DataFrame) -> bool:
+        """Check if a feature DataFrame contains any NaN or null values.
+
+        Only used when ``nan_handling="drop"`` to decide whether the
+        estimator can be called safely at predict time.
+        """
+        null_free = X_tab.select(pl.all_horizontal(pl.all().is_not_null())).to_series()
+        float_cols = X_tab.select(cs.float())
+        if float_cols.width > 0:
+            nan_free = float_cols.select(pl.all_horizontal(pl.all().is_not_nan())).to_series()
+            return not (null_free & nan_free).all()
+        return not null_free.all()
+
+    def _nan_predict_result(self, n_rows: int = 1) -> np.ndarray:
+        """Return a NaN array shaped like a multi-output prediction."""
+        assert self.local_y_t_schema_ is not None
+        n_outputs = self.fit_forecasting_horizon_ * len(self.local_y_t_schema_)
+        return np.full((n_rows, n_outputs), np.nan)
+
     def _fit_single_estimator(
         self,
         X_tab: pl.DataFrame,
@@ -1122,13 +1142,19 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         """
         if self.groups_ is None:
             X_tab = self._get_predict_features()
-            y_tab_pred = estimator.predict(X_tab)  # ty: ignore[unresolved-attribute]
+            if self.nan_handling == "drop" and self._features_have_nan(X_tab):
+                y_tab_pred = self._nan_predict_result()
+            else:
+                y_tab_pred = estimator.predict(X_tab)  # ty: ignore[unresolved-attribute]
             return self._reshape_predictions(y_tab_pred)
 
         y_pred_dict = {}
         for panel_group_name in groups:
             X_tab = self._get_predict_features(panel_group_name)
-            y_tab_pred = estimator.predict(X_tab)
+            if self.nan_handling == "drop" and self._features_have_nan(X_tab):
+                y_tab_pred = self._nan_predict_result()
+            else:
+                y_tab_pred = estimator.predict(X_tab)
             y_pred_dict[panel_group_name] = self._reshape_predictions(y_tab_pred, panel_group_name)
         return pl.concat(list(y_pred_dict.values()), how="horizontal")
 
@@ -1161,6 +1187,8 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         def _predict_step(est: BaseEstimator, X_tab: pl.DataFrame) -> np.ndarray:
             """Predict a single horizon step."""
+            if self.nan_handling == "drop" and self._features_have_nan(X_tab):
+                return np.full(n_targets, np.nan)
             pred = est.predict(X_tab)  # ty: ignore[unresolved-attribute]
             return np.atleast_1d(pred.ravel())[:n_targets]
 
@@ -1220,8 +1248,11 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             X_aug = X_tab.clone()
             rows = []
             for i, est in enumerate(estimators):
-                pred = est.predict(X_aug)  # ty: ignore[unresolved-attribute]
-                pred = np.atleast_1d(pred.ravel())
+                if self.nan_handling == "drop" and self._features_have_nan(X_aug):
+                    pred = np.full(n_targets, np.nan)
+                else:
+                    pred = est.predict(X_aug)  # ty: ignore[unresolved-attribute]
+                    pred = np.atleast_1d(pred.ravel())
                 rows.append(pred[:n_targets])
                 # Augment features for next model
                 X_aug = X_aug.with_columns([pl.Series(f"__aug_{i}_{j}", [v]) for j, v in enumerate(pred)])
@@ -1235,8 +1266,11 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             X_aug = X_tab.clone()
             rows = []
             for i, est in enumerate(estimators):
-                pred = est.predict(X_aug)
-                pred = np.atleast_1d(pred.ravel())
+                if self.nan_handling == "drop" and self._features_have_nan(X_aug):
+                    pred = np.full(n_targets, np.nan)
+                else:
+                    pred = est.predict(X_aug)
+                    pred = np.atleast_1d(pred.ravel())
                 rows.append(pred[:n_targets])
                 X_aug = X_aug.with_columns([pl.Series(f"__aug_{i}_{j}", [v]) for j, v in enumerate(pred)])
             y_pred_arr = np.vstack(rows)

--- a/src/yohou/base/reduction.py
+++ b/src/yohou/base/reduction.py
@@ -14,6 +14,7 @@ import polars.selectors as cs
 from pydantic import StrictInt
 from sklearn.base import BaseEstimator, clone
 from sklearn.linear_model import LinearRegression
+from sklearn.pipeline import Pipeline
 from sklearn.utils.metadata_routing import MetadataRouter, MethodMapping
 from sklearn.utils.parallel import Parallel, delayed
 
@@ -679,6 +680,67 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         n_outputs = self.fit_forecasting_horizon_ * len(self.local_y_t_schema_)
         return np.full((n_rows, n_outputs), np.nan)
 
+    @staticmethod
+    def _resolve_sample_weight_params(
+        estimator: BaseEstimator,
+        sample_weight: np.ndarray,
+    ) -> dict[str, Any]:
+        """Resolve how to pass sample_weight to the estimator's fit method.
+
+        Handles plain estimators, sklearn ``Pipeline`` (configuring
+        metadata routing on the last step), and meta-estimators that
+        accept ``**kwargs``.
+
+        Parameters
+        ----------
+        estimator : BaseEstimator
+            The (cloned) estimator about to be fitted. May be mutated
+            in place (metadata routing configuration on Pipeline steps).
+        sample_weight : np.ndarray
+            Sample weights array.
+
+        Returns
+        -------
+        dict[str, Any]
+            Keyword arguments to merge into the ``fit`` call.
+
+        Raises
+        ------
+        ValueError
+            If the estimator cannot accept ``sample_weight``.
+
+        """
+        fit_sig = inspect.signature(estimator.fit)  # ty: ignore[unresolved-attribute]
+
+        # 1. Explicit sample_weight parameter
+        if "sample_weight" in fit_sig.parameters:
+            return {"sample_weight": sample_weight}
+
+        # 2. Pipeline: configure metadata routing on the last step
+        if isinstance(estimator, Pipeline):
+            last_step = estimator.steps[-1][1]
+            last_sig = inspect.signature(last_step.fit)
+            if "sample_weight" not in last_sig.parameters:
+                raise ValueError(
+                    f"Pipeline's final step {last_step.__class__.__name__} does not support "
+                    f"sample_weight parameter. Cannot use time_weight/vintage_weight for training."
+                )
+            last_step.set_fit_request(sample_weight=True)
+            for _, step in estimator.steps[:-1]:
+                if step != "passthrough":
+                    step.set_fit_request(sample_weight=False)
+            return {"sample_weight": sample_weight}
+
+        # 3. VAR_KEYWORD fallback (**kwargs / **fit_params)
+        has_var_keyword = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in fit_sig.parameters.values())
+        if has_var_keyword:
+            return {"sample_weight": sample_weight}
+
+        raise ValueError(
+            f"Estimator {estimator.__class__.__name__} does not support "
+            f"sample_weight parameter. Cannot use time_weight/vintage_weight for training."
+        )
+
     def _fit_single_estimator(
         self,
         X_tab: pl.DataFrame,
@@ -710,17 +772,9 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         """
         estimator = clone(self.estimator).set_params(**(estimator_params or {}))
 
-        if sample_weight is not None:
-            fit_signature = inspect.signature(estimator.fit)
-            if "sample_weight" not in fit_signature.parameters:
-                raise ValueError(
-                    f"Estimator {estimator.__class__.__name__} does not support "
-                    f"sample_weight parameter. Cannot use time_weight/vintage_weight for training."
-                )
-
         fit_params = estimator_fit_params or {}
         if sample_weight is not None:
-            fit_params = {**fit_params, "sample_weight": sample_weight}
+            fit_params = {**fit_params, **self._resolve_sample_weight_params(estimator, sample_weight)}
 
         estimator.fit(X_tab, y_tab, **fit_params)
         return estimator

--- a/src/yohou/class_proba/reduction.py
+++ b/src/yohou/class_proba/reduction.py
@@ -49,12 +49,13 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         - ``"matched"``: estimator for step h receives only ``*_step_h``.
         - ``"cumulative"``: estimator for step h receives ``*_step_1..h``.
     nan_handling : {"drop", "pass"}, default="pass"
-        How to handle NaN values in the tabularized training data.
+        How to handle NaN values in tabularized data.
         ``"pass"`` leaves NaN in place (suitable for estimators that
         handle NaN natively, such as tree-based models). ``"drop"``
         removes any training instance where X or y contains NaN before
         fitting the estimator, and emits a warning with the count of
-        dropped rows.
+        dropped rows. At predict time, returns NaN predictions for any
+        time step whose features contain NaN.
     panel_strategy : {"global", "multivariate"}, default="global"
         How to handle panel data. See `BaseForecaster` for details.
     n_jobs : int or None, default=None

--- a/src/yohou/interval/reduction.py
+++ b/src/yohou/interval/reduction.py
@@ -39,12 +39,13 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
     panel_strategy : {"global", "multivariate"}, default="global"
         How to handle panel data. See `BaseForecaster` for details.
     nan_handling : {"drop", "pass"}, default="pass"
-        How to handle NaN values in the tabularized training data.
+        How to handle NaN values in tabularized data.
         ``"pass"`` leaves NaN in place (suitable for estimators that
         handle NaN natively, such as tree-based models). ``"drop"``
         removes any training instance where X or y contains NaN before
         fitting the estimator, and emits a warning with the count of
-        dropped rows.
+        dropped rows. At predict time, returns NaN predictions for any
+        time step whose features contain NaN.
     n_jobs : int or None, default=None
         Number of jobs to run in parallel for the ``"direct"`` strategy
         (fitting and predicting H independent models). ``None`` means 1

--- a/src/yohou/point/reduction.py
+++ b/src/yohou/point/reduction.py
@@ -39,12 +39,13 @@ class PointReductionForecaster(BaseReductionForecaster, BasePointForecaster):
     panel_strategy : {"global", "multivariate"}, default="global"
         How to handle panel data. See `BaseForecaster` for details.
     nan_handling : {"drop", "pass"}, default="pass"
-        How to handle NaN values in the tabularized training data.
+        How to handle NaN values in tabularized data.
         ``"pass"`` leaves NaN in place (suitable for estimators that
         handle NaN natively, such as tree-based models). ``"drop"``
         removes any training instance where X or y contains NaN before
         fitting the estimator, and emits a warning with the count of
-        dropped rows.
+        dropped rows. At predict time, returns NaN predictions for any
+        time step whose features contain NaN.
     n_jobs : int or None, default=None
         Number of jobs to run in parallel for the ``"direct"`` strategy
         (fitting and predicting H independent models). ``None`` means 1

--- a/tests/base/test_reduction_nan_handling.py
+++ b/tests/base/test_reduction_nan_handling.py
@@ -349,6 +349,177 @@ class TestNanHandlingEdgeBranches:
         assert y_out.shape[0] == 3
 
 
+class TestNanHandlingPredict:
+    """Tests for NaN handling at predict time when nan_handling='drop'."""
+
+    def test_multi_output_returns_nan_on_nan_features(self):
+        """Predict returns NaN when features contain NaN at predict time (multi-output)."""
+        y = _make_y_with_nan(30, nan_positions=[28, 29])
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, forecasting_horizon=2)
+        y_pred = forecaster.predict()
+        value_col = [c for c in y_pred.columns if c not in ("time", "vintage_time")][0]
+        assert y_pred[value_col].is_nan().all(), "Should return NaN predictions"
+
+    def test_multi_output_panel_returns_nan_on_nan_features(self):
+        """Panel data returns NaN predictions when features have NaN (multi-output)."""
+        length = 30
+        times = pl.datetime_range(
+            start=datetime(2021, 1, 1),
+            end=datetime(2021, 1, 1, 0, 0, length - 1),
+            interval="1s",
+            eager=True,
+        )
+        values_a = [float(i) for i in range(length)]
+        values_b = [float(i) for i in range(length)]
+        values_a[-1] = float("nan")
+        values_b[-1] = float("nan")
+        y = pl.DataFrame({
+            "time": times,
+            "x__value": values_a,
+            "y__value": values_b,
+        })
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+            panel_strategy="global",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, forecasting_horizon=2)
+        y_pred = forecaster.predict()
+        target_cols = [c for c in y_pred.columns if c not in ("time", "vintage_time")]
+        for col in target_cols:
+            assert y_pred[col].is_nan().all(), f"Column {col} should be NaN"
+
+    def test_direct_returns_nan_on_nan_features(self):
+        """Predict returns NaN when features contain NaN (direct strategy)."""
+        y = _make_y_with_nan(30, nan_positions=[28, 29])
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+            reduction_strategy="direct",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, forecasting_horizon=2)
+        y_pred = forecaster.predict()
+        value_col = [c for c in y_pred.columns if c not in ("time", "vintage_time")][0]
+        assert y_pred[value_col].is_nan().all(), "Should return NaN predictions"
+
+    def test_dir_rec_returns_nan_on_nan_features(self):
+        """Predict returns NaN when features contain NaN (dir-rec strategy)."""
+        y = _make_y_with_nan(30, nan_positions=[28, 29])
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+            reduction_strategy="dir-rec",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, forecasting_horizon=2)
+        y_pred = forecaster.predict()
+        value_col = [c for c in y_pred.columns if c not in ("time", "vintage_time")][0]
+        assert y_pred[value_col].is_nan().all(), "Should return NaN predictions"
+
+    def test_dir_rec_panel_returns_nan_on_nan_features(self):
+        """Panel data returns NaN predictions when features have NaN (dir-rec strategy)."""
+        length = 30
+        times = pl.datetime_range(
+            start=datetime(2021, 1, 1),
+            end=datetime(2021, 1, 1, 0, 0, length - 1),
+            interval="1s",
+            eager=True,
+        )
+        values_a = [float(i) for i in range(length)]
+        values_b = [float(i) for i in range(length)]
+        values_a[-1] = float("nan")
+        values_b[-1] = float("nan")
+        y = pl.DataFrame({
+            "time": times,
+            "x__value": values_a,
+            "y__value": values_b,
+        })
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+            reduction_strategy="dir-rec",
+            panel_strategy="global",
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            forecaster.fit(y=y, forecasting_horizon=2)
+        y_pred = forecaster.predict()
+        target_cols = [c for c in y_pred.columns if c not in ("time", "vintage_time")]
+        for col in target_cols:
+            assert y_pred[col].is_nan().all(), f"Column {col} should be NaN"
+
+
+class TestFeaturesHaveNanEdgeCases:
+    """Cover edge branches in _features_have_nan for non-float data."""
+
+    def test_no_float_columns_with_null(self):
+        """_features_have_nan detects null in non-float columns."""
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        X_tab = pl.DataFrame({"a": [1, None, 3], "b": [10, 20, 30]})
+        assert forecaster._features_have_nan(X_tab) is True
+
+    def test_no_float_columns_clean(self):
+        """_features_have_nan returns False for clean non-float data."""
+        forecaster = PointReductionForecaster(
+            estimator=_RecordingEstimator(),
+            nan_handling="drop",
+        )
+        X_tab = pl.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30]})
+        assert forecaster._features_have_nan(X_tab) is False
+
+
+class TestResolveWeightParamsEdgeCases:
+    """Cover edge branches in _resolve_sample_weight_params."""
+
+    def test_var_keyword_fallback(self):
+        """Estimator with **kwargs accepts sample_weight via VAR_KEYWORD fallback."""
+
+        class KwargsEstimator(BaseEstimator):
+            def fit(self, X, y, **kwargs):
+                self.kwargs_ = kwargs
+                return self
+
+            def predict(self, X):
+                return np.zeros(_nrows(X))
+
+        from yohou.base.reduction import BaseReductionForecaster
+
+        sw = np.array([1.0, 2.0, 3.0])
+        result = BaseReductionForecaster._resolve_sample_weight_params(KwargsEstimator(), sw)
+        assert "sample_weight" in result
+        np.testing.assert_array_equal(result["sample_weight"], sw)
+
+    def test_no_support_raises_valueerror(self):
+        """Estimator without sample_weight or **kwargs raises ValueError."""
+
+        class StrictEstimator(BaseEstimator):
+            def fit(self, X, y):
+                return self
+
+            def predict(self, X):
+                return np.zeros(_nrows(X))
+
+        from yohou.base.reduction import BaseReductionForecaster
+
+        sw = np.array([1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="StrictEstimator"):
+            BaseReductionForecaster._resolve_sample_weight_params(StrictEstimator(), sw)
+
+
 class TestParameterValidation:
     def test_invalid_nan_handling_raises(self):
         """4.12: Invalid nan_handling value raises ValueError."""

--- a/tests/point/test_reduction.py
+++ b/tests/point/test_reduction.py
@@ -5,8 +5,10 @@ import polars as pl
 import polars.selectors as cs
 import pytest
 from sklearn.base import BaseEstimator, clone
-from sklearn.linear_model import LinearRegression
+from sklearn.linear_model import LinearRegression, Ridge
 from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
 from conftest import run_checks
 from yohou.point import PointReductionForecaster
@@ -1357,3 +1359,62 @@ class TestStepFeatureAlignment:
         f.fit(y[:25], forecasting_horizon=fh, X_future=X_future)
         y_pred = f.predict(forecasting_horizon=fh)
         assert len(y_pred) == fh
+
+
+class TestPipelineSampleWeightRouting:
+    """Tests for sample_weight routing through Pipeline and plain estimators."""
+
+    @pytest.fixture()
+    def simple_series(self):
+        """Simple time series for weight routing tests."""
+        n = 30
+        time = pl.datetime_range(
+            start=datetime(2021, 1, 1),
+            end=datetime(2021, 1, 1, 0, 0, n - 1),
+            interval="1s",
+            eager=True,
+        )
+        y = pl.DataFrame({
+            "time": time,
+            "value": np.random.default_rng(42).standard_normal(n),
+        })
+        return y
+
+    @staticmethod
+    def _constant_weight(t):
+        return pl.Series("weight", [1.0] * len(t))
+
+    def test_pipeline_with_time_weight(self, simple_series):
+        """Pipeline with Ridge final step accepts time_weight."""
+        pipe = Pipeline([("scaler", StandardScaler()), ("ridge", Ridge())])
+        f = PointReductionForecaster(estimator=pipe)
+        f.set_fit_request(time_weight=True)
+        f.fit(simple_series, forecasting_horizon=3, time_weight=self._constant_weight)
+        y_pred = f.predict()
+        assert len(y_pred) == 3
+        assert "time" in y_pred.columns
+
+    def test_pipeline_unsupported_final_step_raises(self, simple_series):
+        """Pipeline whose final step lacks sample_weight raises ValueError."""
+
+        class NoWeightEstimator(BaseEstimator):
+            def fit(self, X, y):
+                return self
+
+            def predict(self, X):
+                return np.zeros(X.shape[0])
+
+        pipe = Pipeline([("scaler", StandardScaler()), ("noweight", NoWeightEstimator())])
+        f = PointReductionForecaster(estimator=pipe)
+        f.set_fit_request(time_weight=True)
+        with pytest.raises(ValueError, match="NoWeightEstimator"):
+            f.fit(simple_series, forecasting_horizon=3, time_weight=self._constant_weight)
+
+    def test_plain_ridge_with_time_weight(self, simple_series):
+        """Plain Ridge estimator with time_weight works (regression guard)."""
+        f = PointReductionForecaster(estimator=Ridge())
+        f.set_fit_request(time_weight=True)
+        f.fit(simple_series, forecasting_horizon=3, time_weight=self._constant_weight)
+        y_pred = f.predict()
+        assert len(y_pred) == 3
+        assert "time" in y_pred.columns


### PR DESCRIPTION
## Description

`nan_handling="drop"` only filtered NaN during `fit`. At predict time, NaN features passed directly to `estimator.predict()`, crashing estimators that do not accept NaN (e.g. Ridge, Lasso).

Now, when `nan_handling="drop"`, predict methods check for NaN in the feature row and return NaN predictions instead of forwarding NaN to the estimator. Applied to all three reduction strategies: multi-output, direct, and dir-rec.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

When using a Ridge forecaster with `nan_handling="drop"` inside a `SplitConformalForecaster`, the `observe_predict` calibration loop crashes with `ValueError: Input X contains NaN` because NaN features (from lag/rolling windows or missing exogenous data) reach `estimator.predict()` unfiltered.

## Checklist

- [x] My code follows the code style of this project
- [ ] I have run `just fix` to format my code
- [ ] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings