### PR TITLE
feat(testing): add weighter, similarity, and composition check harnesses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ CLAUDE_INSTRUCTIONS.md
 claude-instructions.md
 claude-config.md
 claude-prompt.md
+reviews/
 
 # GitHub Copilot
 COPILOT.md

--- a/src/yohou/compose/column_transformer.py
+++ b/src/yohou/compose/column_transformer.py
@@ -265,30 +265,6 @@ class ColumnTransformer(BaseTransformer, _BaseComposition):
         "verbose_feature_names_out": ["boolean"],
     }
 
-    @property
-    def _transformers(self) -> list[tuple[str, Any]]:
-        """Expose the ``(name, transformer)`` pairs for ``_BaseComposition``.
-
-        ``transformers`` holds ``(name, transformer, columns)`` 3-tuples, but
-        ``_BaseComposition`` expects ``(name, estimator)`` 2-tuples. This adapter
-        drops ``columns`` so nested ``<name>__<param>`` access works, mirroring
-        scikit-learn's own ``ColumnTransformer``.
-        """
-        try:
-            return [(name, trans) for name, trans, _ in self.transformers]
-        except (TypeError, ValueError):
-            return cast("list[tuple[str, Any]]", self.transformers)
-
-    @_transformers.setter
-    def _transformers(self, value: list[tuple[str, Any]]) -> None:
-        """Write back ``(name, transformer)`` pairs, preserving ``columns``."""
-        try:
-            self.transformers = [
-                (name, trans, col) for (name, trans), (_, _, col) in zip(value, self.transformers, strict=True)
-            ]
-        except (TypeError, ValueError):
-            self.transformers = cast("list[tuple[str, Any, Any]]", value)
-
     def get_params(self, deep: bool = True) -> dict[str, Any]:
         """Get parameters for this estimator.
 
@@ -363,16 +339,26 @@ class ColumnTransformer(BaseTransformer, _BaseComposition):
         return tags
 
     @property
-    def _transformers(self) -> list[tuple[str, Any, Any]]:
-        """List of (name, fitted_transformer, column) tuples.
+    def _transformers(self) -> list[tuple[str, Any]]:
+        """List of ``(name, transformer)`` pairs for ``_BaseComposition``.
+
+        ``transformers`` holds ``(name, transformer, columns)`` 3-tuples;
+        ``_BaseComposition`` (and hence nested ``<name>__<param>`` get/set) needs
+        ``(name, transformer)`` 2-tuples. Delegates to scikit-learn's own
+        ``ColumnTransformer`` getter/setter, which drops and restores ``columns``.
 
         Returns
         -------
-        transformers : list[tuple[str, Any, Any]]
-            The fitted transformers.
+        transformers : list[tuple[str, Any]]
+            The ``(name, transformer)`` pairs.
 
         """
         return sklearn_ColumnTransformer._transformers.fget(self)  # ty: ignore[invalid-argument-type]
+
+    @_transformers.setter
+    def _transformers(self, value: list[tuple[str, Any]]) -> None:
+        """Write back ``(name, transformer)`` pairs, preserving ``columns``."""
+        sklearn_ColumnTransformer._transformers.fset(self, value)  # ty: ignore[invalid-argument-type]
 
     def _iter(
         self,

--- a/src/yohou/compose/column_transformer.py
+++ b/src/yohou/compose/column_transformer.py
@@ -265,6 +265,30 @@ class ColumnTransformer(BaseTransformer, _BaseComposition):
         "verbose_feature_names_out": ["boolean"],
     }
 
+    @property
+    def _transformers(self) -> list[tuple[str, Any]]:
+        """Expose the ``(name, transformer)`` pairs for ``_BaseComposition``.
+
+        ``transformers`` holds ``(name, transformer, columns)`` 3-tuples, but
+        ``_BaseComposition`` expects ``(name, estimator)`` 2-tuples. This adapter
+        drops ``columns`` so nested ``<name>__<param>`` access works, mirroring
+        scikit-learn's own ``ColumnTransformer``.
+        """
+        try:
+            return [(name, trans) for name, trans, _ in self.transformers]
+        except (TypeError, ValueError):
+            return cast("list[tuple[str, Any]]", self.transformers)
+
+    @_transformers.setter
+    def _transformers(self, value: list[tuple[str, Any]]) -> None:
+        """Write back ``(name, transformer)`` pairs, preserving ``columns``."""
+        try:
+            self.transformers = [
+                (name, trans, col) for (name, trans), (_, _, col) in zip(value, self.transformers, strict=True)
+            ]
+        except (TypeError, ValueError):
+            self.transformers = cast("list[tuple[str, Any, Any]]", value)
+
     def get_params(self, deep: bool = True) -> dict[str, Any]:
         """Get parameters for this estimator.
 
@@ -280,7 +304,7 @@ class ColumnTransformer(BaseTransformer, _BaseComposition):
             Parameter names mapped to their values.
 
         """
-        return _BaseComposition._get_params(self, attr="transformers", deep=deep)
+        return _BaseComposition._get_params(self, attr="_transformers", deep=deep)
 
     def set_params(self, **params: Any) -> "ColumnTransformer":
         """Set the parameters of this estimator.
@@ -296,7 +320,7 @@ class ColumnTransformer(BaseTransformer, _BaseComposition):
             ColumnTransformer instance.
 
         """
-        _BaseComposition._set_params(self, attr="transformers", **params)
+        _BaseComposition._set_params(self, attr="_transformers", **params)
         return self
 
     def __sklearn_tags__(self) -> Tags:

--- a/src/yohou/interval/similarity.py
+++ b/src/yohou/interval/similarity.py
@@ -8,6 +8,7 @@ import numpy as np
 import polars as pl
 from scipy.spatial.distance import cdist
 from sklearn.base import clone
+from sklearn.utils.validation import check_is_fitted
 
 from yohou.utils._compat import _BaseComposition
 
@@ -218,6 +219,7 @@ class DistanceSimilarity(BaseSimilarity):
         self
 
         """
+        check_is_fitted(self, "_X_observed")
         X_features = self._get_X(y_pred, X_actual)
 
         self._X_observed = pl.concat([self._X_observed, X_features])
@@ -277,6 +279,7 @@ class DistanceSimilarity(BaseSimilarity):
             Similarity weight matrix.
 
         """
+        check_is_fitted(self, "_X_observed")
         X_features = self._get_X(y_pred, X_actual)
 
         XA = X_features.select(pl.exclude("time")).to_numpy()
@@ -499,6 +502,7 @@ class SeasonalSimilarity(BaseSimilarity):
         self
 
         """
+        check_is_fitted(self, "first_time_")
         new_features = self._extract_features(y_pred["time"])
         self._features_observed = np.vstack([self._features_observed, new_features])
         return self
@@ -553,6 +557,7 @@ class SeasonalSimilarity(BaseSimilarity):
             Weight matrix of shape ``(n_predictions, n_calibration)``.
 
         """
+        check_is_fitted(self, "first_time_")
         new_features = self._extract_features(y_pred["time"])
 
         distances: np.ndarray = cdist(
@@ -757,6 +762,7 @@ class CompositeSimilarity(BaseSimilarity, _BaseComposition):
         self
 
         """
+        check_is_fitted(self, "similarities_")
         for _name, sim in self.similarities_:
             sim.observe(y=y, y_pred=y_pred, X_actual=X_actual)
         return self
@@ -808,6 +814,7 @@ class CompositeSimilarity(BaseSimilarity, _BaseComposition):
             ``(n_predictions, n_calibration)``.
 
         """
+        check_is_fitted(self, "similarities_")
         alphas = self._resolved_weights()
         weight_matrices = [sim.predict(y_pred=y_pred, X_actual=X_actual) for _name, sim in self.similarities_]
 

--- a/src/yohou/testing/__init__.py
+++ b/src/yohou/testing/__init__.py
@@ -53,6 +53,21 @@ from .common import (
     check_metadata_routing_default_request,
     check_metadata_routing_get_metadata_routing,
 )
+from .composite import (
+    _yield_composite_reducer_checks,
+    check_composite_combination_validation,
+    check_composite_rejects_bare_list,
+    check_composite_weights_length_validation,
+)
+from .contract import (
+    _yield_composition_contract_checks,
+    _yield_estimator_contract_checks,
+    check_clone_preserves_params,
+    check_composition_clone_deep_clones_components,
+    check_composition_nested_param_addressable,
+    check_get_set_params_round_trip,
+    check_init_no_param_mutation,
+)
 from .forecaster import (
     check_clone_preserves_forecaster_params,
     check_fit_predict_with_X_forecast,
@@ -79,8 +94,10 @@ from .generators import (
     _yield_yohou_forecaster_checks,
     _yield_yohou_scorer_checks,
     _yield_yohou_search_checks,
+    _yield_yohou_similarity_checks,
     _yield_yohou_splitter_checks,
     _yield_yohou_transformer_checks,
+    _yield_yohou_weighter_checks,
 )
 from .interval import (
     check_coverage_rates_parameter,
@@ -139,6 +156,12 @@ from .search import (
     check_search_return_train_score,
     check_search_rewind_delegates,
 )
+from .similarity import (
+    check_similarity_methods_call_check_is_fitted,
+    check_similarity_metric_params_verbatim,
+    check_similarity_predict_matrix_shape,
+    check_similarity_to_weights_rows_reserve_mass,
+)
 from .splitter import (
     check_splitter_n_splits_consistency,
     check_splitter_non_overlapping_tests,
@@ -175,6 +198,14 @@ from .transformer import (
     check_transformer_methods_call_check_is_fitted,
     check_transformer_preserve_dtypes,
     check_transformers_unfitted_stateless,
+)
+from .weighter import (
+    check_weighter_compute_weights_alignment,
+    check_weighter_default_constructible,
+    check_weighter_fit_noop_returns_self,
+    check_weighter_resolved_array_validation,
+    check_weighter_tags_accessible_before_fit,
+    check_weighter_tags_static_after_fit,
 )
 
 __all__ = [
@@ -282,11 +313,34 @@ __all__ = [
     "check_search_observe_delegates",
     "check_metadata_routing_default_request",
     "check_metadata_routing_get_metadata_routing",
+    "check_clone_preserves_params",
+    "check_get_set_params_round_trip",
+    "check_init_no_param_mutation",
+    "check_composition_nested_param_addressable",
+    "check_composition_clone_deep_clones_components",
+    "check_composite_rejects_bare_list",
+    "check_composite_combination_validation",
+    "check_composite_weights_length_validation",
+    "check_weighter_compute_weights_alignment",
+    "check_weighter_fit_noop_returns_self",
+    "check_weighter_resolved_array_validation",
+    "check_weighter_default_constructible",
+    "check_weighter_tags_accessible_before_fit",
+    "check_weighter_tags_static_after_fit",
+    "check_similarity_predict_matrix_shape",
+    "check_similarity_to_weights_rows_reserve_mass",
+    "check_similarity_metric_params_verbatim",
+    "check_similarity_methods_call_check_is_fitted",
+    "_yield_estimator_contract_checks",
+    "_yield_composition_contract_checks",
+    "_yield_composite_reducer_checks",
     "_yield_yohou_forecaster_checks",
     "_yield_yohou_transformer_checks",
     "_yield_yohou_splitter_checks",
     "_yield_yohou_scorer_checks",
     "_yield_yohou_search_checks",
+    "_yield_yohou_weighter_checks",
+    "_yield_yohou_similarity_checks",
     "_Registry",
     "assert_request_equal",
     "assert_request_is_empty",

--- a/src/yohou/testing/composite.py
+++ b/src/yohou/testing/composite.py
@@ -1,0 +1,136 @@
+"""Reducer and bare-list checks for ``{multiply, mean}`` compositors.
+
+These checks cover the part of the composite contract that raises only at
+compute/fit time (not at ``get_params``/``clone``) and therefore needs
+family-specific data: bare-list rejection and ``combination``/``weights``
+validation. They are consumed only by the weighter and similarity family
+harnesses (``CompositeWeighter``, ``CompositeSimilarity``), which pass an
+``operate`` callable that triggers the compositor's validation.
+
+All check functions raise AssertionError on failure.
+"""
+
+from collections.abc import Callable, Generator
+
+__all__ = [
+    "check_composite_combination_validation",
+    "check_composite_rejects_bare_list",
+    "check_composite_weights_length_validation",
+    "_yield_composite_reducer_checks",
+]
+
+
+def check_composite_rejects_bare_list(compositor, descriptor: dict, operate: Callable) -> None:
+    """Check a bare ``[estimator, ...]`` list (no names) is rejected.
+
+    Parameters
+    ----------
+    compositor : BaseEstimator
+        A ``{multiply, mean}`` compositor instance (for its type).
+    descriptor : dict
+        Carries ``"attr"`` (composition-attribute name) and ``"components"``
+        (valid named-tuple component list).
+    operate : callable
+        Invoked with a freshly-built compositor to trigger validation.
+
+    Raises
+    ------
+    AssertionError
+        If the bare list is accepted instead of raising.
+
+    """
+    name = type(compositor).__name__
+    attr = descriptor["attr"]
+    bare = [entry[1] for entry in descriptor["components"]]
+    bad = type(compositor)(**{attr: bare})
+    try:
+        operate(bad)
+    except (ValueError, TypeError):
+        return
+    raise AssertionError(f"{name}: a bare {attr} list (no names) was accepted; expected ValueError/TypeError")
+
+
+def check_composite_combination_validation(compositor, descriptor: dict, operate: Callable) -> None:
+    """Check an unknown ``combination`` raises.
+
+    Parameters
+    ----------
+    compositor : BaseEstimator
+        A ``{multiply, mean}`` compositor instance (for its type).
+    descriptor : dict
+        Carries ``"attr"`` and ``"components"``.
+    operate : callable
+        Invoked with a freshly-built compositor to trigger validation.
+
+    Raises
+    ------
+    AssertionError
+        If the invalid combination is accepted.
+
+    """
+    name = type(compositor).__name__
+    attr = descriptor["attr"]
+    bad = type(compositor)(**{attr: descriptor["components"], "combination": "__invalid__"})
+    try:
+        operate(bad)
+    except ValueError:
+        return
+    raise AssertionError(f"{name}: unknown combination was accepted; expected ValueError")
+
+
+def check_composite_weights_length_validation(compositor, descriptor: dict, operate: Callable) -> None:
+    """Check a ``weights`` list of the wrong length raises.
+
+    Parameters
+    ----------
+    compositor : BaseEstimator
+        A ``{multiply, mean}`` compositor instance (for its type).
+    descriptor : dict
+        Carries ``"attr"`` and ``"components"``.
+    operate : callable
+        Invoked with a freshly-built compositor to trigger validation.
+
+    Raises
+    ------
+    AssertionError
+        If the mismatched-length weights are accepted.
+
+    """
+    name = type(compositor).__name__
+    attr = descriptor["attr"]
+    components = descriptor["components"]
+    bad = type(compositor)(**{attr: components, "weights": [1.0] * (len(components) + 1)})
+    try:
+        operate(bad)
+    except ValueError:
+        return
+    raise AssertionError(f"{name}: weights of wrong length were accepted; expected ValueError")
+
+
+def _yield_composite_reducer_checks(
+    compositor,
+    descriptor: dict,
+    operate: Callable,
+) -> Generator[tuple[str, Callable, dict], None, None]:
+    """Yield the reducer/bare-list checks for a ``{multiply, mean}`` compositor.
+
+    Parameters
+    ----------
+    compositor : BaseEstimator
+        A ``CompositeWeighter`` or ``CompositeSimilarity`` instance.
+    descriptor : dict
+        Per-compositor descriptor with ``"attr"`` and ``"components"``.
+    operate : callable
+        Triggers the compositor's validation at compute/fit time
+        (e.g. ``lambda c: c.compute_weights(key)`` or ``lambda c: c.fit(y, y_pred)``).
+
+    Yields
+    ------
+    tuple of (str, callable, dict)
+        ``(check_name, check_func, check_kwargs)`` consumable by ``run_checks``.
+
+    """
+    kwargs = {"descriptor": descriptor, "operate": operate}
+    yield "check_composite_rejects_bare_list", check_composite_rejects_bare_list, kwargs
+    yield "check_composite_combination_validation", check_composite_combination_validation, kwargs
+    yield "check_composite_weights_length_validation", check_composite_weights_length_validation, kwargs

--- a/src/yohou/testing/contract.py
+++ b/src/yohou/testing/contract.py
@@ -1,0 +1,340 @@
+"""Family-agnostic sklearn estimator-contract and composition-contract checks.
+
+This module provides systematic validation functions shared across estimator
+families:
+
+1. Estimator-contract checks - the sklearn contract (``clone`` round-trip,
+   ``get_params``/``set_params`` round-trip, no ``__init__`` mutation) that was
+   previously checked only for forecasters and searches.
+2. Composition-contract checks - the *data-free* part of the
+   ``_BaseComposition`` contract (nested ``<name>__<param>`` addressability and
+   clone-deep-clones), run over every compositor in yohou.
+
+All check functions raise AssertionError on failure.
+"""
+
+import inspect
+from collections.abc import Callable, Generator
+
+from sklearn.base import BaseEstimator, clone
+
+
+def _safe_equal(a: object, b: object) -> bool:
+    """Equality that tolerates DataFrame/array params (whose ``==`` is not a bool).
+
+    Falls back to ``.equals`` for frame-like values and to ``.all()`` for
+    array-like comparison results; returns ``False`` if equality cannot be
+    determined.
+    """
+    if a is b:
+        return True
+    equals = getattr(a, "equals", None)
+    if callable(equals):
+        try:
+            return bool(equals(b))
+        except Exception:  # noqa: BLE001
+            return False
+    try:
+        result = a == b
+    except Exception:  # noqa: BLE001
+        return False
+    if isinstance(result, bool):
+        return result
+    reducer = getattr(result, "all", None)
+    if callable(reducer):
+        try:
+            return bool(reducer())
+        except Exception:  # noqa: BLE001
+            return False
+    return bool(result)
+
+
+__all__ = [
+    "check_clone_preserves_params",
+    "check_composition_clone_deep_clones_components",
+    "check_composition_nested_param_addressable",
+    "check_get_set_params_round_trip",
+    "check_init_no_param_mutation",
+    "_yield_composition_contract_checks",
+    "_yield_estimator_contract_checks",
+]
+
+
+# ---------------------------------------------------------------------------
+# Estimator-contract checks (sklearn contract)
+# ---------------------------------------------------------------------------
+
+
+def check_clone_preserves_params(estimator) -> None:
+    """Check ``clone()`` preserves shallow params and freshens nested estimators.
+
+    Family-agnostic generalization of ``check_clone_preserves_forecaster_params``:
+    the clone reproduces every ``get_params(deep=False)`` value, and nested
+    sub-estimators (including ``(name, estimator)`` tuple lists) become fresh
+    instances of the same type.
+
+    Parameters
+    ----------
+    estimator : BaseEstimator
+        Estimator instance to clone.
+
+    Raises
+    ------
+    AssertionError
+        If the clone has different parameter keys or values.
+
+    """
+    name = type(estimator).__name__
+    estimator_clone = clone(estimator)
+
+    original = estimator.get_params(deep=False)
+    cloned = estimator_clone.get_params(deep=False)
+
+    assert set(original.keys()) == set(cloned.keys()), (
+        f"{name}: clone() changed parameter keys: {set(cloned.keys())} vs {set(original.keys())}"
+    )
+
+    for key, orig_val in original.items():
+        cloned_val = cloned[key]
+        if orig_val is None:
+            assert cloned_val is None, f"{name}: parameter {key!r} expected None, got {cloned_val!r}"
+        elif isinstance(orig_val, list) and orig_val and isinstance(orig_val[0], tuple):
+            # List of (name, estimator[, ...]) tuples (compositors).
+            assert isinstance(cloned_val, list), f"{name}: parameter {key!r} expected list, got {type(cloned_val)}"
+            assert len(cloned_val) == len(orig_val), f"{name}: parameter {key!r} changed length under clone()"
+            for orig_item, cloned_item in zip(orig_val, cloned_val, strict=True):
+                if not (isinstance(orig_item, tuple) and isinstance(cloned_item, tuple)):
+                    continue
+                assert orig_item[0] == cloned_item[0], f"{name}: component name changed under clone()"
+                orig_est, cloned_est = orig_item[1], cloned_item[1]
+                if isinstance(orig_est, BaseEstimator):
+                    assert type(orig_est) is type(cloned_est), (
+                        f"{name}: component {orig_item[0]!r} changed type under clone()"
+                    )
+        elif isinstance(orig_val, BaseEstimator):
+            assert type(orig_val) is type(cloned_val), f"{name}: parameter {key!r} changed type under clone()"
+        else:
+            assert _safe_equal(orig_val, cloned_val), (
+                f"{name}: parameter {key!r} expected {orig_val!r}, got {cloned_val!r}"
+            )
+
+
+def check_get_set_params_round_trip(estimator) -> None:
+    """Check ``set_params(**get_params(deep=True))`` is a no-op.
+
+    Also asserts every ``get_params(deep=False)`` key is a constructor
+    parameter (the sklearn ``get_params`` contract).
+
+    Parameters
+    ----------
+    estimator : BaseEstimator
+        Estimator instance.
+
+    Raises
+    ------
+    AssertionError
+        If the round-trip mutates shallow params or a shallow key is not a
+        constructor parameter.
+
+    """
+    name = type(estimator).__name__
+
+    init_params = {p for p in inspect.signature(type(estimator).__init__).parameters if p != "self"}
+    shallow = estimator.get_params(deep=False)
+    for key in shallow:
+        assert key in init_params, f"{name}: get_params key {key!r} is not a constructor parameter"
+
+    before = estimator.get_params(deep=False)
+    estimator.set_params(**estimator.get_params(deep=True))
+    after = estimator.get_params(deep=False)
+
+    assert set(before.keys()) == set(after.keys()), f"{name}: set_params round-trip changed parameter keys"
+    for key, before_val in before.items():
+        after_val = after[key]
+        if isinstance(before_val, BaseEstimator) or (
+            isinstance(before_val, list) and before_val and isinstance(before_val[0], tuple)
+        ):
+            continue  # nested estimators compare by identity/structure, not equality
+        assert _safe_equal(before_val, after_val), (
+            f"{name}: set_params round-trip changed {key!r}: {before_val!r} -> {after_val!r}"
+        )
+
+
+def check_init_no_param_mutation(estimator) -> None:
+    """Check ``__init__`` stores constructor arguments verbatim.
+
+    For every constructor parameter with a default, a default-constructed
+    instance must store that exact default (e.g. ``metric_params=None`` stays
+    ``None``, never ``{}``). Catches the init-mutation bug class.
+
+    Parameters
+    ----------
+    estimator : BaseEstimator
+        Estimator instance (used only for its type).
+
+    Raises
+    ------
+    AssertionError
+        If a stored attribute differs from the constructor default.
+
+    """
+    cls = type(estimator)
+    name = cls.__name__
+    signature = inspect.signature(cls.__init__)
+
+    if any(
+        p.default is inspect.Parameter.empty and pname not in ("self",)
+        for pname, p in signature.parameters.items()
+        if p.kind in (p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY)
+    ):
+        return  # not default-constructible; skip (covered where representative instances exist)
+
+    fresh = cls()
+    for pname, param in signature.parameters.items():
+        if pname == "self" or param.default is inspect.Parameter.empty:
+            continue
+        if not hasattr(fresh, pname):
+            continue  # stored under a different name (e.g. a property); out of scope here
+        stored = getattr(fresh, pname)
+        default = param.default
+        if default is None:
+            assert stored is None, f"{name}: __init__ mutated {pname!r} from None to {stored!r}"
+        else:
+            assert stored == default, f"{name}: __init__ mutated {pname!r} from {default!r} to {stored!r}"
+
+
+def _yield_estimator_contract_checks(
+    estimator,
+) -> Generator[tuple[str, Callable, dict], None, None]:
+    """Yield the shared sklearn estimator-contract checks.
+
+    Parameters
+    ----------
+    estimator : BaseEstimator
+        Estimator instance the checks run against.
+
+    Yields
+    ------
+    tuple of (str, callable, dict)
+        ``(check_name, check_func, check_kwargs)`` consumable by ``run_checks``.
+
+    """
+    yield "check_clone_preserves_params", check_clone_preserves_params, {}
+    yield "check_get_set_params_round_trip", check_get_set_params_round_trip, {}
+    yield "check_init_no_param_mutation", check_init_no_param_mutation, {}
+
+
+# ---------------------------------------------------------------------------
+# Composition-contract checks (data-free part of the _BaseComposition contract)
+# ---------------------------------------------------------------------------
+
+
+def _first_named_component(compositor, attr: str) -> tuple[str, BaseEstimator]:
+    """Return the ``(name, estimator)`` of the first component, handling 3-tuples."""
+    entries = getattr(compositor, attr)
+    first = entries[0]
+    return first[0], first[1]
+
+
+def check_composition_nested_param_addressable(compositor, descriptor: dict) -> None:
+    """Check nested ``<name>__<param>`` get/set on a ``_BaseComposition``.
+
+    ``get_params(deep=True)`` must expose the first component's parameters as
+    ``<name>__<param>``, and ``set_params(<name>__<param>=value)`` must round-trip.
+
+    Parameters
+    ----------
+    compositor : BaseEstimator
+        A ``_BaseComposition``-based compositor instance.
+    descriptor : dict
+        Carries the composition-attribute name under ``"attr"``.
+
+    Raises
+    ------
+    AssertionError
+        If the nested parameter is absent or does not round-trip.
+
+    """
+    name = type(compositor).__name__
+    attr = descriptor["attr"]
+    comp_name, inner = _first_named_component(compositor, attr)
+
+    inner_params = inner.get_params(deep=False)
+    if not inner_params:
+        return  # component exposes no params; nothing to address
+
+    param = next(iter(inner_params))
+    key = f"{comp_name}__{param}"
+
+    deep = compositor.get_params(deep=True)
+    assert key in deep, f"{name}: get_params(deep=True) missing nested key {key!r}"
+
+    value = deep[key]
+    compositor.set_params(**{key: value})
+    assert compositor.get_params(deep=True)[key] == value or compositor.get_params(deep=True)[key] is value, (
+        f"{name}: set_params({key}=...) did not round-trip"
+    )
+
+
+def check_composition_clone_deep_clones_components(compositor, descriptor: dict) -> None:
+    """Check ``clone(compositor)`` produces fresh same-type components.
+
+    Parameters
+    ----------
+    compositor : BaseEstimator
+        A ``_BaseComposition``-based compositor instance.
+    descriptor : dict
+        Carries the composition-attribute name under ``"attr"``.
+
+    Raises
+    ------
+    AssertionError
+        If a cloned component is the same instance or a different type.
+
+    """
+    name = type(compositor).__name__
+    attr = descriptor["attr"]
+    cloned = clone(compositor)
+
+    orig_entries = getattr(compositor, attr)
+    cloned_entries = getattr(cloned, attr)
+    assert len(orig_entries) == len(cloned_entries), f"{name}: clone() changed component count"
+
+    for orig, cl in zip(orig_entries, cloned_entries, strict=True):
+        orig_est, cl_est = orig[1], cl[1]
+        if not isinstance(orig_est, BaseEstimator):
+            continue  # 'passthrough'/None sentinels
+        assert type(orig_est) is type(cl_est), f"{name}: component {orig[0]!r} changed type under clone()"
+        assert orig_est is not cl_est, f"{name}: component {orig[0]!r} was not deep-cloned (same instance)"
+
+
+def _yield_composition_contract_checks(
+    compositor,
+    descriptor: dict,
+) -> Generator[tuple[str, Callable, dict], None, None]:
+    """Yield the data-free generic ``_BaseComposition`` contract checks.
+
+    Parameters
+    ----------
+    compositor : BaseEstimator
+        A ``_BaseComposition``-based compositor instance.
+    descriptor : dict
+        Per-compositor descriptor with the composition-attribute name under
+        ``"attr"``.
+
+    Yields
+    ------
+    tuple of (str, callable, dict)
+        ``(check_name, check_func, check_kwargs)`` consumable by ``run_checks``.
+
+    """
+    yield (
+        "check_composition_nested_param_addressable",
+        check_composition_nested_param_addressable,
+        {"descriptor": descriptor},
+    )
+    yield (
+        "check_composition_clone_deep_clones_components",
+        check_composition_clone_deep_clones_components,
+        {"descriptor": descriptor},
+    )

--- a/src/yohou/testing/contract.py
+++ b/src/yohou/testing/contract.py
@@ -60,11 +60,6 @@ __all__ = [
 ]
 
 
-# ---------------------------------------------------------------------------
-# Estimator-contract checks (sklearn contract)
-# ---------------------------------------------------------------------------
-
-
 def check_clone_preserves_params(estimator) -> None:
     """Check ``clone()`` preserves shallow params and freshens nested estimators.
 
@@ -222,11 +217,6 @@ def _yield_estimator_contract_checks(
     yield "check_clone_preserves_params", check_clone_preserves_params, {}
     yield "check_get_set_params_round_trip", check_get_set_params_round_trip, {}
     yield "check_init_no_param_mutation", check_init_no_param_mutation, {}
-
-
-# ---------------------------------------------------------------------------
-# Composition-contract checks (data-free part of the _BaseComposition contract)
-# ---------------------------------------------------------------------------
 
 
 def _first_named_component(compositor, attr: str) -> tuple[str, BaseEstimator]:

--- a/src/yohou/testing/generators.py
+++ b/src/yohou/testing/generators.py
@@ -9,8 +9,10 @@ from typing import Any
 
 import polars as pl
 
+from yohou.interval.similarity import CompositeSimilarity
 from yohou.model_selection import GridSearchCV
 from yohou.utils import inspect_panel
+from yohou.weighting.weighters import CompositeWeighter
 
 from .class_proba import (
     check_class_proba_classes_attribute,
@@ -24,6 +26,8 @@ from .common import (
     check_metadata_routing_default_request,
     check_metadata_routing_get_metadata_routing,
 )
+from .composite import _yield_composite_reducer_checks
+from .contract import _yield_estimator_contract_checks
 from .forecaster import (
     check_clone_preserves_forecaster_params,
     check_fit_predict_with_X_forecast,
@@ -92,6 +96,12 @@ from .search import (
     check_search_return_train_score,
     check_search_rewind_delegates,
 )
+from .similarity import (
+    check_similarity_methods_call_check_is_fitted,
+    check_similarity_metric_params_verbatim,
+    check_similarity_predict_matrix_shape,
+    check_similarity_to_weights_rows_reserve_mass,
+)
 from .splitter import (
     check_splitter_n_splits_consistency,
     check_splitter_non_overlapping_tests,
@@ -129,6 +139,14 @@ from .transformer import (
     check_transformer_methods_call_check_is_fitted,
     check_transformer_preserve_dtypes,
     check_transformers_unfitted_stateless,
+)
+from .weighter import (
+    check_weighter_compute_weights_alignment,
+    check_weighter_default_constructible,
+    check_weighter_fit_noop_returns_self,
+    check_weighter_resolved_array_validation,
+    check_weighter_tags_accessible_before_fit,
+    check_weighter_tags_static_after_fit,
 )
 
 
@@ -1290,3 +1308,85 @@ def _yield_yohou_search_checks(
                     "X_forecast": X_forecast_test,
                 },
             )
+
+
+def _yield_yohou_weighter_checks(
+    weighter,
+    key: pl.Series,
+) -> Generator[tuple[str, Callable, dict], None, None]:
+    """Generate applicable checks for a weighter.
+
+    Yields the weighter-family behavioral checks, the shared sklearn
+    estimator-contract checks, and (for ``CompositeWeighter``) the reducer and
+    bare-list checks.
+
+    Parameters
+    ----------
+    weighter : BaseWeighter
+        Weighter instance.
+    key : pl.Series
+        Key series (datetime or integer) to weight.
+
+    Yields
+    ------
+    tuple of (str, callable, dict)
+        ``(check_name, check_func, check_kwargs)`` consumable by ``run_checks``.
+
+    """
+    yield "check_weighter_compute_weights_alignment", check_weighter_compute_weights_alignment, {"key": key}
+    yield "check_weighter_fit_noop_returns_self", check_weighter_fit_noop_returns_self, {}
+    yield "check_weighter_resolved_array_validation", check_weighter_resolved_array_validation, {"key": key}
+    yield "check_weighter_default_constructible", check_weighter_default_constructible, {}
+    yield "check_weighter_tags_accessible_before_fit", check_weighter_tags_accessible_before_fit, {}
+    yield "check_weighter_tags_static_after_fit", check_weighter_tags_static_after_fit, {}
+
+    yield from _yield_estimator_contract_checks(weighter)
+
+    if isinstance(weighter, CompositeWeighter):
+        descriptor = {"attr": "weighters", "components": list(weighter.weighters)}
+        yield from _yield_composite_reducer_checks(weighter, descriptor, operate=lambda c: c.compute_weights(key))
+
+
+def _yield_yohou_similarity_checks(
+    similarity,
+    y_calib: pl.DataFrame,
+    y_pred_calib: pl.DataFrame,
+) -> Generator[tuple[str, Callable, dict], None, None]:
+    """Generate applicable checks for a similarity measure.
+
+    Yields the similarity-family behavioral checks, the shared sklearn
+    estimator-contract checks, and (for ``CompositeSimilarity``) the reducer and
+    bare-list checks.
+
+    Parameters
+    ----------
+    similarity : BaseSimilarity
+        Similarity instance.
+    y_calib : pl.DataFrame
+        Calibration target frame (matching ``fit(y, y_pred, X_actual=None)``).
+    y_pred_calib : pl.DataFrame
+        Calibration prediction frame.
+
+    Yields
+    ------
+    tuple of (str, callable, dict)
+        ``(check_name, check_func, check_kwargs)`` consumable by ``run_checks``.
+
+    """
+    calib = {"y_calib": y_calib, "y_pred_calib": y_pred_calib}
+    yield "check_similarity_predict_matrix_shape", check_similarity_predict_matrix_shape, calib
+    yield "check_similarity_to_weights_rows_reserve_mass", check_similarity_to_weights_rows_reserve_mass, calib
+    yield "check_similarity_metric_params_verbatim", check_similarity_metric_params_verbatim, {}
+    yield (
+        "check_similarity_methods_call_check_is_fitted",
+        check_similarity_methods_call_check_is_fitted,
+        {"y_pred_calib": y_pred_calib},
+    )
+
+    yield from _yield_estimator_contract_checks(similarity)
+
+    if isinstance(similarity, CompositeSimilarity):
+        descriptor = {"attr": "similarities", "components": list(similarity.similarities)}
+        yield from _yield_composite_reducer_checks(
+            similarity, descriptor, operate=lambda c: c.fit(y_calib, y_pred_calib)
+        )

--- a/src/yohou/testing/similarity.py
+++ b/src/yohou/testing/similarity.py
@@ -1,0 +1,151 @@
+"""Check functions for yohou similarity measures.
+
+Systematic validation functions for the ``BaseSimilarity`` estimator family
+(interval-forecasting similarity measures). All check functions raise
+AssertionError on failure.
+"""
+
+try:
+    import polars as pl
+except ImportError as e:
+    raise ImportError("polars is required for yohou.testing module. Install with: uv sync --group tests") from e
+
+import numpy as np
+from sklearn.base import clone
+from sklearn.exceptions import NotFittedError
+
+__all__ = [
+    "check_similarity_metric_params_verbatim",
+    "check_similarity_methods_call_check_is_fitted",
+    "check_similarity_predict_matrix_shape",
+    "check_similarity_to_weights_rows_reserve_mass",
+]
+
+
+def check_similarity_predict_matrix_shape(similarity, y_calib: pl.DataFrame, y_pred_calib: pl.DataFrame) -> None:
+    """Check ``predict`` returns an ``(n_pred, n_calib)`` weight matrix.
+
+    Parameters
+    ----------
+    similarity : BaseSimilarity
+        Similarity instance.
+    y_calib : pl.DataFrame
+        Calibration target frame.
+    y_pred_calib : pl.DataFrame
+        Calibration prediction frame.
+
+    Raises
+    ------
+    AssertionError
+        If ``predict`` does not return the expected ``(n_pred, n_calib)`` shape.
+
+    """
+    name = type(similarity).__name__
+    sim = clone(similarity)
+    sim.fit(y_calib, y_pred_calib)
+
+    n_pred = 2
+    query = y_pred_calib.head(n_pred)
+    weights = sim.predict(query)
+    assert isinstance(weights, np.ndarray), f"{name}.predict must return np.ndarray, got {type(weights)}"
+    assert weights.shape == (n_pred, len(y_calib)), (
+        f"{name}.predict returned shape {weights.shape}, expected ({n_pred}, {len(y_calib)})"
+    )
+
+
+def check_similarity_to_weights_rows_reserve_mass(
+    similarity, y_calib: pl.DataFrame, y_pred_calib: pl.DataFrame
+) -> None:
+    """Check each predicted weight row is non-negative and sums below 1.
+
+    Pins the ``BaseSimilarity._to_weights`` / ``_reserve_mass`` invariant: a
+    softmax of negative distances re-normalized as ``raw / (sum(raw) + 1)``, so
+    every row reserves mass for the (hypothetical) test point.
+
+    Parameters
+    ----------
+    similarity : BaseSimilarity
+        Similarity instance.
+    y_calib : pl.DataFrame
+        Calibration target frame.
+    y_pred_calib : pl.DataFrame
+        Calibration prediction frame.
+
+    Raises
+    ------
+    AssertionError
+        If any row is negative or sums to 1 or more.
+
+    """
+    name = type(similarity).__name__
+    sim = clone(similarity)
+    sim.fit(y_calib, y_pred_calib)
+
+    weights = sim.predict(y_pred_calib.head(2))
+    assert np.all(weights >= 0), f"{name}.predict produced negative weights"
+    row_sums = weights.sum(axis=1)
+    assert np.all(row_sums < 1.0), (
+        f"{name}.predict rows must sum to < 1 (reserved-mass invariant), got max row sum {row_sums.max()}"
+    )
+
+
+def check_similarity_metric_params_verbatim(similarity) -> None:
+    """Check ``metric_params=None`` is stored verbatim (no init-mutation).
+
+    Skipped for similarities without a ``metric_params`` parameter.
+
+    Parameters
+    ----------
+    similarity : BaseSimilarity
+        Similarity instance (used for its type).
+
+    Raises
+    ------
+    AssertionError
+        If a default-constructed instance mutates ``metric_params`` away from None.
+
+    """
+    cls = type(similarity)
+    if "metric_params" not in cls().get_params(deep=False):
+        return
+    fresh = cls()
+    assert fresh.metric_params is None, (
+        f"{cls.__name__}: default metric_params mutated from None to {fresh.metric_params!r}"
+    )
+    assert fresh.get_params(deep=False)["metric_params"] is None, (
+        f"{cls.__name__}: get_params reports metric_params as {fresh.get_params(deep=False)['metric_params']!r}, not None"
+    )
+
+
+def check_similarity_methods_call_check_is_fitted(similarity, y_pred_calib: pl.DataFrame) -> None:
+    """Check query methods raise ``NotFittedError`` before ``fit``.
+
+    Parameters
+    ----------
+    similarity : BaseSimilarity
+        Similarity instance.
+    y_pred_calib : pl.DataFrame
+        A prediction frame to pass to the unfitted query methods.
+
+    Raises
+    ------
+    AssertionError
+        If ``predict`` or ``observe`` does not raise ``NotFittedError`` when unfitted.
+
+    """
+    name = type(similarity).__name__
+    query = y_pred_calib.head(2)
+
+    unfitted = clone(similarity)
+    try:
+        unfitted.predict(query)
+        raise AssertionError(f"{name}.predict() must raise NotFittedError when unfitted")
+    except NotFittedError:
+        pass
+
+    unfitted2 = clone(similarity)
+    try:
+        unfitted2.observe(query, query)
+        raise AssertionError(f"{name}.observe() must raise NotFittedError when unfitted")
+    except NotFittedError:
+        pass

--- a/src/yohou/testing/similarity.py
+++ b/src/yohou/testing/similarity.py
@@ -5,12 +5,8 @@ Systematic validation functions for the ``BaseSimilarity`` estimator family
 AssertionError on failure.
 """
 
-try:
-    import polars as pl
-except ImportError as e:
-    raise ImportError("polars is required for yohou.testing module. Install with: uv sync --group tests") from e
-
 import numpy as np
+import polars as pl
 from sklearn.base import clone
 from sklearn.exceptions import NotFittedError
 

--- a/src/yohou/testing/weighter.py
+++ b/src/yohou/testing/weighter.py
@@ -4,12 +4,8 @@ Systematic validation functions for the ``BaseWeighter`` estimator family
 (time-axis weighters). All check functions raise AssertionError on failure.
 """
 
-try:
-    import polars as pl
-except ImportError as e:
-    raise ImportError("polars is required for yohou.testing module. Install with: uv sync --group tests") from e
-
 import numpy as np
+import polars as pl
 
 from yohou.weighting.weighters import BaseWeighter, _resolve_weighter_to_array
 

--- a/src/yohou/testing/weighter.py
+++ b/src/yohou/testing/weighter.py
@@ -1,0 +1,176 @@
+"""Check functions for yohou weighters.
+
+Systematic validation functions for the ``BaseWeighter`` estimator family
+(time-axis weighters). All check functions raise AssertionError on failure.
+"""
+
+try:
+    import polars as pl
+except ImportError as e:
+    raise ImportError("polars is required for yohou.testing module. Install with: uv sync --group tests") from e
+
+import numpy as np
+
+from yohou.weighting.weighters import BaseWeighter, _resolve_weighter_to_array
+
+__all__ = [
+    "check_weighter_compute_weights_alignment",
+    "check_weighter_default_constructible",
+    "check_weighter_fit_noop_returns_self",
+    "check_weighter_resolved_array_validation",
+    "check_weighter_tags_accessible_before_fit",
+    "check_weighter_tags_static_after_fit",
+]
+
+
+def check_weighter_compute_weights_alignment(weighter, key: pl.Series) -> None:
+    """Check ``compute_weights`` returns one weight per key element.
+
+    Parameters
+    ----------
+    weighter : BaseWeighter
+        Weighter instance.
+    key : pl.Series
+        Key series to weight.
+
+    Raises
+    ------
+    AssertionError
+        If the output is not a ``pl.Series`` aligned 1:1 with ``key``.
+
+    """
+    name = type(weighter).__name__
+    weights = weighter.compute_weights(key)
+    assert isinstance(weights, pl.Series), f"{name}.compute_weights must return pl.Series, got {type(weights)}"
+    assert len(weights) == len(key), (
+        f"{name}.compute_weights returned {len(weights)} weights, expected {len(key)} (one per key element)"
+    )
+
+
+def check_weighter_fit_noop_returns_self(weighter) -> None:
+    """Check ``fit`` is a no-op returning self that leaves params unchanged.
+
+    Parameters
+    ----------
+    weighter : BaseWeighter
+        Weighter instance.
+
+    Raises
+    ------
+    AssertionError
+        If ``fit`` does not return ``self`` or alters constructor parameters.
+
+    """
+    name = type(weighter).__name__
+    before = weighter.get_params(deep=False)
+    returned = weighter.fit(None)
+    assert returned is weighter, f"{name}.fit() must return self"
+    after = weighter.get_params(deep=False)
+    assert before.keys() == after.keys(), f"{name}.fit() changed parameter keys"
+
+
+def check_weighter_resolved_array_validation(weighter, key: pl.Series) -> None:
+    """Check resolved-array validation rejects NaN/negative/inf/all-zero.
+
+    Drives ``_resolve_weighter_to_array`` (and ``_validate_weight_array``) with
+    weighters whose resolution yields each invalid case and asserts a
+    ``ValueError`` is raised.
+
+    Parameters
+    ----------
+    weighter : BaseWeighter
+        Weighter instance (unused; the check is family-level).
+    key : pl.Series
+        Key series with which to resolve the stub weighters.
+
+    Raises
+    ------
+    AssertionError
+        If any invalid resolved array is accepted.
+
+    """
+    n = len(key)
+
+    class _BadWeighter(BaseWeighter):
+        def __init__(self, values: np.ndarray) -> None:
+            self._values = values
+
+        def compute_weights(self, key: pl.Series, group_name: str | None = None) -> pl.Series:
+            return pl.Series(self._values, dtype=pl.Float64).alias("weight")
+
+    cases = {
+        "NaN": np.array([np.nan] + [1.0] * (n - 1)),
+        "negative": np.array([-1.0] + [1.0] * (n - 1)),
+        "infinite": np.array([np.inf] + [1.0] * (n - 1)),
+        "all-zero": np.zeros(n),
+    }
+    for label, values in cases.items():
+        try:
+            _resolve_weighter_to_array(_BadWeighter(values), key)
+        except ValueError:
+            continue
+        raise AssertionError(f"resolved-array validation accepted {label} weights; expected ValueError")
+
+
+def check_weighter_default_constructible(weighter) -> None:
+    """Check the weighter class is constructible with no arguments.
+
+    Parameters
+    ----------
+    weighter : BaseWeighter
+        Weighter instance (used for its type).
+
+    Raises
+    ------
+    AssertionError
+        If ``type(weighter)()`` raises.
+
+    """
+    cls = type(weighter)
+    try:
+        cls()
+    except Exception as e:  # noqa: BLE001
+        raise AssertionError(f"{cls.__name__} is not default-constructible: {type(e).__name__}: {e}") from e
+
+
+def check_weighter_tags_accessible_before_fit(weighter) -> None:
+    """Check ``__sklearn_tags__()`` is callable on an unfitted weighter.
+
+    Parameters
+    ----------
+    weighter : BaseWeighter
+        Weighter instance.
+
+    Raises
+    ------
+    AssertionError
+        If tags are not accessible.
+
+    """
+    name = type(weighter).__name__
+    assert hasattr(weighter, "__sklearn_tags__"), f"{name} must have __sklearn_tags__()"
+    try:
+        weighter.__sklearn_tags__()
+    except Exception as e:  # noqa: BLE001
+        raise AssertionError(f"{name}.__sklearn_tags__() raised {type(e).__name__}: {e}") from e
+
+
+def check_weighter_tags_static_after_fit(weighter) -> None:
+    """Check tags are unchanged by the no-op ``fit``.
+
+    Parameters
+    ----------
+    weighter : BaseWeighter
+        Unfitted weighter instance.
+
+    Raises
+    ------
+    AssertionError
+        If tags change after ``fit``.
+
+    """
+    name = type(weighter).__name__
+    before = weighter.__sklearn_tags__()
+    weighter.fit(None)
+    after = weighter.__sklearn_tags__()
+    assert before == after, f"{name} tags changed after fit() - tags should be static"

--- a/tests/compose/test_column_transformer.py
+++ b/tests/compose/test_column_transformer.py
@@ -547,3 +547,27 @@ class TestColumnTransformerTagsAggregation:
         )
         tags = ct.__sklearn_tags__()
         assert tags.input_tags.min_value is None or isinstance(tags.input_tags.min_value, int | float)
+
+
+class TestColumnTransformerNestedParams:
+    """Nested ``<name>__<param>`` get/set over the 3-tuple ``transformers`` form."""
+
+    def test_get_params_exposes_nested(self):
+        ct = ColumnTransformer(transformers=[("s", SimpleTransformer(add_constant=1.0), ["a"])])
+        params = ct.get_params(deep=True)
+        assert "s__add_constant" in params
+        assert params["s__add_constant"] == 1.0
+
+    def test_set_params_routes_nested(self):
+        ct = ColumnTransformer(transformers=[("s", SimpleTransformer(add_constant=1.0), ["a"])])
+        ct.set_params(s__add_constant=5.0)
+        assert {n: t for n, t, _ in ct.transformers}["s"].add_constant == 5.0
+
+    def test_replace_component_preserves_columns(self):
+        ct = ColumnTransformer(transformers=[("s", SimpleTransformer(), ["a"])])
+        # Replacing a whole component routes through the _transformers setter,
+        # which rebuilds the 3-tuple and preserves the original columns.
+        ct.set_params(s=StatelessTransformer())
+        assert len(ct.transformers[0]) == 3
+        assert ct.transformers[0][2] == ["a"]
+        assert isinstance(ct.transformers[0][1], StatelessTransformer)

--- a/tests/interval/test_similarity.py
+++ b/tests/interval/test_similarity.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import polars as pl
 import pytest
-from sklearn.base import clone
 
 from yohou.interval.similarity import CompositeSimilarity, DistanceSimilarity, SeasonalSimilarity
 
@@ -48,46 +47,6 @@ def prediction_data():
 
 class TestDistanceSimilarityBasic:
     """Basic tests for DistanceSimilarity."""
-
-    def test_fit_returns_self(self, train_data):
-        """Test that fit returns the estimator."""
-        y, y_pred = train_data
-        sim = DistanceSimilarity()
-        result = sim.fit(y, y_pred)
-        assert result is sim
-
-    def test_predict_returns_ndarray(self, train_data, prediction_data):
-        """Test that predict returns a numpy array."""
-        y, y_pred = train_data
-        sim = DistanceSimilarity()
-        sim.fit(y, y_pred)
-        weights = sim.predict(prediction_data)
-        assert isinstance(weights, np.ndarray)
-
-    def test_predict_shape(self, train_data, prediction_data):
-        """Test that predict returns correct shape."""
-        y, y_pred = train_data
-        sim = DistanceSimilarity()
-        sim.fit(y, y_pred)
-        weights = sim.predict(prediction_data)
-        # Shape: (n_test_samples, n_train_samples)
-        assert weights.shape == (2, 8)
-
-    def test_weights_are_positive(self, train_data, prediction_data):
-        """Test that all weights are positive."""
-        y, y_pred = train_data
-        sim = DistanceSimilarity()
-        sim.fit(y, y_pred)
-        weights = sim.predict(prediction_data)
-        assert np.all(weights > 0)
-
-    def test_weights_are_finite(self, train_data, prediction_data):
-        """Test that all weights are finite."""
-        y, y_pred = train_data
-        sim = DistanceSimilarity()
-        sim.fit(y, y_pred)
-        weights = sim.predict(prediction_data)
-        assert np.all(np.isfinite(weights))
 
     def test_default_metric(self):
         """Test default metric is euclidean."""
@@ -195,37 +154,6 @@ class TestDistanceSimilarityWithExogenous:
         assert weights.shape == (2, 8)
 
 
-class TestDistanceSimilarityProperties:
-    """Tests for properties and attributes."""
-
-    def test_clone(self):
-        """Test that DistanceSimilarity can be cloned."""
-        sim = DistanceSimilarity(metric="cityblock")
-        cloned = clone(sim)
-        assert cloned.metric == "cityblock"
-        assert cloned is not sim
-
-    def test_get_params(self):
-        """Test get_params returns expected parameters."""
-        sim = DistanceSimilarity(metric="cosine", metric_params={"p": 2})
-        params = sim.get_params()
-        assert params["metric"] == "cosine"
-        assert params["metric_params"] == {"p": 2}
-
-    def test_set_params(self):
-        """Test set_params updates parameters."""
-        sim = DistanceSimilarity()
-        sim.set_params(metric="cityblock")
-        assert sim.metric == "cityblock"
-
-    def test_tags(self):
-        """Test sklearn tags are set correctly."""
-        sim = DistanceSimilarity()
-        tags = sim.__sklearn_tags__()
-        assert tags.estimator_type == "similarity"
-        assert tags.requires_fit is True
-
-
 @pytest.fixture
 def daily_data():
     """Create 10 weeks of daily data with weekly seasonality."""
@@ -318,29 +246,6 @@ class TestDistanceSimilarityNullRejection:
 class TestSeasonalSimilarityBasic:
     """Basic tests for SeasonalSimilarity."""
 
-    def test_fit_returns_self(self, daily_data):
-        """Test that fit returns the estimator."""
-        y, y_pred = daily_data
-        sim = SeasonalSimilarity(seasonalities=[7.0])
-        result = sim.fit(y, y_pred)
-        assert result is sim
-
-    def test_predict_returns_ndarray(self, daily_data, daily_prediction_data):
-        """Test that predict returns a numpy array."""
-        y, y_pred = daily_data
-        sim = SeasonalSimilarity(seasonalities=[7.0])
-        sim.fit(y, y_pred)
-        weights = sim.predict(daily_prediction_data)
-        assert isinstance(weights, np.ndarray)
-
-    def test_predict_shape(self, daily_data, daily_prediction_data):
-        """Test that predict returns correct shape."""
-        y, y_pred = daily_data
-        sim = SeasonalSimilarity(seasonalities=[7.0])
-        sim.fit(y, y_pred)
-        weights = sim.predict(daily_prediction_data)
-        assert weights.shape == (1, 70)
-
     def test_predict_shape_multi_row(self, daily_data):
         """Test predict shape with multiple prediction rows."""
         y, y_pred = daily_data
@@ -351,30 +256,6 @@ class TestSeasonalSimilarityBasic:
         y_pred_new = pl.DataFrame({"time": dates, "value": [1.0, 2.0, 3.0]})
         weights = sim.predict(y_pred_new)
         assert weights.shape == (3, 70)
-
-    def test_weights_are_positive(self, daily_data, daily_prediction_data):
-        """Test that all weights are positive."""
-        y, y_pred = daily_data
-        sim = SeasonalSimilarity(seasonalities=[7.0])
-        sim.fit(y, y_pred)
-        weights = sim.predict(daily_prediction_data)
-        assert np.all(weights > 0)
-
-    def test_weights_are_finite(self, daily_data, daily_prediction_data):
-        """Test that all weights are finite."""
-        y, y_pred = daily_data
-        sim = SeasonalSimilarity(seasonalities=[7.0])
-        sim.fit(y, y_pred)
-        weights = sim.predict(daily_prediction_data)
-        assert np.all(np.isfinite(weights))
-
-    def test_weights_row_sum_less_than_one(self, daily_data, daily_prediction_data):
-        """Test that weight rows sum to less than 1 (uniform component reserved)."""
-        y, y_pred = daily_data
-        sim = SeasonalSimilarity(seasonalities=[7.0])
-        sim.fit(y, y_pred)
-        weights = sim.predict(daily_prediction_data)
-        assert np.all(np.sum(weights, axis=1) < 1.0)
 
     def test_empty_seasonalities_raises(self, daily_data):
         """Test that empty seasonalities raises ValueError."""
@@ -524,39 +405,6 @@ class TestSeasonalSimilarityObserve:
 
 class TestSeasonalSimilarityProperties:
     """Tests for properties and sklearn compatibility."""
-
-    def test_clone(self):
-        """Test that SeasonalSimilarity can be cloned."""
-        sim = SeasonalSimilarity(seasonalities=[7.0, 365.25], metric="cityblock")
-        cloned = clone(sim)
-        assert cloned.seasonalities == [7.0, 365.25]
-        assert cloned.metric == "cityblock"
-        assert cloned is not sim
-
-    def test_get_params(self):
-        """Test get_params returns expected parameters."""
-        sim = SeasonalSimilarity(
-            seasonalities=[7.0],
-            harmonics={7.0: [1, 2]},
-            metric="cosine",
-        )
-        params = sim.get_params()
-        assert params["seasonalities"] == [7.0]
-        assert params["harmonics"] == {7.0: [1, 2]}
-        assert params["metric"] == "cosine"
-
-    def test_set_params(self):
-        """Test set_params updates parameters."""
-        sim = SeasonalSimilarity(seasonalities=[7.0])
-        sim.set_params(metric="cityblock")
-        assert sim.metric == "cityblock"
-
-    def test_tags(self):
-        """Test sklearn tags are set correctly."""
-        sim = SeasonalSimilarity(seasonalities=[7.0])
-        tags = sim.__sklearn_tags__()
-        assert tags.estimator_type == "similarity"
-        assert tags.requires_fit is True
 
     def test_auto_detect_interval(self, daily_data):
         """Test that interval is auto-detected from timestamps."""
@@ -709,80 +557,6 @@ def composite_data():
 class TestCompositeSimilarityBasic:
     """Core fit/predict behaviour."""
 
-    def test_fit_returns_self(self, composite_data):
-        y, y_pred = composite_data
-        comp = CompositeSimilarity(
-            similarities=[
-                ("dist", DistanceSimilarity(metric="euclidean")),
-                ("seasonal", SeasonalSimilarity(seasonalities=[7.0])),
-            ],
-        )
-        result = comp.fit(y, y_pred)
-        assert result is comp
-
-    def test_predict_returns_ndarray(self, composite_data):
-        y, y_pred = composite_data
-        comp = CompositeSimilarity(
-            similarities=[
-                ("dist", DistanceSimilarity(metric="euclidean")),
-                ("seasonal", SeasonalSimilarity(seasonalities=[7.0])),
-            ],
-        )
-        comp.fit(y, y_pred)
-        new_pred = y_pred.tail(1)
-        weights = comp.predict(new_pred)
-        assert isinstance(weights, np.ndarray)
-
-    def test_predict_shape(self, composite_data):
-        y, y_pred = composite_data
-        comp = CompositeSimilarity(
-            similarities=[
-                ("dist", DistanceSimilarity(metric="euclidean")),
-                ("seasonal", SeasonalSimilarity(seasonalities=[7.0])),
-            ],
-        )
-        comp.fit(y, y_pred)
-        new_pred = y_pred.tail(3)
-        weights = comp.predict(new_pred)
-        assert weights.shape == (3, len(y_pred))
-
-    def test_weights_are_positive(self, composite_data):
-        y, y_pred = composite_data
-        comp = CompositeSimilarity(
-            similarities=[
-                ("dist", DistanceSimilarity(metric="euclidean")),
-                ("seasonal", SeasonalSimilarity(seasonalities=[7.0])),
-            ],
-        )
-        comp.fit(y, y_pred)
-        weights = comp.predict(y_pred.tail(1))
-        assert np.all(weights > 0)
-
-    def test_weights_are_finite(self, composite_data):
-        y, y_pred = composite_data
-        comp = CompositeSimilarity(
-            similarities=[
-                ("dist", DistanceSimilarity(metric="euclidean")),
-                ("seasonal", SeasonalSimilarity(seasonalities=[7.0])),
-            ],
-        )
-        comp.fit(y, y_pred)
-        weights = comp.predict(y_pred.tail(1))
-        assert np.all(np.isfinite(weights))
-
-    def test_row_sum_less_than_one_multiply(self, composite_data):
-        y, y_pred = composite_data
-        comp = CompositeSimilarity(
-            similarities=[
-                ("dist", DistanceSimilarity(metric="euclidean")),
-                ("seasonal", SeasonalSimilarity(seasonalities=[7.0])),
-            ],
-            combination="multiply",
-        )
-        comp.fit(y, y_pred)
-        weights = comp.predict(y_pred.tail(2))
-        assert np.all(weights.sum(axis=1) < 1.0)
-
     def test_mean_combination(self, composite_data):
         y, y_pred = composite_data
         comp = CompositeSimilarity(
@@ -796,48 +570,6 @@ class TestCompositeSimilarityBasic:
         weights = comp.predict(y_pred.tail(1))
         assert weights.shape == (1, len(y_pred))
         assert np.all(weights > 0)
-
-
-class TestCompositeSimilarityValidation:
-    """Parameter validation."""
-
-    def test_fewer_than_two_raises(self):
-        comp = CompositeSimilarity(similarities=[DistanceSimilarity()])
-        with pytest.raises(ValueError, match="at least 2"):
-            comp.fit(
-                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
-                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
-            )
-
-    def test_none_similarities_raises(self):
-        comp = CompositeSimilarity(similarities=None)
-        with pytest.raises(ValueError, match="at least 2"):
-            comp.fit(
-                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
-                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
-            )
-
-    def test_invalid_combination_raises(self):
-        comp = CompositeSimilarity(
-            similarities=[("a", DistanceSimilarity()), ("b", DistanceSimilarity())],
-            combination="invalid",
-        )
-        with pytest.raises(ValueError, match="combination"):
-            comp.fit(
-                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
-                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
-            )
-
-    def test_weights_length_mismatch_raises(self):
-        comp = CompositeSimilarity(
-            similarities=[("a", DistanceSimilarity()), ("b", DistanceSimilarity())],
-            weights=[1.0, 2.0, 3.0],
-        )
-        with pytest.raises(ValueError, match="weights length"):
-            comp.fit(
-                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
-                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
-            )
 
 
 class TestCompositeSimilarityWeights:
@@ -953,34 +685,6 @@ class TestCompositeSimilarityObserveRewind:
         assert comp.similarities_[1][1]._features_observed.shape[0] == n_temp_before
 
 
-class TestCompositeSimilarityProperties:
-    """sklearn estimator interface."""
-
-    def test_clone(self):
-        comp = CompositeSimilarity(
-            similarities=[
-                ("dist", DistanceSimilarity(metric="euclidean")),
-                ("seasonal", SeasonalSimilarity(seasonalities=[7.0])),
-            ],
-            combination="mean",
-            weights=[0.3, 0.7],
-        )
-        cloned = clone(comp)
-        assert cloned.combination == "mean"
-        assert cloned.weights == [0.3, 0.7]
-        assert len(cloned.similarities) == 2
-
-    def test_get_params(self):
-        comp = CompositeSimilarity(
-            similarities=[("dist", DistanceSimilarity()), ("seasonal", SeasonalSimilarity(seasonalities=[7.0]))],
-            combination="multiply",
-        )
-        params = comp.get_params()
-        assert params["combination"] == "multiply"
-        assert params["weights"] is None
-        assert len(params["similarities"]) == 2
-
-
 class TestCompositeSimilarityIntegration:
     """Integration with SplitConformalForecaster."""
 
@@ -1037,56 +741,6 @@ class TestSeasonalSimilaritySingleTimestamp:
         weights = sim.predict(y_pred)
         assert weights.shape == (1, 1)
         assert np.all(np.isfinite(weights))
-
-
-class TestCompositeSimilarityComposition:
-    """Real-composition behaviour: nested param addressing and clean rejection."""
-
-    def _comp(self):
-        return CompositeSimilarity(
-            similarities=[
-                ("dist", DistanceSimilarity(metric="euclidean")),
-                ("seasonal", SeasonalSimilarity(seasonalities=[7.0])),
-            ]
-        )
-
-    def test_nested_param_addressable(self):
-        params = self._comp().get_params(deep=True)
-        assert "dist__metric" in params
-        assert "seasonal__seasonalities" in params
-
-    def test_nested_param_settable(self):
-        comp = self._comp()
-        comp.set_params(dist__metric="cosine")
-        assert dict(comp.similarities)["dist"].metric == "cosine"
-
-    def test_clone_roundtrips(self):
-        comp = self._comp()
-        cloned = clone(comp)
-        assert isinstance(cloned, CompositeSimilarity)
-        assert dict(cloned.similarities)["dist"].metric == "euclidean"
-
-    def test_bare_list_rejected(self):
-        comp = CompositeSimilarity(similarities=[DistanceSimilarity(), SeasonalSimilarity(seasonalities=[7.0])])
-        with pytest.raises(ValueError, match="name, similarity"):
-            comp.fit(
-                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
-                pl.DataFrame({"time": [datetime(2021, 1, 1)], "value": [1.0]}),
-            )
-
-
-class TestDistanceSimilarityMetricParamsClone:
-    """metric_params init-mutation fix: stored verbatim, clone round-trips."""
-
-    def test_default_round_trips_as_none(self):
-        sim = DistanceSimilarity()
-        assert sim.metric_params is None
-        assert clone(sim).get_params() == sim.get_params()
-
-    def test_seasonal_default_round_trips_as_none(self):
-        sim = SeasonalSimilarity(seasonalities=[7.0])
-        assert sim.metric_params is None
-        assert clone(sim).get_params()["metric_params"] is None
 
 
 class TestSimilarityTuningThroughForecaster:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -14,15 +14,21 @@ from sklearn.base import clone
 
 from conftest import run_checks
 from yohou.base import BaseForecaster, BaseTransformer
+from yohou.interval.base import BaseSimilarity
 from yohou.metrics.base import BaseScorer
 from yohou.model_selection.split import BaseSplitter
 from yohou.testing import (
+    _yield_composition_contract_checks,
     _yield_yohou_forecaster_checks,
     _yield_yohou_scorer_checks,
+    _yield_yohou_similarity_checks,
     _yield_yohou_splitter_checks,
     _yield_yohou_transformer_checks,
+    _yield_yohou_weighter_checks,
 )
+from yohou.utils._compat import _BaseComposition
 from yohou.utils.discovery import all_estimators
+from yohou.weighting import BaseWeighter
 
 # These classes require special init args and can't be default-constructed
 # or need composition with inner estimators, so we exclude them from the
@@ -374,3 +380,171 @@ class TestClassProbaScorerCommon:
             instance.fit(y_truth)
 
         run_checks(instance, _yield_yohou_scorer_checks(instance, y_truth, y_pred))
+
+
+# ---------------------------------------------------------------------------
+# Weighter family
+# ---------------------------------------------------------------------------
+
+
+def _weighter_key() -> pl.Series:
+    """Five daily datetimes used as the weighter key fixture."""
+    return pl.Series("time", [datetime(2024, 1, d) for d in range(1, 6)])
+
+
+def _weighter_instances() -> dict[str, object]:
+    """Representative *working* weighter instances keyed by class name.
+
+    ``TableWeighter`` and ``CompositeWeighter`` are default-constructible but
+    cannot operate with default args, so concrete fixtures are supplied.
+    """
+    from yohou.weighting import (
+        CompositeWeighter,
+        ExponentialDecayWeighter,
+        LinearDecayWeighter,
+        LookupWeighter,
+        SeasonalEmphasisWeighter,
+        TableWeighter,
+    )
+
+    key = _weighter_key()
+    frame = pl.DataFrame({"time": key, "weight": [0.1, 0.2, 0.3, 0.2, 0.2]})
+    return {
+        "ExponentialDecayWeighter": ExponentialDecayWeighter(half_life=2),
+        "LinearDecayWeighter": LinearDecayWeighter(),
+        "SeasonalEmphasisWeighter": SeasonalEmphasisWeighter(seasonality=2),
+        "LookupWeighter": LookupWeighter(),
+        "TableWeighter": TableWeighter(frame=frame, on="time"),
+        "CompositeWeighter": CompositeWeighter([
+            ("decay", ExponentialDecayWeighter(half_life=2)),
+            ("lin", LinearDecayWeighter(max_steps=3)),
+        ]),
+    }
+
+
+class TestWeighterCommon:
+    """Run systematic checks on all discovered weighters."""
+
+    @pytest.mark.parametrize(
+        "name,cls",
+        [(n, c) for n, c in all_estimators() if issubclass(c, BaseWeighter)],
+        ids=[n for n, c in all_estimators() if issubclass(c, BaseWeighter)],
+    )
+    def test_weighter_checks(self, name, cls):
+        """Run all applicable check-generator checks for a weighter."""
+        instances = _weighter_instances()
+        assert name in instances, f"No representative instance registered for weighter {name}"
+        weighter = instances[name]
+        run_checks(weighter, _yield_yohou_weighter_checks(weighter, _weighter_key()))
+
+
+# ---------------------------------------------------------------------------
+# Similarity family
+# ---------------------------------------------------------------------------
+
+
+def _similarity_calibration() -> tuple[pl.DataFrame, pl.DataFrame]:
+    """Calibration ``(y, y_pred)`` frames for similarity tests (21 daily rows)."""
+    dates = [datetime(2021, 1, 1) + timedelta(days=i) for i in range(21)]
+    y = pl.DataFrame({"time": dates, "value": [float(i) for i in range(21)]})
+    y_pred = pl.DataFrame({"time": dates, "value": [float(i) + 0.5 for i in range(21)]})
+    return y, y_pred
+
+
+def _similarity_instances() -> dict[str, object]:
+    """Representative *working* similarity instances keyed by class name."""
+    from yohou.interval.similarity import CompositeSimilarity, DistanceSimilarity, SeasonalSimilarity
+
+    return {
+        "DistanceSimilarity": DistanceSimilarity(),
+        "SeasonalSimilarity": SeasonalSimilarity(seasonalities=[7.0]),
+        "CompositeSimilarity": CompositeSimilarity([
+            ("dist", DistanceSimilarity()),
+            ("seas", SeasonalSimilarity(seasonalities=[7.0])),
+        ]),
+    }
+
+
+class TestSimilarityCommon:
+    """Run systematic checks on all discovered similarities."""
+
+    @pytest.mark.parametrize(
+        "name,cls",
+        [(n, c) for n, c in all_estimators() if issubclass(c, BaseSimilarity)],
+        ids=[n for n, c in all_estimators() if issubclass(c, BaseSimilarity)],
+    )
+    def test_similarity_checks(self, name, cls):
+        """Run all applicable check-generator checks for a similarity."""
+        instances = _similarity_instances()
+        assert name in instances, f"No representative instance registered for similarity {name}"
+        similarity = instances[name]
+        y_calib, y_pred_calib = _similarity_calibration()
+        run_checks(similarity, _yield_yohou_similarity_checks(similarity, y_calib, y_pred_calib))
+
+
+# ---------------------------------------------------------------------------
+# Composition contract (every _BaseComposition compositor)
+# ---------------------------------------------------------------------------
+
+
+def _composition_descriptors() -> dict[str, dict]:
+    """Per-compositor descriptor (composition-attribute + representative components).
+
+    Covers every concrete ``_BaseComposition`` subclass across the weighter,
+    similarity, transformer, and forecaster families.
+    """
+    from yohou.interval.similarity import DistanceSimilarity, SeasonalSimilarity
+    from yohou.point import SeasonalNaive
+    from yohou.preprocessing import LagTransformer
+    from yohou.weighting import ExponentialDecayWeighter, LinearDecayWeighter
+
+    def two_forecasters() -> list:
+        return [("a", SeasonalNaive(seasonality=1)), ("b", SeasonalNaive(seasonality=1))]
+
+    return {
+        "CompositeWeighter": {
+            "attr": "weighters",
+            "components": [("decay", ExponentialDecayWeighter(half_life=2)), ("lin", LinearDecayWeighter(max_steps=3))],
+        },
+        "CompositeSimilarity": {
+            "attr": "similarities",
+            "components": [("dist", DistanceSimilarity()), ("seas", SeasonalSimilarity(seasonalities=[7.0]))],
+        },
+        "FeatureUnion": {
+            "attr": "transformer_list",
+            "components": [("a", LagTransformer(lag=[1])), ("b", LagTransformer(lag=[2]))],
+        },
+        "FeaturePipeline": {
+            "attr": "steps",
+            "components": [("a", LagTransformer(lag=[1])), ("b", LagTransformer(lag=[2]))],
+        },
+        "ColumnTransformer": {
+            "attr": "transformers",
+            "components": [("a", LagTransformer(lag=[1]), ["value"])],
+        },
+        "ColumnForecaster": {
+            "attr": "forecasters",
+            "components": [("a", SeasonalNaive(seasonality=1))],
+        },
+        "DecompositionPipeline": {"attr": "forecasters", "components": two_forecasters()},
+        "VotingPointForecaster": {"attr": "forecasters", "components": two_forecasters()},
+        "VotingIntervalForecaster": {"attr": "forecasters", "components": two_forecasters()},
+        "VotingClassProbaForecaster": {"attr": "forecasters", "components": two_forecasters()},
+    }
+
+
+class TestCompositionContractCommon:
+    """Run the data-free composition contract over every _BaseComposition compositor."""
+
+    @pytest.mark.parametrize(
+        "name,cls",
+        [(n, c) for n, c in all_estimators() if issubclass(c, _BaseComposition)],
+        ids=[n for n, c in all_estimators() if issubclass(c, _BaseComposition)],
+    )
+    def test_composition_contract(self, name, cls):
+        """Run clone + nested-param checks for a compositor."""
+        descriptors = _composition_descriptors()
+        assert name in descriptors, f"No composition descriptor registered for {name}"
+        descriptor = descriptors[name]
+        compositor = cls(**{descriptor["attr"]: descriptor["components"]})
+        run_checks(compositor, _yield_composition_contract_checks(compositor, descriptor))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -382,11 +382,6 @@ class TestClassProbaScorerCommon:
         run_checks(instance, _yield_yohou_scorer_checks(instance, y_truth, y_pred))
 
 
-# ---------------------------------------------------------------------------
-# Weighter family
-# ---------------------------------------------------------------------------
-
-
 def _weighter_key() -> pl.Series:
     """Five daily datetimes used as the weighter key fixture."""
     return pl.Series("time", [datetime(2024, 1, d) for d in range(1, 6)])
@@ -438,11 +433,6 @@ class TestWeighterCommon:
         run_checks(weighter, _yield_yohou_weighter_checks(weighter, _weighter_key()))
 
 
-# ---------------------------------------------------------------------------
-# Similarity family
-# ---------------------------------------------------------------------------
-
-
 def _similarity_calibration() -> tuple[pl.DataFrame, pl.DataFrame]:
     """Calibration ``(y, y_pred)`` frames for similarity tests (21 daily rows)."""
     dates = [datetime(2021, 1, 1) + timedelta(days=i) for i in range(21)]
@@ -480,11 +470,6 @@ class TestSimilarityCommon:
         similarity = instances[name]
         y_calib, y_pred_calib = _similarity_calibration()
         run_checks(similarity, _yield_yohou_similarity_checks(similarity, y_calib, y_pred_calib))
-
-
-# ---------------------------------------------------------------------------
-# Composition contract (every _BaseComposition compositor)
-# ---------------------------------------------------------------------------
 
 
 def _composition_descriptors() -> dict[str, dict]:

--- a/tests/testing/test_contract.py
+++ b/tests/testing/test_contract.py
@@ -1,0 +1,168 @@
+"""Unit tests for the shared estimator-contract and composition-contract checks."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+from sklearn.base import BaseEstimator
+
+from yohou.testing.contract import (
+    _safe_equal,
+    check_clone_preserves_params,
+    check_composition_clone_deep_clones_components,
+    check_composition_nested_param_addressable,
+    check_get_set_params_round_trip,
+    check_init_no_param_mutation,
+)
+
+
+class _Inner(BaseEstimator):
+    def __init__(self, p=1):
+        self.p = p
+
+
+class _NoParams(BaseEstimator):
+    """Estimator whose constructor takes no tunable parameters."""
+
+
+class _Compo(BaseEstimator):
+    def __init__(self, items=None, scalar=2, nothing=None, sub=None):
+        self.items = items
+        self.scalar = scalar
+        self.nothing = nothing
+        self.sub = sub
+
+
+def test_safe_equal_identity():
+    obj = object()
+    assert _safe_equal(obj, obj)
+
+
+def test_safe_equal_scalar():
+    assert _safe_equal(3, 3)
+    assert not _safe_equal(3, 4)
+
+
+def test_safe_equal_dataframe_uses_equals():
+    df = pl.DataFrame({"a": [1, 2]})
+    assert _safe_equal(df, pl.DataFrame({"a": [1, 2]}))
+    assert not _safe_equal(df, pl.DataFrame({"a": [1, 3]}))
+
+
+def test_safe_equal_equals_method_raising_returns_false():
+    class HasBadEquals:
+        def equals(self, other):
+            raise RuntimeError("boom")
+
+    assert not _safe_equal(HasBadEquals(), HasBadEquals())
+
+
+def test_safe_equal_numpy_array_reduces_with_all():
+    a = np.array([1, 2, 3])
+    assert _safe_equal(a, np.array([1, 2, 3]))
+    assert not _safe_equal(a, np.array([1, 2, 4]))
+
+
+def test_safe_equal_eq_raising_returns_false():
+    class BadEq:
+        __hash__ = object.__hash__
+
+        def __eq__(self, other):
+            raise RuntimeError("boom")
+
+    assert not _safe_equal(BadEq(), BadEq())
+
+
+def test_safe_equal_array_all_raising_returns_false():
+    class WeirdResult:
+        def all(self):
+            raise RuntimeError("boom")
+
+    class WeirdEq:
+        __hash__ = object.__hash__
+
+        def __eq__(self, other):
+            return WeirdResult()
+
+    assert not _safe_equal(WeirdEq(), WeirdEq())
+
+
+def test_safe_equal_non_bool_non_array_result_falls_back_to_bool():
+    class IntEq:
+        __hash__ = object.__hash__
+
+        def __eq__(self, other):
+            return 1  # truthy, not a bool, no .all()
+
+    assert _safe_equal(IntEq(), IntEq())
+
+
+def test_clone_preserves_params_covers_all_branches():
+    # items: list of (name, estimator) tuples (two components, so the loop
+    # iterates more than once); sub: nested estimator; nothing: None;
+    # scalar: plain value -> exercises every branch.
+    check_clone_preserves_params(_Compo(items=[("a", _Inner()), ("b", _Inner(p=2))], sub=_Inner()))
+
+
+def test_clone_preserves_params_handles_sentinels_and_non_tuples():
+    # ('p', 'passthrough'): tuple whose component is not an estimator (skips the
+    # type assertion); a bare estimator entry: not a tuple at all (skipped).
+    check_clone_preserves_params(_Compo(items=[("p", "passthrough"), ("a", _Inner()), _Inner()]))
+
+
+def test_clone_preserves_params_dataframe_param():
+    class WithFrame(BaseEstimator):
+        def __init__(self, frame=None):
+            self.frame = frame
+
+    check_clone_preserves_params(WithFrame(frame=pl.DataFrame({"a": [1, 2]})))
+
+
+def test_get_set_params_round_trip_covers_nested_skip():
+    check_get_set_params_round_trip(_Compo(items=[("a", _Inner())], sub=_Inner()))
+
+
+def test_init_no_param_mutation_passes_for_verbatim_storage():
+    check_init_no_param_mutation(_Compo())
+
+
+def test_init_no_param_mutation_skips_non_default_constructible():
+    class NeedsArg(BaseEstimator):
+        def __init__(self, x):
+            self.x = x
+
+    # No default for x -> early return, no assertion error.
+    check_init_no_param_mutation(NeedsArg(1))
+
+
+def test_init_no_param_mutation_skips_attr_stored_elsewhere():
+    class StoresElsewhere(BaseEstimator):
+        def __init__(self, a=1):
+            self._a = a  # not stored as self.a
+
+    check_init_no_param_mutation(StoresElsewhere())
+
+
+def test_init_no_param_mutation_detects_mutation():
+    class Mutates(BaseEstimator):
+        def __init__(self, a=None):
+            self.a = a if a is not None else {}  # None -> {}
+
+    with pytest.raises(AssertionError, match="mutated"):
+        check_init_no_param_mutation(Mutates())
+
+
+def test_composition_nested_param_addressable_skips_paramless_component():
+    comp = _Compo(items=[("a", _NoParams())])
+    # First component exposes no params -> the check returns without asserting.
+    check_composition_nested_param_addressable(comp, {"attr": "items"})
+
+
+def test_composition_clone_deep_clones_components_happy_path():
+    check_composition_clone_deep_clones_components(_Compo(items=[("a", _Inner())]), {"attr": "items"})
+
+
+def test_composition_clone_deep_clones_components_skips_sentinel():
+    # Non-estimator components (e.g. 'passthrough') are skipped, not deep-clone checked.
+    check_composition_clone_deep_clones_components(_Compo(items=[("a", "passthrough")]), {"attr": "items"})

--- a/tests/testing/test_weighter_checks.py
+++ b/tests/testing/test_weighter_checks.py
@@ -1,0 +1,42 @@
+"""Unit tests for the failure branches of the weighter check functions."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from yohou.testing.weighter import (
+    check_weighter_default_constructible,
+    check_weighter_tags_accessible_before_fit,
+)
+from yohou.weighting.weighters import BaseWeighter
+
+
+class _NeedsArgWeighter(BaseWeighter):
+    """Weighter that is not default-constructible."""
+
+    def __init__(self, scale):
+        self.scale = scale
+
+    def compute_weights(self, key: pl.Series, group_name: str | None = None) -> pl.Series:
+        return pl.Series([1.0] * len(key), dtype=pl.Float64).alias("weight")
+
+
+class _BadTagsWeighter(BaseWeighter):
+    """Weighter whose tag access raises."""
+
+    def compute_weights(self, key: pl.Series, group_name: str | None = None) -> pl.Series:
+        return pl.Series([1.0] * len(key), dtype=pl.Float64).alias("weight")
+
+    def __sklearn_tags__(self):
+        raise RuntimeError("boom")
+
+
+def test_default_constructible_flags_required_args():
+    with pytest.raises(AssertionError, match="not default-constructible"):
+        check_weighter_default_constructible(_NeedsArgWeighter(scale="position"))
+
+
+def test_tags_accessible_flags_raising_tags():
+    with pytest.raises(AssertionError, match="__sklearn_tags__"):
+        check_weighter_tags_accessible_before_fit(_BadTagsWeighter())

--- a/tests/weighting/test_weighting.py
+++ b/tests/weighting/test_weighting.py
@@ -36,11 +36,6 @@ def steps() -> pl.Series:
     return pl.Series("forecasting_step", [1, 2, 3])
 
 
-# ---------------------------------------------------------------------------
-# Legacy-equivalence golden values (formerly the factory functions)
-# ---------------------------------------------------------------------------
-
-
 def test_exponential_decay_matches_legacy_values(times: pl.Series) -> None:
     """ExponentialDecayWeighter reproduces the old exponential_decay_weight output."""
     weights = ExponentialDecayWeighter(half_life=1).compute_weights(times).to_list()
@@ -73,11 +68,6 @@ def test_seasonal_emphasis_matches_legacy_values() -> None:
     assert weights == pytest.approx([1.0, 1.0, 1.0, 2.0])
 
 
-# ---------------------------------------------------------------------------
-# ExponentialDecayWeighter: scale handling (thread C1')
-# ---------------------------------------------------------------------------
-
-
 def test_exponential_scale_inferred_elapsed_for_datetime(times: pl.Series) -> None:
     """Datetime keys default to elapsed scale."""
     w = ExponentialDecayWeighter(half_life=1)
@@ -108,11 +98,6 @@ def test_exponential_timedelta_elapsed_ok(times: pl.Series) -> None:
     """A timedelta half_life is valid with elapsed scale."""
     weights = ExponentialDecayWeighter(half_life=timedelta(days=1), scale="elapsed").compute_weights(times)
     assert weights.to_list() == pytest.approx([0.25, 0.5, 1.0])
-
-
-# ---------------------------------------------------------------------------
-# LookupWeighter / TableWeighter (thread A3)
-# ---------------------------------------------------------------------------
 
 
 def test_lookup_default_applies_to_missing_keys(steps: pl.Series) -> None:
@@ -156,11 +141,6 @@ def test_table_weighter_panel_group_column(times: pl.Series) -> None:
     assert weights == pytest.approx([1.0, 2.0, 3.0])
 
 
-# ---------------------------------------------------------------------------
-# CompositeWeighter (thread D)
-# ---------------------------------------------------------------------------
-
-
 def test_composite_multiplies_components(times: pl.Series) -> None:
     """CompositeWeighter multiplies component outputs element-wise."""
     a = ExponentialDecayWeighter(half_life=2)
@@ -174,11 +154,6 @@ def test_base_weighter_is_abstract() -> None:
     """BaseWeighter cannot be instantiated directly."""
     with pytest.raises(TypeError):
         BaseWeighter()  # type: ignore[abstract]
-
-
-# ---------------------------------------------------------------------------
-# _resolve_weighter_to_array + validation helpers
-# ---------------------------------------------------------------------------
 
 
 def test_normalize_weights_sums_to_n() -> None:
@@ -211,11 +186,6 @@ def test_combine_weight_vectors_zero_product_raises() -> None:
         _combine_weight_vectors(np.array([1.0, 0.0]), np.array([0.0, 1.0]), n=2)
 
 
-# ---------------------------------------------------------------------------
-# Single-element key short-circuits
-# ---------------------------------------------------------------------------
-
-
 def test_linear_decay_single_key_returns_one() -> None:
     """A length-1 key yields weight 1.0 (no rank range to decay over)."""
     weights = LinearDecayWeighter().compute_weights(pl.Series("time", [datetime(2024, 1, 1)])).to_list()
@@ -226,11 +196,6 @@ def test_seasonal_emphasis_single_key_returns_one() -> None:
     """A length-1 key yields weight 1.0 (no phase to emphasize)."""
     weights = SeasonalEmphasisWeighter(seasonality=7).compute_weights(pl.Series("time", [datetime(2024, 1, 1)]))
     assert weights.to_list() == pytest.approx([1.0])
-
-
-# ---------------------------------------------------------------------------
-# TableWeighter error/branch paths
-# ---------------------------------------------------------------------------
 
 
 def test_table_weighter_none_frame_raises(times: pl.Series) -> None:
@@ -260,22 +225,12 @@ def test_table_weighter_missing_panel_columns_raises(times: pl.Series) -> None:
         TableWeighter(frame=frame, on="time").compute_weights(times, group_name="C")
 
 
-# ---------------------------------------------------------------------------
-# CompositeWeighter get_params / set_params edge paths
-# ---------------------------------------------------------------------------
-
-
 def test_composite_set_params_replaces_weighters_list() -> None:
     """set_params replaces the whole weighters list."""
     w = CompositeWeighter([("decay", ExponentialDecayWeighter(1))])
     new = [("lin", LinearDecayWeighter(2))]
     w.set_params(weighters=new)
     assert w.weighters is new
-
-
-# ---------------------------------------------------------------------------
-# _resolve_weighter_to_array contract checks
-# ---------------------------------------------------------------------------
 
 
 def test_resolve_weighter_to_array_rejects_non_series(times: pl.Series) -> None:
@@ -298,11 +253,6 @@ def test_resolve_weighter_to_array_rejects_mismatched_length(times: pl.Series) -
 
     with pytest.raises(ValueError, match="expected 3 rows"):
         _resolve_weighter_to_array(_BadLength(), times)
-
-
-# ---------------------------------------------------------------------------
-# CompositeWeighter combination = "mean" and per-component weights
-# ---------------------------------------------------------------------------
 
 
 def test_composite_mean_combination(times: pl.Series) -> None:

--- a/tests/weighting/test_weighting.py
+++ b/tests/weighting/test_weighting.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import polars as pl
 import pytest
-from sklearn.base import clone
 
 from yohou.weighting import (
     BaseWeighter,
@@ -22,7 +21,6 @@ from yohou.weighting.weighters import (
     _combine_weight_vectors,
     _normalize_weights,
     _resolve_weighter_to_array,
-    _validate_weight_array,
 )
 
 
@@ -172,56 +170,6 @@ def test_composite_multiplies_components(times: pl.Series) -> None:
     assert got == pytest.approx(expected)
 
 
-def test_composite_empty_raises(times: pl.Series) -> None:
-    """An empty CompositeWeighter raises."""
-    with pytest.raises(ValueError, match="at least one"):
-        CompositeWeighter([]).compute_weights(times)
-
-
-def test_composite_nested_params_addressable() -> None:
-    """Component params are addressable via <name>__param (sklearn _BaseComposition)."""
-    w = CompositeWeighter([("decay", ExponentialDecayWeighter(7)), ("seasonal", SeasonalEmphasisWeighter(7))])
-    assert "decay__half_life" in w.get_params(deep=True)
-    w.set_params(decay__half_life=14)
-    assert dict(w.weighters)["decay"].half_life == 14
-
-
-def test_composite_clone_roundtrips() -> None:
-    """CompositeWeighter survives sklearn clone."""
-    w = CompositeWeighter([("decay", ExponentialDecayWeighter(7)), ("lin", LinearDecayWeighter(3))])
-    c = clone(w)
-    assert isinstance(c, CompositeWeighter)
-    assert dict(c.weighters)["decay"].half_life == 7
-    assert dict(c.weighters)["lin"].max_steps == 3
-
-
-# ---------------------------------------------------------------------------
-# Estimator protocol: get_params / clone / fit
-# ---------------------------------------------------------------------------
-
-
-def test_weighter_params_introspectable() -> None:
-    """Strategy parameters appear in get_params and are settable."""
-    w = ExponentialDecayWeighter(half_life=7)
-    assert w.get_params()["half_life"] == 7
-    w.set_params(half_life=14)
-    assert w.half_life == 14
-
-
-def test_weighter_clone_roundtrips() -> None:
-    """A weighter survives sklearn clone with its params."""
-    w = ExponentialDecayWeighter(half_life=7, scale="position")
-    c = clone(w)
-    assert c.half_life == 7
-    assert c.scale == "position"
-
-
-def test_weighter_fit_is_noop_returns_self() -> None:
-    """The default fit is a no-op returning self."""
-    w = ExponentialDecayWeighter(half_life=7)
-    assert w.fit(None) is w
-
-
 def test_base_weighter_is_abstract() -> None:
     """BaseWeighter cannot be instantiated directly."""
     with pytest.raises(TypeError):
@@ -231,37 +179,6 @@ def test_base_weighter_is_abstract() -> None:
 # ---------------------------------------------------------------------------
 # _resolve_weighter_to_array + validation helpers
 # ---------------------------------------------------------------------------
-
-
-def test_resolve_weighter_to_array_validates(times: pl.Series) -> None:
-    """_resolve_weighter_to_array returns a validated numpy array."""
-    arr = _resolve_weighter_to_array(ExponentialDecayWeighter(1), times, None, "time weight")
-    assert isinstance(arr, np.ndarray)
-    assert arr.tolist() == pytest.approx([0.25, 0.5, 1.0])
-
-
-def test_validate_weight_array_rejects_nan() -> None:
-    """NaN weights are rejected."""
-    with pytest.raises(ValueError, match="NaN"):
-        _validate_weight_array(np.array([1.0, np.nan, 1.0]), name="w")
-
-
-def test_validate_weight_array_rejects_negative() -> None:
-    """Negative weights are rejected."""
-    with pytest.raises(ValueError, match="negative"):
-        _validate_weight_array(np.array([1.0, -1.0]), name="w")
-
-
-def test_validate_weight_array_rejects_inf() -> None:
-    """Infinite weights are rejected."""
-    with pytest.raises(ValueError, match="infinite"):
-        _validate_weight_array(np.array([1.0, np.inf]), name="w")
-
-
-def test_validate_weight_array_rejects_all_zero() -> None:
-    """All-zero weights are rejected."""
-    with pytest.raises(ValueError, match="zero"):
-        _validate_weight_array(np.array([0.0, 0.0]), name="w")
 
 
 def test_normalize_weights_sums_to_n() -> None:
@@ -356,20 +273,6 @@ def test_composite_set_params_replaces_weighters_list() -> None:
     assert w.weighters is new
 
 
-def test_composite_set_params_routes_nested() -> None:
-    """Nested <name>__param keys are routed to the named component."""
-    w = CompositeWeighter([("decay", ExponentialDecayWeighter(1)), ("lin", LinearDecayWeighter(2))])
-    w.set_params(decay__half_life=9)
-    assert dict(w.weighters)["decay"].half_life == 9
-
-
-def test_composite_bare_list_rejected(times: pl.Series) -> None:
-    """A bare list (not named tuples) is rejected at compute time."""
-    w = CompositeWeighter([ExponentialDecayWeighter(1), LinearDecayWeighter(2)])  # type: ignore[list-item]
-    with pytest.raises(ValueError, match="name, weighter"):
-        w.compute_weights(times)
-
-
 # ---------------------------------------------------------------------------
 # _resolve_weighter_to_array contract checks
 # ---------------------------------------------------------------------------
@@ -435,28 +338,6 @@ def test_composite_multiply_exponents(times: pl.Series) -> None:
         .to_list()
     )
     assert got == pytest.approx(expected)
-
-
-def test_composite_invalid_combination_raises(times: pl.Series) -> None:
-    """An unknown combination raises."""
-    w = CompositeWeighter([("a", ExponentialDecayWeighter(1)), ("b", LinearDecayWeighter(2))], combination="bad")
-    with pytest.raises(ValueError, match="combination"):
-        w.compute_weights(times)
-
-
-def test_composite_weights_length_mismatch_raises(times: pl.Series) -> None:
-    """weights length must match the number of components."""
-    w = CompositeWeighter([("a", ExponentialDecayWeighter(1)), ("b", LinearDecayWeighter(2))], weights=[1.0])
-    with pytest.raises(ValueError, match="weights length"):
-        w.compute_weights(times)
-
-
-def test_composite_get_params_includes_combination_and_weights() -> None:
-    """combination and weights are introspectable / tunable."""
-    w = CompositeWeighter([("a", ExponentialDecayWeighter(1))], combination="mean", weights=[1.0])
-    params = w.get_params(deep=True)
-    assert params["combination"] == "mean"
-    assert params["weights"] == [1.0]
 
 
 def test_weighters_not_importable_from_old_utils_path() -> None:


### PR DESCRIPTION
## Description

Adds systematic `_yield_yohou_*_checks` harnesses for the **weighter** and **similarity** estimator families — the two families that lacked one — backed by a shared family-agnostic **estimator-contract** battery (`clone`/`get_set_params` round-trip, no-`__init__`-mutation) and a **composition-contract** battery run over *every* `_BaseComposition` compositor in yohou (10 compositors across the weighter/similarity/transformer/forecaster families) via a standalone test. The hand-written weighter/similarity suites are deduplicated: per-class contract boilerplate the harnesses now cover is removed; numeric, integration, and regression-guard tests are kept.

Two production bugs the new harnesses surfaced are fixed in the same PR:
- **`ColumnTransformer`**: `get_params(deep=True)`/`set_params` now expose nested `<name>__<param>` for its `(name, est, columns)` 3-tuples (sklearn's `_transformers` adapter pattern). Previously nested tuning was unreachable and `set_params(a__lag=...)` raised `ValueError: too many values to unpack`.
- **Similarity `predict`/`observe`**: now raise `NotFittedError` when called before `fit` (was `AttributeError`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

`yohou.testing` ships systematic check harnesses for transformers, forecasters, splitters, scorers, and searches, but the weighter (#81) and similarity (#82) families introduced by recent merges had none — they were validated only by ad-hoc per-class suites. This closes that gap symmetrically and, as a side effect, gives the whole library its first shared sklearn-contract and composition-contract coverage.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Test-infrastructure-first change; the only production edits are the two harness-surfaced fixes above. Full suite: 5102 passed, 18 skipped, 2 xfailed. New coverage: 6 weighters, 3 similarities, and all 10 `_BaseComposition` compositors.