### PR TITLE
fix(metrics): correct CalibrationError to empirical-coverage deviation

### DIFF
--- a/src/yohou/metrics/base.py
+++ b/src/yohou/metrics/base.py
@@ -126,7 +126,7 @@ class BaseScorer(BaseEstimator, metaclass=abc.ABCMeta):
     def fit(self, y_train: pl.DataFrame, *, forecaster=None, **params) -> BaseScorer:
         """Fit the scorer on training data.
 
-        Validates ``groups`` and ``component_names`` against
+        Validates ``groups`` and ``components`` against
         training data.  Stores training data statistics for scaled metrics
         (e.g., MASE).  Subclasses should override to add type-specific
         parameter validation.
@@ -151,11 +151,11 @@ class BaseScorer(BaseEstimator, metaclass=abc.ABCMeta):
         Raises
         ------
         ValueError
-            If ``groups`` or ``component_names`` contain names not
+            If ``groups`` or ``components`` contain names not
             present in ``y_train``.
 
         """
-        # Validate base parameters (groups, component_names)
+        # Validate base parameters (groups, components)
         self._validate_parameters(y_train=y_train)
 
         # Validate input structure without aligning (single dataframe)
@@ -1263,7 +1263,7 @@ class BasePointScorer(BaseScorer, metaclass=abc.ABCMeta):
         """Fit the scorer on training data.
 
         Validates ``aggregation_method``, ``groups``, and
-        ``component_names``.
+        ``components``.
 
         Parameters
         ----------
@@ -1285,7 +1285,7 @@ class BasePointScorer(BaseScorer, metaclass=abc.ABCMeta):
         ------
         ValueError
             If ``aggregation_method`` contains invalid values, or if
-            ``groups`` / ``component_names`` are not found in
+            ``groups`` / ``components`` are not found in
             ``y_train``.
 
         """
@@ -1502,7 +1502,7 @@ class BaseIntervalScorer(BaseScorer, metaclass=abc.ABCMeta):
         """Fit the scorer on training data.
 
         Validates ``coverage_rates``, ``aggregation_method``,
-        ``groups``, and ``component_names``.
+        ``groups``, and ``components``.
 
         Parameters
         ----------
@@ -1524,7 +1524,7 @@ class BaseIntervalScorer(BaseScorer, metaclass=abc.ABCMeta):
         ------
         ValueError
             If ``coverage_rates`` are invalid, ``aggregation_method`` contains
-            invalid values, or if ``groups`` / ``component_names``
+            invalid values, or if ``groups`` / ``components``
             are not found in ``y_train``.
 
         """
@@ -1765,7 +1765,7 @@ class BaseClassProbaScorer(BaseScorer, metaclass=abc.ABCMeta):
         """Fit the scorer on training data.
 
         Validates ``aggregation_method``, ``groups``, and
-        ``component_names``.
+        ``components``.
 
         Parameters
         ----------
@@ -1787,7 +1787,7 @@ class BaseClassProbaScorer(BaseScorer, metaclass=abc.ABCMeta):
         ------
         ValueError
             If ``aggregation_method`` contains invalid values, or if
-            ``groups`` / ``component_names`` are not found in
+            ``groups`` / ``components`` are not found in
             ``y_train``.
 
         """

--- a/src/yohou/metrics/interval.py
+++ b/src/yohou/metrics/interval.py
@@ -675,7 +675,13 @@ class CalibrationError(BaseIntervalScorer):
         )
 
     def _compute_raw_scores(self, y_truth, y_pred, coverage_rates, target_columns):
-        """Compute per-row calibration error values."""
+        """Compute per-row in-interval indicators.
+
+        Calibration error is ``|empirical_coverage - rate|``; empirical coverage
+        is the mean of these indicators, formed during aggregation (see
+        ``_aggregate_scores``). The deviation is NOT applied per row here, because
+        ``mean(|indicator - rate|)`` is not ``|mean(indicator) - rate|``.
+        """
         frames = []
         for rate in coverage_rates:
             rate_data = {}
@@ -684,9 +690,43 @@ class CalibrationError(BaseIntervalScorer):
                 upper_col = f"{col}_upper_{rate}"
                 if lower_col in y_pred.columns and upper_col in y_pred.columns:
                     in_interval = (y_truth[col] >= y_pred[lower_col]) & (y_truth[col] <= y_pred[upper_col])
-                    rate_data[col] = (in_interval.cast(pl.Float64) - rate).abs()
+                    rate_data[col] = in_interval.cast(pl.Float64)
             frames.append(pl.DataFrame(rate_data).with_columns(pl.lit(rate).alias("coverage_rate")))
         return pl.concat(frames)
+
+    def _aggregate_scores(self, raw_scores, context=None):
+        """Form empirical coverage per rate, then ``|coverage - rate|``, then collapse rates.
+
+        Empirical coverage is a population statistic: the observation rows must be
+        collapsed into a coverage fraction *before* the absolute deviation is taken.
+        This reorders the base pipeline, which would otherwise collapse coverage
+        rates first and average per-row deviations, yielding ``mean(|indicator -
+        rate|)`` instead of ``|mean(indicator) - rate|``.
+        """
+        dims = self._normalize_agg_methods(self.aggregation_method, include_coveragewise=True)
+        collapse_rates = "coveragewise" in dims
+
+        # 1. Collapse observation rows (and components/groups/vintages) on the
+        #    indicators to form empirical coverage per rate, retaining coverage_rate.
+        collapsed = self._collapse_rows(raw_scores, context, dims)
+        coverage = self._aggregate_per_vintage_scores(collapsed, context)
+
+        # With the >= 2 coverage-rate guard, coverage is always a per-rate DataFrame.
+        if not isinstance(coverage, pl.DataFrame):
+            return coverage
+
+        # 2. Replace each coverage value with |coverage - rate|.
+        meta_names = {"coverage_rate", "forecasting_step", "vintage_time", "time"}
+        val_cols = [c for c in coverage.columns if c not in meta_names]
+        deviation = coverage.with_columns([(pl.col(c) - pl.col("coverage_rate")).abs().alias(c) for c in val_cols])
+
+        # 3. Collapse the coverage-rate dimension (weighted if coverage_rates is a dict).
+        if collapse_rates:
+            deviation = self._collapse_coverage_rates(deviation)
+            if deviation.shape == (1, 1):
+                return float(deviation.to_series()[0])
+
+        return deviation
 
     def score(  # type: ignore
         self, y_truth: pl.DataFrame, y_pred: pl.DataFrame, /, **params

--- a/src/yohou/metrics/point.py
+++ b/src/yohou/metrics/point.py
@@ -278,7 +278,7 @@ class RootMeanSquaredError(BasePointScorer):
     Attributes
     ----------
     lower_is_better : bool
-        Always True for MSE.
+        Always True for RMSE.
 
     Examples
     --------
@@ -1098,11 +1098,6 @@ class MedianAbsoluteError(BasePointScorer):
         float or pl.DataFrame
             Aggregated median absolute error.
 
-        Raises
-        ------
-        TypeError
-            If time_weight or step_weight are passed (median is not weight-compatible).
-
         """
         check_is_fitted(self, ["_is_fitted"])
 
@@ -1366,11 +1361,6 @@ class R2Score(BasePointScorer):
         float or pl.DataFrame
             R² score. 1.0 for perfect predictions, 0.0 for mean-level predictions.
 
-        Raises
-        ------
-        TypeError
-            If time_weight or step_weight are passed.
-
         """
         check_is_fitted(self, ["_is_fitted"])
 
@@ -1537,11 +1527,6 @@ class MeanDirectionalAccuracy(BasePointScorer):
         -------
         float or pl.DataFrame
             MDA score between 0 and 1. 1.0 for perfect directional prediction.
-
-        Raises
-        ------
-        TypeError
-            If time_weight or step_weight are passed.
 
         """
         check_is_fitted(self, ["_is_fitted"])

--- a/tests/metrics/test_interval.py
+++ b/tests/metrics/test_interval.py
@@ -444,6 +444,89 @@ class TestCalibrationError:
         assert "calibration_error" in df.columns
         assert len(df) == len(y_true)
 
+    def test_calibration_error_matches_coverage_deviation(self):
+        """Score equals mean over rates of |empirical_coverage - rate|.
+
+        Five timesteps, identical interval [0, 2] at both rates; three of five
+        truths fall inside, so empirical coverage is 0.6 at each rate.
+        CalibError = (|0.6 - 0.5| + |0.6 - 0.9|) / 2 = 0.2. The buggy per-row
+        formula mean(|indicator - rate|) returns 0.46 instead.
+        """
+        times = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(5)]
+        y_true = pl.DataFrame({"time": times, "value": [1.0, 1.0, 1.0, 100.0, 100.0]})
+        y_pred = pl.DataFrame({
+            "vintage_time": [datetime(2019, 12, 31)] * 5,
+            "time": times,
+            "value_lower_0.5": [0.0] * 5,
+            "value_upper_0.5": [2.0] * 5,
+            "value_lower_0.9": [0.0] * 5,
+            "value_upper_0.9": [2.0] * 5,
+        })
+        error = CalibrationError(coverage_rates=[0.5, 0.9])
+        error.fit(y_true)
+        score = error.score(y_true, y_pred)
+
+        assert score == pytest.approx(0.2)
+
+    def test_calibration_error_perfect_calibration_is_zero(self):
+        """Empirical coverage equal to the nominal rate at every rate yields exactly 0.
+
+        Ten timesteps with nested intervals: [0, 4.5] covers 5/10 (rate 0.5) and
+        [0, 8.5] covers 9/10 (rate 0.9), so coverage matches nominal at both rates.
+        """
+        times = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(10)]
+        y_true = pl.DataFrame({"time": times, "value": [float(i) for i in range(10)]})
+        y_pred = pl.DataFrame({
+            "vintage_time": [datetime(2019, 12, 31)] * 10,
+            "time": times,
+            "value_lower_0.5": [0.0] * 10,
+            "value_upper_0.5": [4.5] * 10,
+            "value_lower_0.9": [0.0] * 10,
+            "value_upper_0.9": [8.5] * 10,
+        })
+        error = CalibrationError(coverage_rates=[0.5, 0.9])
+        error.fit(y_true)
+
+        assert error.score(y_true, y_pred) == pytest.approx(0.0)
+
+    def test_calibration_error_per_component_coverage(self):
+        """Components retained: each component's error uses its own empirical coverage.
+
+        Component ``a`` is covered in 3/5 rows (coverage 0.6 -> error 0.2);
+        component ``b`` is covered in all 5 rows (coverage 1.0 -> error
+        (|1 - 0.5| + |1 - 0.9|) / 2 = 0.3). Aggregation collapses every
+        dimension except components.
+        """
+        times = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(5)]
+        y_true = pl.DataFrame({
+            "time": times,
+            "a": [1.0, 1.0, 1.0, 100.0, 100.0],
+            "b": [1.0, 1.0, 1.0, 1.0, 1.0],
+        })
+        y_pred = pl.DataFrame({
+            "vintage_time": [datetime(2019, 12, 31)] * 5,
+            "time": times,
+            "a_lower_0.5": [0.0] * 5,
+            "a_upper_0.5": [2.0] * 5,
+            "a_lower_0.9": [0.0] * 5,
+            "a_upper_0.9": [2.0] * 5,
+            "b_lower_0.5": [0.0] * 5,
+            "b_upper_0.5": [2.0] * 5,
+            "b_lower_0.9": [0.0] * 5,
+            "b_upper_0.9": [2.0] * 5,
+        })
+        error = CalibrationError(
+            aggregation_method=["stepwise", "vintagewise", "groupwise", "coveragewise"],
+            coverage_rates=[0.5, 0.9],
+        )
+        error.fit(y_true)
+        df = error.score(y_true, y_pred)
+
+        assert isinstance(df, pl.DataFrame)
+        row = df.to_dicts()[0]
+        assert row["a"] == pytest.approx(0.2)
+        assert row["b"] == pytest.approx(0.3)
+
 
 class TestPanelData:
     def test_panel_data_coverage_with_panel_data(self):


### PR DESCRIPTION
## Description

`CalibrationError` computed a per-row `mean(|indicator - rate|)` instead of the documented `|empirical_coverage - rate|`. The two differ by Jensen's inequality, so the metric never reached zero for a perfectly calibrated interval. On a case with empirical coverage `0.6` at rates `{0.5, 0.9}` it returned `0.46` where the documented formula gives `0.2`. The fix forms empirical coverage first (collapsing the observation rows), then takes the absolute deviation, then averages across coverage rates, respecting all aggregation modes.

This PR also corrects three verified-false metric docstrings surfaced by the same QA review.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

> Note: the API (signature, return type, `>= 2 rate` guard) is unchanged, but `CalibrationError` **output values shift** to the corrected numbers. Any stored baselines computed with the old behavior will differ.

## Motivation and Context

The metric silently reported a wrong, never-zero value, corrupting any model selection or diagnostics that relied on it. The name, the class docstring formula, and standard usage all already mean `|coverage - nominal|`; only the implementation was the outlier.

Fixes #

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Changes in this PR:
- **`CalibrationError` (`metrics/interval.py`)**: `_compute_raw_scores` now emits in-interval indicators (matching `EmpiricalCoverage`); a new `_aggregate_scores` override reorders the pipeline to coverage -> `|coverage - rate|` -> collapse rates (no `self` mutation, thread-safe; reuses the base weighted rate-collapse).
- **`metrics/point.py`**: RMSE `lower_is_better` label `MSE` -> `RMSE`; removed `Raises: TypeError` blocks from `MedianAbsoluteError`, `R2Score`, `MeanDirectionalAccuracy` (none accept `time_weight`/`step_weight`, so the error cannot be raised).
- **`metrics/base.py`**: `component_names` -> `components` (9 occurrences) in the scorer `fit` docstrings, matching the real parameter name.

Verification: failing-first oracle test confirmed (`0.46` before, `0.2` after); new tests pin perfect-calibration `-> 0.0` and per-component coverage. Passing: `tests/metrics/` (521), scoring-composition + scorer-registry consumers (187), `plotting/test_evaluation.py` (205), doctests on the edited modules (17). ruff + ty clean.