### PR TITLE
fix(reduction): handle Pipeline steps that lack set_fit_request for sample_weight

### DIFF
--- a/src/yohou/base/reduction.py
+++ b/src/yohou/base/reduction.py
@@ -1,6 +1,7 @@
 """Base class for reduction-based forecasters."""
 
 import abc
+import contextlib
 import inspect
 import numbers
 import warnings
@@ -728,7 +729,8 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             last_step.set_fit_request(sample_weight=True)
             for _, step in estimator.steps[:-1]:
                 if step != "passthrough":
-                    step.set_fit_request(sample_weight=False)
+                    with contextlib.suppress(TypeError, AttributeError):
+                        step.set_fit_request(sample_weight=False)
             return {"sample_weight": sample_weight}
 
         # 3. VAR_KEYWORD fallback (**kwargs / **fit_params)

--- a/tests/point/test_reduction.py
+++ b/tests/point/test_reduction.py
@@ -1418,3 +1418,19 @@ class TestPipelineSampleWeightRouting:
         y_pred = f.predict()
         assert len(y_pred) == 3
         assert "time" in y_pred.columns
+
+    def test_pipeline_with_non_weight_aware_intermediate_step(self, simple_series):
+        """Pipeline with intermediate step that lacks set_fit_request for sample_weight."""
+        from sklearn.impute import SimpleImputer
+
+        pipe = Pipeline([
+            ("imputer", SimpleImputer(strategy="mean")),
+            ("scaler", StandardScaler()),
+            ("ridge", Ridge()),
+        ])
+        f = PointReductionForecaster(estimator=pipe)
+        f.set_fit_request(time_weight=True)
+        f.fit(simple_series, forecasting_horizon=3, time_weight=self._constant_weight)
+        y_pred = f.predict()
+        assert len(y_pred) == 3
+        assert "time" in y_pred.columns


### PR DESCRIPTION
## Description

When an sklearn `Pipeline` contains intermediate steps (e.g., `SimpleImputer`) that do not support `set_fit_request` for `sample_weight`, the metadata routing configuration in `_resolve_sample_weight_params` raises an `AttributeError`. This PR wraps the call with `contextlib.suppress` so unsupported steps are silently skipped.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Discovered while running the AS DAM forecast template notebook with a `Pipeline([SimpleImputer, StandardScaler, Ridge])` estimator and `time_weight`. The `SimpleImputer` step does not accept `sample_weight` at all, so calling `set_fit_request(sample_weight=False)` on it raises `AttributeError`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings