### PR TITLE
fix: remediate issues across codebase

### DIFF
--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -265,18 +265,22 @@ def _get_module_members(py_file):
     ``from .submodule import Name``, this function follows those imports and
     discovers the definitions in the referenced submodule files.
 
-    Returns a dict with *classes* and *functions* lists.  Each entry is a dict
-    with *name*, *doc* (first line of the docstring, or empty string), and
-    *source_module* (dotted relative submodule like ``"naive"`` for names
-    imported from a sibling file, or ``""`` for names defined directly).
+    Returns a dict with *classes*, *functions*, and *attributes* lists.  Each
+    entry is a dict with *name*, *doc* (first line of the docstring, or empty
+    string), and *source_module* (dotted relative submodule like ``"naive"``
+    for names imported from a sibling file, or ``""`` for names defined
+    directly).  *attributes* holds re-exported module-level constants and type
+    aliases (e.g. ``PredictionType``, ``POINT``) that are part of the public
+    API but are neither classes nor functions.
     """
     classes = []
     functions = []
+    attributes = []
     try:
         source = py_file.read_text(encoding="utf-8")
         tree = ast.parse(source)
     except (SyntaxError, UnicodeDecodeError):
-        return {"classes": classes, "functions": functions}
+        return {"classes": classes, "functions": functions, "attributes": attributes}
 
     # Collect direct definitions
     for node in ast.iter_child_nodes(tree):
@@ -287,17 +291,37 @@ def _get_module_members(py_file):
             doc = ast.get_docstring(node) or ""
             functions.append({"name": node.name, "doc": doc.strip().split("\n")[0], "source_module": ""})
 
-    # For __init__.py: resolve relative imports to sibling module files
+    # For __init__.py: resolve re-exports (relative, or absolute within this
+    # package) to the sibling module files that define each name.
     if py_file.name == "__init__.py" and not classes and not functions:
         pkg_dir = py_file.parent
-        # Collect all imported public names grouped by source module
+        # Dotted name of this package (e.g. "yohou.plotting"), used to recognize
+        # absolute re-exports such as ``from yohou.plotting._utils import ...``.
+        pkg_parts: list[str] = []
+        for part in reversed(pkg_dir.parts):
+            if part == "src":
+                break
+            pkg_parts.insert(0, part)
+        pkg_dotted = ".".join(pkg_parts)
+
+        # Collect imported public names grouped by their source submodule file.
         import_map: dict[str, list[str]] = {}
         for node in ast.iter_child_nodes(tree):
-            if isinstance(node, ast.ImportFrom) and node.module and node.level == 1:
-                for alias in node.names:
-                    imported = alias.asname or alias.name
-                    if not imported.startswith("_"):
-                        import_map.setdefault(node.module, []).append(imported)
+            if not (isinstance(node, ast.ImportFrom) and node.module):
+                continue
+            if node.level == 1:
+                rel_module = node.module
+            elif node.level == 0 and node.module.startswith(f"{pkg_dotted}."):
+                rel_module = node.module[len(pkg_dotted) + 1 :]
+            else:
+                continue
+            if "." in rel_module:
+                # Only direct sibling modules map to a single page-name segment.
+                continue
+            for alias in node.names:
+                imported = alias.asname or alias.name
+                if not imported.startswith("_"):
+                    import_map.setdefault(rel_module, []).append(imported)
 
         # Scan the referenced files and pick out the imported definitions
         for rel_module, names in import_map.items():
@@ -325,8 +349,32 @@ def _get_module_members(py_file):
                         "doc": doc.strip().split("\n")[0],
                         "source_module": rel_module,
                     })
+                else:
+                    for attr_name in _assignment_targets(tnode):
+                        if attr_name in name_set:
+                            attributes.append({
+                                "name": attr_name,
+                                "doc": "",
+                                "source_module": rel_module,
+                            })
 
-    return {"classes": classes, "functions": functions}
+    return {"classes": classes, "functions": functions, "attributes": attributes}
+
+
+def _assignment_targets(node):
+    """Yield public names bound by a module-level assignment node.
+
+    Handles both annotated assignments (``POINT: frozenset = ...``) and plain
+    assignments (``LINE_DASH_SEQUENCE = [...]``), skipping private names.
+    """
+    targets = []
+    if isinstance(node, ast.AnnAssign):
+        targets = [node.target]
+    elif isinstance(node, ast.Assign):
+        targets = node.targets
+    for target in targets:
+        if isinstance(target, ast.Name) and not target.id.startswith("_"):
+            yield target.id
 
 
 def _build_members_tables(package_name, module_name, members):
@@ -499,7 +547,7 @@ def _generate_api_pages(project_root):
             continue
 
         members = _get_module_members(mod_file)
-        for entry in members["classes"] + members["functions"]:
+        for entry in members["classes"] + members["functions"] + members["attributes"]:
             src = entry.get("source_module", "")
             if src:
                 qualified = f"yohou.{mod['module_name']}.{src}.{entry['name']}"

--- a/docs/pages/api/base.md
+++ b/docs/pages/api/base.md
@@ -20,3 +20,9 @@ Abstract base classes used internally by all Yohou estimators. See the concrete 
 | [`BaseStandardForecaster`](generated/yohou.base.standard.BaseStandardForecaster.md) | Mixin providing standard (single DataFrame) forecaster operations. |
 | [`BasePanelForecaster`](generated/yohou.base.panel.BasePanelForecaster.md) | Mixin providing panel (dict of DataFrames) forecaster operations. |
 | [`BaseReductionForecaster`](generated/yohou.base.reduction.BaseReductionForecaster.md) | Base class for forecasters using reduction to supervised learning. |
+
+### Types
+
+| Name | Description |
+| --- | --- |
+| [`PredictionType`](generated/yohou.base.forecaster.PredictionType.md) | Literal type alias for the kind of prediction a forecaster produces. |

--- a/docs/pages/api/datasets.md
+++ b/docs/pages/api/datasets.md
@@ -31,7 +31,6 @@ Each function downloads data from [Monash/Zenodo](https://forecastingdata.org) (
 | --- | --- |
 | [`clear_data_home`](generated/yohou.datasets._fetchers.clear_data_home.md) | Delete all the content of the data home cache. |
 | [`get_data_home`](generated/yohou.datasets._fetchers.get_data_home.md) | Return the path of the yohou data directory. |
-| [`parse_tsf`](generated/yohou.datasets._tsf_parser.parse_tsf.md) | Parse a Monash `.tsf` file into a wide polars DataFrame. |
 
 ### Synthetic generators
 

--- a/docs/pages/api/metrics.md
+++ b/docs/pages/api/metrics.md
@@ -13,6 +13,9 @@ Scorers for evaluating point forecasts, prediction intervals, and conformal pred
 | [`BaseScorer`](generated/yohou.metrics.base.BaseScorer.md) | Base class for all forecasting metrics. |
 | [`BasePointScorer`](generated/yohou.metrics.base.BasePointScorer.md) | Base class for point forecast metrics. |
 | [`BaseIntervalScorer`](generated/yohou.metrics.base.BaseIntervalScorer.md) | Base class for interval forecast metrics. |
+| [`BaseClassProbaScorer`](generated/yohou.metrics.base.BaseClassProbaScorer.md) | Base class for class-probability metrics. |
+| [`BaseHardLabelScorer`](generated/yohou.metrics.base.BaseHardLabelScorer.md) | Base class for hard-label classification metrics. |
+| [`BaseRankingScorer`](generated/yohou.metrics.base.BaseRankingScorer.md) | Base class for ranking-based classification metrics. |
 | [`BaseConformityScorer`](generated/yohou.metrics.conformity_base.BaseConformityScorer.md) | Base class for conformal prediction conformity scorers. |
 
 ### Point Scorers
@@ -22,8 +25,11 @@ Scorers for evaluating point forecasts, prediction intervals, and conformal pred
 | [`MeanAbsoluteError`](generated/yohou.metrics.point.MeanAbsoluteError.md) | Mean Absolute Error metric for point forecasts. |
 | [`MeanAbsolutePercentageError`](generated/yohou.metrics.point.MeanAbsolutePercentageError.md) | Mean Absolute Percentage Error metric for point forecasts. |
 | [`MeanAbsoluteScaledError`](generated/yohou.metrics.point.MeanAbsoluteScaledError.md) | Mean Absolute Scaled Error metric for point forecasts. |
+| [`MaxAbsoluteError`](generated/yohou.metrics.point.MaxAbsoluteError.md) | Maximum Absolute Error metric for point forecasts. |
+| [`MeanDirectionalAccuracy`](generated/yohou.metrics.point.MeanDirectionalAccuracy.md) | Mean Directional Accuracy metric for point forecasts. |
 | [`MeanSquaredError`](generated/yohou.metrics.point.MeanSquaredError.md) | Mean Squared Error metric for point forecasts. |
 | [`MedianAbsoluteError`](generated/yohou.metrics.point.MedianAbsoluteError.md) | Median Absolute Error metric for point forecasts. |
+| [`R2Score`](generated/yohou.metrics.point.R2Score.md) | Coefficient of determination (R-squared) metric for point forecasts. |
 | [`RootMeanSquaredError`](generated/yohou.metrics.point.RootMeanSquaredError.md) | Root Mean Squared Error metric for point forecasts. |
 | [`RootMeanSquaredScaledError`](generated/yohou.metrics.point.RootMeanSquaredScaledError.md) | Root Mean Squared Scaled Error metric for point forecasts. |
 | [`SymmetricMeanAbsolutePercentageError`](generated/yohou.metrics.point.SymmetricMeanAbsolutePercentageError.md) | Symmetric Mean Absolute Percentage Error metric for point forecasts. |
@@ -33,6 +39,7 @@ Scorers for evaluating point forecasts, prediction intervals, and conformal pred
 | Name | Description |
 | --- | --- |
 | [`CalibrationError`](generated/yohou.metrics.interval.CalibrationError.md) | Calibration Error for prediction intervals. |
+| [`ContinuousRankedProbabilityScore`](generated/yohou.metrics.interval.ContinuousRankedProbabilityScore.md) | Continuous Ranked Probability Score for prediction intervals. |
 | [`EmpiricalCoverage`](generated/yohou.metrics.interval.EmpiricalCoverage.md) | Empirical coverage rate for prediction intervals. |
 | [`IntervalScore`](generated/yohou.metrics.interval.IntervalScore.md) | Interval Score (Winkler Score) for prediction intervals. |
 | [`MeanIntervalWidth`](generated/yohou.metrics.interval.MeanIntervalWidth.md) | Mean width of prediction intervals. |
@@ -43,8 +50,10 @@ Scorers for evaluating point forecasts, prediction intervals, and conformal pred
 | Name | Description |
 | --- | --- |
 | [`AbsoluteGammaResidual`](generated/yohou.metrics.conformity.AbsoluteGammaResidual.md) | Absolute gamma residual scorer using absolute relative errors. |
+| [`AbsoluteQuantileResidual`](generated/yohou.metrics.conformity.AbsoluteQuantileResidual.md) | Absolute quantile residual conformity scorer using unsigned pinball errors. |
 | [`AbsoluteResidual`](generated/yohou.metrics.conformity.AbsoluteResidual.md) | Absolute residual conformity scorer using unsigned prediction errors. |
 | [`GammaResidual`](generated/yohou.metrics.conformity.GammaResidual.md) | Gamma residual scorer using relative prediction errors. |
+| [`QuantileResidual`](generated/yohou.metrics.conformity.QuantileResidual.md) | Quantile residual conformity scorer using signed pinball errors. |
 | [`Residual`](generated/yohou.metrics.conformity.Residual.md) | Residual-based conformity scorer using signed prediction errors. |
 
 ### Classification Scorers
@@ -53,4 +62,10 @@ Scorers for evaluating point forecasts, prediction intervals, and conformal pred
 | --- | --- |
 | [`Accuracy`](generated/yohou.metrics.classification.Accuracy.md) | Categorical accuracy from class-probability forecasts. |
 | [`BrierScore`](generated/yohou.metrics.class_proba.BrierScore.md) | Multi-class Brier score for class-probability forecasts. |
+| [`FBetaScore`](generated/yohou.metrics.classification.FBetaScore.md) | F-beta score (hard-label) from class-probability forecasts. |
 | [`LogLoss`](generated/yohou.metrics.class_proba.LogLoss.md) | Logarithmic loss (cross-entropy) for class-probability forecasts. |
+| [`PRAuC`](generated/yohou.metrics.classification.PRAuC.md) | Area under the precision-recall curve from class-probability forecasts. |
+| [`Precision`](generated/yohou.metrics.classification.Precision.md) | Precision (hard-label) from class-probability forecasts. |
+| [`RankedProbabilityScore`](generated/yohou.metrics.class_proba.RankedProbabilityScore.md) | Ranked Probability Score for ordered class-probability forecasts. |
+| [`Recall`](generated/yohou.metrics.classification.Recall.md) | Recall (hard-label) from class-probability forecasts. |
+| [`ROCAuC`](generated/yohou.metrics.classification.ROCAuC.md) | Area under the ROC curve from class-probability forecasts. |

--- a/docs/pages/api/model_selection.md
+++ b/docs/pages/api/model_selection.md
@@ -22,8 +22,17 @@ Time series cross-validation splitters and hyperparameter search.
 | [`ExpandingWindowSplitter`](generated/yohou.model_selection.split.ExpandingWindowSplitter.md) | Expanding window time series cross-validation splitter. |
 | [`SlidingWindowSplitter`](generated/yohou.model_selection.split.SlidingWindowSplitter.md) | Sliding window time series cross-validation splitter. |
 
+### Cross-validation
+
+| Name | Description |
+| --- | --- |
+| [`cross_validate`](generated/yohou.model_selection.validation.cross_validate.md) | Evaluate a forecaster across cross-validation splits, returning multiple scores. |
+| [`cross_val_score`](generated/yohou.model_selection.validation.cross_val_score.md) | Evaluate a forecaster across cross-validation splits with a single scorer. |
+| [`cross_val_predict`](generated/yohou.model_selection.validation.cross_val_predict.md) | Generate cross-validated predictions for each split. |
+
 ### Utilities
 
 | Name | Description |
 | --- | --- |
-| [`check_cv`](generated/yohou.model_selection.split.check_cv.md) | Input checker utility for building a cross-validator. |
+| [`train_test_split`](generated/yohou.model_selection.split.train_test_split.md) | Split a time series into contiguous train and test sets. |
+| [`check_cv_alignment`](generated/yohou.model_selection.split.check_cv_alignment.md) | Validate that a cross-validator's splits align with the data. |

--- a/docs/pages/api/plotting.md
+++ b/docs/pages/api/plotting.md
@@ -15,6 +15,10 @@ Interactive time series visualization functions using Plotly. All plotting funct
 | [`plot_time_series`](generated/yohou.plotting.exploration.plot_time_series.md) | Plot basic line plots for one or more time series. |
 | [`plot_rolling_statistics`](generated/yohou.plotting.exploration.plot_rolling_statistics.md) | Plot rolling window statistics (mean, std, min, max, median, quantiles). |
 | [`plot_missing_data`](generated/yohou.plotting.exploration.plot_missing_data.md) | Visualize missing data patterns over time. |
+| [`plot_distribution`](generated/yohou.plotting.exploration.plot_distribution.md) | Plot the value distribution of one or more time series. |
+| [`plot_outliers`](generated/yohou.plotting.exploration.plot_outliers.md) | Highlight detected outliers over time. |
+| [`plot_resampling_comparison`](generated/yohou.plotting.exploration.plot_resampling_comparison.md) | Compare a time series before and after resampling. |
+| [`plot_seasonal_heatmap`](generated/yohou.plotting.diagnostics.plot_seasonal_heatmap.md) | Plot a heatmap of values across seasonal periods. |
 | [`plot_seasonality`](generated/yohou.plotting.diagnostics.plot_seasonality.md) | Plot seasonal overlay. |
 | [`plot_subseasonality`](generated/yohou.plotting.diagnostics.plot_subseasonality.md) | Plot seasonal subseries. |
 | [`plot_lag_scatter`](generated/yohou.plotting.diagnostics.plot_lag_scatter.md) | Plot scatter plots of y(t) vs y(t-lag) for analysing temporal dependencies. |
@@ -60,9 +64,20 @@ Interactive time series visualization functions using Plotly. All plotting funct
 
 | Name | Description |
 | --- | --- |
-| [`apply_default_layout`](generated/yohou.plotting._utils.apply_default_layout.md) | Apply default layout configuration to a figure. |
 | [`get_color_sequence`](generated/yohou.plotting._utils.get_color_sequence.md) | Get color sequence for plotting multiple series. |
 | [`palette_yohou`](generated/yohou.plotting._utils.palette_yohou.md) | Return the yohou color palette. |
 | [`resolve_color_palette`](generated/yohou.plotting._utils.resolve_color_palette.md) | Resolve a user-provided color palette or fall back to the default. |
-| [`facet_figure`](generated/yohou.plotting._utils.facet_figure.md) | Create a faceted subplot figure for panel data. |
 | [`resolve_panel_columns`](generated/yohou.plotting._utils.resolve_panel_columns.md) | Resolve which panel columns to plot. |
+| [`LINE_DASH_SEQUENCE`](generated/yohou.plotting._utils.LINE_DASH_SEQUENCE.md) | Default sequence of dash styles for distinguishing series. |
+| [`LegendTracker`](generated/yohou.plotting._utils.LegendTracker.md) | Track legend entries to deduplicate them across traces. |
+| [`PanelColorManager`](generated/yohou.plotting._utils.PanelColorManager.md) | Assign consistent colors to series across panel facets. |
+| [`RenderContext`](generated/yohou.plotting._utils.RenderContext.md) | Hold shared rendering state passed through plotting helpers. |
+| [`linked_legendgroup_kwargs`](generated/yohou.plotting._utils.linked_legendgroup_kwargs.md) | Build keyword arguments that link legend groups across subplots. |
+
+### Configuration
+
+| Name | Description |
+| --- | --- |
+| [`get_config`](generated/yohou.plotting._utils.get_config.md) | Return the current global plotting configuration. |
+| [`set_config`](generated/yohou.plotting._utils.set_config.md) | Set global plotting configuration options. |
+| [`config_context`](generated/yohou.plotting._utils.config_context.md) | Context manager for temporarily overriding plotting configuration. |

--- a/docs/pages/api/point.md
+++ b/docs/pages/api/point.md
@@ -11,5 +11,6 @@ Point forecasters for generating scalar-value predictions.
 | Name | Description |
 | --- | --- |
 | [`BasePointForecaster`](generated/yohou.point.base.BasePointForecaster.md) | Base class for point forecasters. |
+| [`MeanSeasonalNaive`](generated/yohou.point.naive.MeanSeasonalNaive.md) | Seasonal naive forecaster that averages values across previous seasons. |
 | [`PointReductionForecaster`](generated/yohou.point.reduction.PointReductionForecaster.md) | Point forecaster using sklearn estimators on tabularized time series. |
 | [`SeasonalNaive`](generated/yohou.point.naive.SeasonalNaive.md) | Seasonal naive forecaster that repeats values from previous season. |

--- a/docs/pages/api/utils.md
+++ b/docs/pages/api/utils.md
@@ -29,6 +29,22 @@ Validation, panel data, tags, discovery, and other utility functions.
 | [`check_groups_exist`](generated/yohou.utils.validation.check_groups_exist.md) | Validate all requested panel groups exist in fitted forecaster. |
 | [`check_panel_groups_match`](generated/yohou.utils.validation.check_panel_groups_match.md) | Validate that y and X have matching panel group structures. |
 | [`check_panel_internal_consistency`](generated/yohou.utils.validation.check_panel_internal_consistency.md) | Validate that all panel groups in a DataFrame have the same local column structure. |
+| [`window_futures`](generated/yohou.utils.pivot.window_futures.md) | Window known-future feature values into per-vintage forecast horizons. |
+
+### Tags
+
+| Name | Description |
+| --- | --- |
+| [`Tags`](generated/yohou.utils.tags.Tags.md) | Container of estimator tags describing capabilities and requirements. |
+| [`ForecasterTags`](generated/yohou.utils.tags.ForecasterTags.md) | Tags specific to forecaster estimators. |
+| [`InputTags`](generated/yohou.utils.tags.InputTags.md) | Tags describing the input data an estimator accepts. |
+| [`TargetTags`](generated/yohou.utils.tags.TargetTags.md) | Tags describing the target an estimator supports. |
+| [`TransformerTags`](generated/yohou.utils.tags.TransformerTags.md) | Tags specific to transformer estimators. |
+| [`SplitterTags`](generated/yohou.utils.tags.SplitterTags.md) | Tags specific to cross-validation splitters. |
+| [`POINT`](generated/yohou.utils.tags.POINT.md) | Prediction-type constant for point forecasts. |
+| [`INTERVAL`](generated/yohou.utils.tags.INTERVAL.md) | Prediction-type constant for interval forecasts. |
+| [`POINT_INTERVAL`](generated/yohou.utils.tags.POINT_INTERVAL.md) | Prediction-type constant for combined point and interval forecasts. |
+| [`CLASS_PROBA`](generated/yohou.utils.tags.CLASS_PROBA.md) | Prediction-type constant for class-probability forecasts. |
 
 ### Data validation
 

--- a/src/yohou/base/forecaster.py
+++ b/src/yohou/base/forecaster.py
@@ -21,6 +21,7 @@ from yohou.base.utils import _derive_step_columns
 from yohou.utils import (
     Tags,
     cast,
+    get_group_df,
     inspect_panel,
     validate_forecaster_data,
 )
@@ -74,9 +75,10 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
     Notes
     -----
     ``observe()`` appends new observations to internal buffers **without
-    refitting** the model.  ``rewind()`` truncates buffers to the last
-    ``observation_horizon`` rows.  Together they enable streaming /
-    rolling-window evaluation.
+    refitting** the model.  ``rewind()`` rebuilds internal buffers from the
+    provided historical window, allowing state to be reset to any prior point
+    without refitting.  Together they enable streaming / rolling-window
+    evaluation.
 
     The ``forecasting_horizon`` is set at ``fit`` time but can be
     overridden at ``predict`` time.
@@ -601,14 +603,6 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
             X_forecast=X_forecast,
         )
 
-        # Special handling for forecasters with no observation horizon
-        if self.observation_horizon == 0:  # pragma: no cover
-            # If there is no observation horizon, only check for time column presence
-            if "time" not in y.columns:
-                raise ValueError("y must contain 'time' column.")
-            if X_actual is not None and "time" not in X_actual.columns:
-                raise ValueError("X_actual must contain 'time' column.")
-
         # Dispatch to mixin methods
         if self.groups_ is None:
             BaseStandardForecaster._rewind_standard(self, y, X_actual, X_future=X_future, X_forecast=X_forecast)
@@ -796,8 +790,6 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
             # Swap step columns in _X_t_observed
             if X_step_new is not None:
                 if isinstance(self._X_t_observed, dict):
-                    from yohou.utils.panel import get_group_df  # noqa: PLC0415
-
                     for group_name, group_df in self._X_t_observed.items():
                         cols_to_drop = [c for c in local_step_cols if c in group_df.columns]  # ty: ignore[unresolved-attribute]
                         new_group_step = get_group_df(X_step_new, group_name, self._step_schema_per_group_).select(  # ty: ignore[invalid-argument-type]
@@ -1063,7 +1055,7 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
         groups: list[str],
         **params,
     ) -> pl.DataFrame:
-        """Predicts `_fit_forecasting_horizon` steps from the observation horizon.
+        """Predicts ``fit_forecasting_horizon_`` steps from the observation horizon.
 
         Parameters
         ----------
@@ -1078,7 +1070,7 @@ class BaseForecaster(BaseStandardForecaster, BasePanelForecaster, BaseEstimator,
             Predicted time series.
 
         """
-        raise NotImplementedError(f"The forecaster of type {type(self)} does not implement_predict_one.")
+        raise NotImplementedError(f"The forecaster of type {type(self)} does not implement _predict_one.")
 
     def _predict(
         self,

--- a/src/yohou/base/panel.py
+++ b/src/yohou/base/panel.py
@@ -713,9 +713,12 @@ class BasePanelForecaster:
         """
         # For panel data, all groups share the same time progression
         # Use the first group's observed_time_ as reference
-        first_group_name = list(self.observed_time_.keys())[0]
+        first_group_name = next(iter(self.observed_time_))
         observed_time_value = self.observed_time_[first_group_name]
 
+        # interval_ may be a non-uniform string offset (e.g. "1mo"), so steps
+        # are advanced one at a time via add_interval rather than a vectorised
+        # datetime_range that assumes a fixed timedelta.
         predicted_times = [add_interval(observed_time_value, self.interval_, n=n) for n in range(1, len(y_pred) + 1)]
 
         time = pl.DataFrame({"vintage_time": [observed_time_value] * len(y_pred), "time": predicted_times})

--- a/src/yohou/base/reduction.py
+++ b/src/yohou/base/reduction.py
@@ -46,7 +46,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
     target_transformer : instance of `BaseTransformer` or None, default=None
         Transformer used to transform the target time series into the new target.
     feature_transformer : instance of `BaseTransformer` or None, default=None
-        Transformer used to transform the target time series into features.
+        Transformer used to transform the feature time series into features.
     panel_strategy : {"global", "multivariate"}, default="global"
         How to handle panel data. See `BaseForecaster` for details.
     step_feature_alignment : {"all", "matched", "cumulative"}, default="all"
@@ -73,6 +73,23 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         unless in a ``joblib.parallel_backend`` context. ``-1`` means
         using all processors. Has no effect for ``"multi-output"`` or
         ``"dir-rec"`` strategies.
+    time_weighter : instance of `BaseWeighter` or None, default=None
+        Weighter producing per-timestamp weights for the target time
+        axis. Converted to sklearn ``sample_weight`` for training using
+        ``sample_weight_alignment``.
+    vintage_weighter : instance of `BaseWeighter` or None, default=None
+        Weighter producing per-vintage weights. Looked up directly per
+        training sample (no alignment) and combined multiplicatively with
+        the time weights.
+    sample_weight_alignment : {"first_step", "mean_step", \
+"weighted_mean_step", "max_weight_step", "min_weight_step"}, \
+default="first_step"
+        How to collapse the per-step ``time_weighter`` weights of a
+        sample's forecast window into a single ``sample_weight``.
+        ``"first_step"`` uses the one-step-ahead weight; ``"mean_step"``,
+        ``"max_weight_step"``, and ``"min_weight_step"`` aggregate across
+        the horizon; ``"weighted_mean_step"`` uses an exponentially
+        decaying weighting of the horizon steps.
 
     Notes
     -----
@@ -363,11 +380,13 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         -----
         Lag-to-step renaming convention:
         - Input: y with lag_0, lag_1, lag_2, ..., lag_H features
+        - General mapping: lag_{H - k} becomes step_k for k in 1..H.
         - For forecasting_horizon=3:
-            - lag_1 → step_1 (1-step-ahead target)
-            - lag_2 → step_2 (2-step-ahead target)
-            - lag_3 → step_3 (3-step-ahead target)
-            - lag_0 is the most recent observation (not a target)
+            - lag_2 → step_1 (1-step-ahead target)
+            - lag_1 → step_2 (2-step-ahead target)
+            - lag_0 → step_3 (3-step-ahead target)
+            - lag_3 (the oldest lag) maps to step_0 and is not selected as a
+              target
 
         This convention makes it clear that we're predicting future values, not
         explaining historical ones.
@@ -484,6 +503,13 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             Stacked target matrix with all horizon steps.
 
         """
+        if X_t is None:
+            raise ValueError(
+                "Cannot tabularize: no feature matrix is available. Set "
+                "target_as_feature to include the target as a feature, or "
+                "provide exogenous features."
+            )
+
         if self.groups_ is None:
             assert isinstance(y_t, pl.DataFrame)
             assert isinstance(X_t, pl.DataFrame)
@@ -588,14 +614,7 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         if self.nan_handling == "pass":
             return X_tab, y_tab, sample_weight
 
-        # For null: check all columns. For NaN: only float columns.
-        null_free = X_tab.select(pl.all_horizontal(pl.all().is_not_null())).to_series()
-        float_cols = X_tab.select(cs.float())
-        if float_cols.width > 0:
-            nan_free = float_cols.select(pl.all_horizontal(pl.all().is_not_nan())).to_series()
-            x_ok = null_free & nan_free
-        else:
-            x_ok = null_free
+        x_ok = self._compute_x_ok_mask(X_tab)
 
         if isinstance(y_tab, pl.Series):
             y_ok = y_tab.is_not_null()
@@ -632,18 +651,28 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         return X_tab, y_tab, sample_weight
 
+    @staticmethod
+    def _compute_x_ok_mask(X_tab: pl.DataFrame) -> pl.Series:
+        """Compute a per-row mask of feature rows free of nulls and NaNs.
+
+        For nulls, every column is checked. For NaNs, only float columns
+        are checked. The returned boolean Series is ``True`` for rows that
+        are safe to feed to the estimator.
+        """
+        null_free = X_tab.select(pl.all_horizontal(pl.all().is_not_null())).to_series()
+        float_cols = X_tab.select(cs.float())
+        if float_cols.width > 0:
+            nan_free = float_cols.select(pl.all_horizontal(pl.all().is_not_nan())).to_series()
+            return null_free & nan_free
+        return null_free
+
     def _features_have_nan(self, X_tab: pl.DataFrame) -> bool:
         """Check if a feature DataFrame contains any NaN or null values.
 
         Only used when ``nan_handling="drop"`` to decide whether the
         estimator can be called safely at predict time.
         """
-        null_free = X_tab.select(pl.all_horizontal(pl.all().is_not_null())).to_series()
-        float_cols = X_tab.select(cs.float())
-        if float_cols.width > 0:
-            nan_free = float_cols.select(pl.all_horizontal(pl.all().is_not_nan())).to_series()
-            return not (null_free & nan_free).all()
-        return not null_free.all()
+        return not self._compute_x_ok_mask(X_tab).all()
 
     def _nan_predict_result(self, n_rows: int = 1) -> np.ndarray:
         """Return a NaN array shaped like a multi-output prediction."""
@@ -891,13 +920,11 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             forecasting_horizon,
         )
 
-        y_columns = (
-            list(self.local_y_t_schema_.keys())
-            if self.groups_ is None
-            else [c for c in next(iter(y_t.values())).columns if c != "time"]
-            if isinstance(y_t, dict)
-            else list(self.local_y_t_schema_.keys())
-        )
+        if self.groups_ is None:
+            y_columns = list(self.local_y_t_schema_.keys())
+        else:
+            assert isinstance(y_t, dict)
+            y_columns = [c for c in next(iter(y_t.values())).columns if c != "time"]
 
         def _fit_step(step: int) -> BaseEstimator:
             """Fit a single estimator for horizon step."""
@@ -971,13 +998,11 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         self._dir_rec_n_original_features_ = X_tab.shape[1]
 
-        y_columns = (
-            list(self.local_y_t_schema_.keys())
-            if self.groups_ is None
-            else [c for c in next(iter(y_t.values())).columns if c != "time"]
-            if isinstance(y_t, dict)
-            else list(self.local_y_t_schema_.keys())
-        )
+        if self.groups_ is None:
+            y_columns = list(self.local_y_t_schema_.keys())
+        else:
+            assert isinstance(y_t, dict)
+            y_columns = [c for c in next(iter(y_t.values())).columns if c != "time"]
 
         estimators: list[BaseEstimator] = []
         X_aug = X_tab.clone()  # Progressively augmented feature matrix

--- a/src/yohou/base/standard.py
+++ b/src/yohou/base/standard.py
@@ -42,7 +42,9 @@ class BaseStandardForecaster:
     groups_: None
     local_y_schema_: dict[str, pl.DataType]
     local_X_actual_schema_: dict[str, pl.DataType] | None
-    shared_X_actual_schema_: None
+    # Always None for standalone non-panel forecasters, but compositions
+    # (e.g. ColumnForecaster) may aggregate shared schemas from panel children.
+    shared_X_actual_schema_: dict[str, pl.DataType] | None
     observation_horizon: int
     observed_time_: datetime
     interval_: timedelta | str

--- a/src/yohou/base/transformer.py
+++ b/src/yohou/base/transformer.py
@@ -88,7 +88,8 @@ class BaseTransformer(BaseEstimator, metaclass=abc.ABCMeta):
         # Create Tags with transformer-specific defaults
         tags = Tags(estimator_type="transformer", requires_fit=True)
 
-        assert tags.transformer_tags is not None
+        if tags.transformer_tags is None:
+            raise RuntimeError('Tags object has no transformer_tags; estimator_type="transformer" was not honoured.')
 
         # Default to non-invertible; subclasses set _tags = {"invertible": True}
         tags.transformer_tags.invertible = False
@@ -396,8 +397,9 @@ class BaseTransformer(BaseEstimator, metaclass=abc.ABCMeta):
         observations with the new input, applying the transformation,
         and then updating the internal state.
 
-        Equivalent to calling ``observe(X)`` then ``transform(X)``, but
-        uses pre-existing memory for the transform.
+        Transforms using pre-existing memory first, then updates state with
+        ``observe(X)``. This is NOT equivalent to ``observe(X); transform(X)``,
+        since the transform uses memory from before the observation.
 
         Parameters
         ----------
@@ -441,9 +443,10 @@ class BaseTransformer(BaseEstimator, metaclass=abc.ABCMeta):
         """Transform the input and rewind state (stateless transform).
 
         Applies the transformation to the full input and then rewinds
-        internal state.  Because ``transform()`` already drops the first
-        ``observation_horizon`` rows for stateful transformers, the result
-        has ``len(X) - observation_horizon`` rows.
+        internal state. Stateful subclasses typically discard the first
+        ``observation_horizon`` rows inside ``_transform()``, so the result
+        usually has ``len(X) - observation_horizon`` rows, but the exact count
+        depends on the transformer implementation.
 
         Equivalent to calling ``rewind(X)`` then ``transform(X)``.
 

--- a/src/yohou/base/utils.py
+++ b/src/yohou/base/utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -241,9 +243,9 @@ def _rewind_transformers_one(
     Parameters
     ----------
     y : pl.DataFrame
-        New target observations.
+        Historical target time series to rewind state from.
     X_actual : pl.DataFrame or None
-        New features.
+        Historical feature observations to rewind state from.
     target_transformer : BaseTransformer or None
         Target transformer to rewind.
     feature_transformer : BaseTransformer or None
@@ -262,8 +264,18 @@ def _rewind_transformers_one(
     y_t = y
 
     if target_transformer is not None:
-        target_transformer.rewind(X=y[:-observation_horizon])
-        y_t = target_transformer.observe_transform(y[-observation_horizon:])
+        # Use an explicit split index rather than negative slicing: when
+        # observation_horizon == 0, y[:-0] is empty and y[-0:] is the full
+        # frame, which inverts the rewind/observe windows. len(y) - 0 == len(y)
+        # rewinds over all rows and leaves an empty observation window.
+        split = len(y) - observation_horizon
+        if split < 0:
+            raise ValueError(
+                f"observation_horizon={observation_horizon} exceeds the number of "
+                f"available rows ({len(y)}); not enough data to rewind."
+            )
+        target_transformer.rewind(X=y[:split])
+        y_t = target_transformer.observe_transform(y[split:])
 
     X_feat_in = _build_feature_input(y, y_t, X_actual, target_as_feature, feature_transformer)
 
@@ -297,7 +309,17 @@ def _rewind_transformers_one(
         # directly on them raises NotFittedError because their fit() does
         # not set the base-class fitted attributes.
         X_t_all = feature_transformer.rewind_transform(X_feat_in)
-        X_t = X_t_all.tail(1)
+        # Keep the row aligned to the most-recent observation timestamp rather
+        # than blindly taking the last row: when the feature transformer drops
+        # rows (its own observation_horizon), the surviving tail may not line up
+        # with the latest observation.
+        last_time = y["time"][-1]
+        if "time" in X_t_all.columns:
+            X_t = X_t_all.filter(pl.col("time") == last_time)
+            if X_t.is_empty():
+                X_t = X_t_all.tail(1)
+        else:
+            X_t = X_t_all.tail(1)
 
     return X_t
 
@@ -386,8 +408,6 @@ def _derive_step_columns(
 
         # Warn if any value column has step columns that are entirely null,
         # indicating the matched vintage(s) don't cover the full horizon.
-        import re  # noqa: PLC0415
-
         step_cols_forecast = [c for c in forecast_pivoted.columns if c != "time" and re.search(r"_step_\d+$", c)]
         if step_cols_forecast:
             # Find the highest step number that has at least one non-null value
@@ -397,8 +417,6 @@ def _derive_step_columns(
                 if m and forecast_pivoted[c].null_count() < len(forecast_pivoted):
                     max_covered = max(max_covered, int(m.group(1)))
             if max_covered < forecasting_horizon:
-                import warnings  # noqa: PLC0415
-
                 warnings.warn(
                     f"X_forecast covers {max_covered} of {forecasting_horizon} "
                     f"forecast steps. The remaining step features will be null. "

--- a/src/yohou/class_proba/base.py
+++ b/src/yohou/class_proba/base.py
@@ -25,7 +25,7 @@ class BaseClassProbaForecaster(BaseForecaster, metaclass=abc.ABCMeta):
     target_transformer : instance of `BaseTransformer` or None, default=None
         Transformer used to transform the target time series into the new target.
     feature_transformer : instance of `BaseTransformer` or None, default=None
-        Transformer used to transform the target time series into features.
+        Transformer used to transform the feature time series (``X_actual``) into features.
     target_as_feature : {"transformed", "raw"} or None, default="transformed"
         Controls whether the target is included as a feature.
         ``"transformed"`` includes the transformed target, ``"raw"``
@@ -48,7 +48,7 @@ class BaseClassProbaForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
     classes_: dict[str, list[str]]
     n_classes_: dict[str, int]
-    label_to_code_: dict[str, dict[str, float]]
+    label_to_code_: dict[str, dict[str, int]]
 
     def __sklearn_tags__(self) -> Tags:
         """Get estimator tags.
@@ -301,6 +301,8 @@ class BaseClassProbaForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         ------
         sklearn.exceptions.NotFittedError
             If the forecaster has not been fitted yet.
+        ValueError
+            If ``groups`` contains names not seen during fit.
 
         """
         y_proba = self.predict_class_proba(
@@ -327,8 +329,10 @@ class BaseClassProbaForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         Returns
         -------
         pl.DataFrame
-            DataFrame with ``"time"``, and one column per original target
-            containing the class label with highest probability.
+            DataFrame with ``"vintage_time"``, ``"time"``, and one column per
+            original target containing the class label with highest
+            probability. In panel mode, output columns carry the
+            ``{group}__{target}`` prefix to match the input schema.
 
         """
         check_is_fitted(self, ["classes_"])
@@ -336,18 +340,33 @@ class BaseClassProbaForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         time_cols = [c for c in ("vintage_time", "time") if c in y_proba.columns]
         result = y_proba.select(time_cols)
 
-        for target_col, class_labels in self.classes_.items():
-            proba_cols = [f"{target_col}_proba_{label}" for label in class_labels]
-            # For each row, find the index of the max probability column
-            # then map that index to the class label.
-            argmax_series = y_proba.select(pl.concat_list(proba_cols).list.arg_max().alias("_idx"))["_idx"]
-            label_series = pl.Series(values=class_labels)
-            result = result.with_columns(
-                argmax_series.map_elements(
-                    lambda idx, _labels=label_series: _labels[idx],
-                    return_dtype=pl.String,
-                ).alias(target_col),
-            )
+        if self.groups_ is None:
+            group_prefixes: list[str | None] = [None]
+        else:
+            # Only emit groups whose proba columns are present in y_proba
+            # (predict may have been called with a subset of groups).
+            present = set(y_proba.columns)
+            group_prefixes = [
+                group_prefix
+                for group_prefix in self.groups_
+                if any(col.startswith(f"{group_prefix}__") for col in present)
+            ]
+
+        for group_prefix in group_prefixes:
+            for target_col, class_labels in self.classes_.items():
+                if group_prefix is None:
+                    out_col = target_col
+                    proba_cols = [f"{target_col}_proba_{label}" for label in class_labels]
+                else:
+                    out_col = f"{group_prefix}__{target_col}"
+                    proba_cols = [f"{group_prefix}__{target_col}_proba_{label}" for label in class_labels]
+                # For each row, find the index of the max probability column
+                # then gather the matching class label.
+                argmax_series = y_proba.select(pl.concat_list(proba_cols).list.arg_max().cast(pl.UInt32).alias("_idx"))[
+                    "_idx"
+                ]
+                label_series = pl.Series(values=class_labels)
+                result = result.with_columns(label_series.gather(argmax_series).alias(out_col))
 
         return result
 
@@ -405,7 +424,7 @@ class BaseClassProbaForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             if y[col].dtype.is_numeric():
                 continue
             # For panel columns like "group_0__weather", extract "weather"
-            base_col = col.split("__")[-1] if "__" in col else col
+            base_col = col.split("__", 1)[1] if "__" in col else col
             if base_col in self.label_to_code_:
                 mapping = self.label_to_code_[base_col]
                 exprs.append(pl.col(col).replace_strict(mapping, return_dtype=pl.Float64).alias(col))
@@ -505,8 +524,9 @@ class BaseClassProbaForecaster(BaseForecaster, metaclass=abc.ABCMeta):
     ) -> pl.DataFrame:
         """Alternate recursive predict_class_proba and observe.
 
-        Equivalent to calling ``observe(y, X_actual)`` then
-        ``predict_class_proba()``. Returns probability predictions.
+        Emits an initial prediction from the current state, then alternates
+        observing a stride-sized slice of ``y`` and predicting, collecting
+        all probability predictions.
 
         Parameters
         ----------
@@ -526,7 +546,7 @@ class BaseClassProbaForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             data.
         stride : int or None, default=None
             Step size for rolling update-predict. If ``None``, defaults to
-            ``forecasting_horizon``.
+            the horizon specified at fit time (``fit_forecasting_horizon_``).
         X_future : pl.DataFrame or None, default=None
             Known future features with a ``"time"`` column.
         X_forecast : pl.DataFrame or None, default=None
@@ -596,8 +616,9 @@ class BaseClassProbaForecaster(BaseForecaster, metaclass=abc.ABCMeta):
     ) -> pl.DataFrame:
         """Alternate recursive predict and observe.
 
-        Equivalent to calling ``observe(y, X_actual)`` then ``predict()``.
-        Returns argmax class predictions.
+        Emits an initial prediction from the current state, then alternates
+        observing a stride-sized slice of ``y`` and predicting, collecting
+        all argmax class predictions.
 
         Parameters
         ----------
@@ -617,7 +638,7 @@ class BaseClassProbaForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             data.
         stride : int or None, default=None
             Step size for rolling update-predict. If ``None``, defaults to
-            ``forecasting_horizon``.
+            the horizon specified at fit time (``fit_forecasting_horizon_``).
         X_future : pl.DataFrame or None, default=None
             Known future features with a ``"time"`` column.
         X_forecast : pl.DataFrame or None, default=None

--- a/src/yohou/class_proba/reduction.py
+++ b/src/yohou/class_proba/reduction.py
@@ -430,6 +430,18 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         pl.DataFrame
             Probability DataFrame with ``{target}_proba_{class}`` columns.
 
+        Notes
+        -----
+        ``classes_`` is the *globally merged* class set across every panel
+        group (see ``fit``); each group's underlying sklearn classifier may
+        have been trained on a subset of those classes, so its
+        ``predict_proba`` can return fewer columns than ``len(classes_)``.
+        When a global class index has no corresponding column from the
+        estimator (``c_idx >= len(step_proba)``), its probability is filled
+        with ``0.0``: the class was unseen by this group, so it carries zero
+        mass. This is expected reconciliation, not data loss, and keeps the
+        per-group output aligned to the shared global class layout.
+
         """
         assert self.local_y_t_schema_ is not None
         y_cols = list(self.local_y_t_schema_.keys())
@@ -465,6 +477,7 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
                         if c_idx < len(step_proba):
                             result_data[col_name].append(float(step_proba[c_idx]))
                         else:
+                            # Global class unseen by this group's estimator; zero mass.
                             result_data[col_name].append(0.0)
         else:
             # Single-output classifier or single-target: proba shape (1, n_classes)
@@ -512,6 +525,14 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         -------
         pl.DataFrame
             Single-row probability DataFrame.
+
+        Notes
+        -----
+        As in ``_predict_proba_and_reshape``, a global class index without a
+        matching column from the estimator (``c_idx >= len(step_proba)``) is
+        filled with ``0.0``. This reconciles a group whose estimator saw only
+        a subset of the globally merged ``classes_``; the unseen class
+        correctly carries zero mass rather than being dropped.
 
         """
         assert self.local_y_t_schema_ is not None

--- a/src/yohou/class_proba/reduction.py
+++ b/src/yohou/class_proba/reduction.py
@@ -224,7 +224,7 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         for col in y.columns:
             if col == "time":
                 continue
-            base_col = col.split("__")[-1] if "__" in col else col
+            base_col = col.split("__", 1)[1] if "__" in col else col
             unique_vals = sorted(y[col].drop_nulls().unique().cast(pl.String).to_list())
             if base_col in self.classes_:
                 merged = sorted(set(self.classes_[base_col]) | set(unique_vals))
@@ -273,7 +273,7 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         for col in y.columns:
             if col == "time":
                 continue
-            base_col = col.split("__")[-1] if "__" in col else col
+            base_col = col.split("__", 1)[1] if "__" in col else col
             mapping = self.label_to_code_[base_col]
             # Cast to String first to handle Categorical/Enum/String uniformly,
             # then replace labels with integer codes.
@@ -420,7 +420,8 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         estimator : BaseEstimator
             Fitted classifier.
         X_tab : pl.DataFrame
-            Feature DataFrame of shape ``(1, n_features)``.
+            Feature DataFrame, typically of shape ``(1, n_features)`` at
+            predict time (the shape is a caller convention, not enforced here).
         panel_group_name : str or None
             Panel group prefix for column naming.
 
@@ -483,8 +484,9 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
                     if panel_group_name is not None:
                         col_name = f"{panel_group_name}__{col_name}"
                     result_data[col_name].append(float(step_proba[c_idx]) if c_idx < len(step_proba) else 0.0)
-                # If fh > 1, replicate (the recursive loop in predict_class_proba handles stepping)
-                # This branch should only be reached with fh=1 in multi-output mode.
+                # This branch builds a single row and is only reached with
+                # fh=1 in single-output mode; multi-step stepping is handled
+                # by the recursive loop in predict_class_proba.
 
         return pl.DataFrame(result_data)
 
@@ -501,7 +503,8 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         estimator : BaseEstimator
             Fitted single-step classifier.
         X_tab : pl.DataFrame
-            Feature DataFrame of shape ``(1, n_features)``.
+            Feature DataFrame, typically of shape ``(1, n_features)`` at
+            predict time (the shape is a caller convention, not enforced here).
         panel_group_name : str or None
             Panel group prefix for column naming.
 

--- a/src/yohou/compose/column_forecaster.py
+++ b/src/yohou/compose/column_forecaster.py
@@ -131,8 +131,11 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
         How to handle columns not assigned to any forecaster:
 
         - ``"drop"``: Unassigned columns are excluded from predictions.
-        - ``"passthrough"``: Unassigned columns are excluded from predictions
-          (same as ``"drop"``).
+        - ``"passthrough"``: Accepted as an alias of ``"drop"``; unassigned
+          columns are excluded from predictions. Note this differs from
+          sklearn's ``ColumnTransformer``, where ``"passthrough"`` carries
+          columns through unchanged: a forecaster cannot pass observed
+          columns through as future predictions, so both strings drop them.
         - estimator: A ``BaseForecaster`` instance used to forecast the
           unassigned columns.
 
@@ -144,6 +147,10 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
     verbose_feature_names_out : bool, default=False
         If True, prefix output column names with the forecaster name
         (e.g., 'sales_forecaster__sales'). If False, keep original column names.
+        This default differs from `ColumnTransformer` (which defaults to
+        ``verbose_feature_names_out=True``): the forecaster side preserves
+        original column names by default, while the transformer side prefixes
+        by default for feature clarity.
     panel_strategy : {"global", "multivariate"}, default="global"
         How to handle panel data. See `BaseForecaster` for details.
 
@@ -205,7 +212,8 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
       ``remainder``: dropped, or forecasted by an estimator
     - Forecasters are fitted in parallel when ``n_jobs > 1``
     - Predictions are concatenated in the order: forecasters, then remainder
-    - All forecasters receive the same exogenous features X_actual
+    - All forecasters (including the remainder) receive the same exogenous
+      inputs: ``X_actual``, ``X_future``, and ``X_forecast``
 
     """
 
@@ -532,8 +540,21 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
         if self.remainder_forecaster_ is not None and hasattr(self.remainder_forecaster_, "local_y_schema_"):
             self.local_y_schema_.update(self.remainder_forecaster_.local_y_schema_)
 
-        self.local_X_actual_schema_ = getattr(first_forecaster, "local_X_actual_schema_", None)
-        self.shared_X_actual_schema_ = getattr(first_forecaster, "shared_X_actual_schema_", None)
+        # X_actual schemas are merged across all forecasters; since every
+        # forecaster receives the same X_actual these are consistent, but
+        # merging avoids discarding schema seen by later forecasters.
+        all_forecasters = [f for _, f, _ in self.forecasters_]
+        if self.remainder_forecaster_ is not None:
+            all_forecasters.append(self.remainder_forecaster_)
+        self.local_X_actual_schema_ = None
+        self.shared_X_actual_schema_ = None
+        for forecaster in all_forecasters:
+            local_schema = getattr(forecaster, "local_X_actual_schema_", None)
+            if local_schema is not None:
+                self.local_X_actual_schema_ = {**(self.local_X_actual_schema_ or {}), **local_schema}
+            shared_schema = getattr(forecaster, "shared_X_actual_schema_", None)
+            if shared_schema is not None:
+                self.shared_X_actual_schema_ = {**(self.shared_X_actual_schema_ or {}), **shared_schema}
 
         # Set transformed schema attributes (no transformation for meta-forecaster)
         self.local_y_t_schema_ = self.local_y_schema_
@@ -588,6 +609,7 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
 
         predictions: list[pl.DataFrame] = []
         time_columns: pl.DataFrame | None = None
+        time_col_names: list[str] = []
 
         # Predict with each forecaster
         for name, forecaster, _cols in self.forecasters_:
@@ -603,10 +625,11 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
 
             # Store time columns from first prediction
             if time_columns is None:
-                time_columns = y_pred.select(["vintage_time", "time"])
-                predictions.append(y_pred.select(~cs.by_name("vintage_time", "time")))
+                time_col_names = [c for c in ["vintage_time", "time"] if c in y_pred.columns]
+                time_columns = y_pred.select(time_col_names)
+                predictions.append(y_pred.select(~cs.by_name(*time_col_names)))
             else:
-                predictions.append(y_pred.select(~cs.by_name("vintage_time", "time")))
+                predictions.append(y_pred.select(~cs.by_name(*time_col_names)))
 
         # Predict with remainder forecaster if present
         if self.remainder_forecaster_ is not None and self.remainder_cols_:
@@ -619,7 +642,7 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
                 X_forecast=X_forecast,
                 **remainder_params.predict,
             )
-            predictions.append(y_pred_remainder.select(~cs.by_name("vintage_time", "time")))
+            predictions.append(y_pred_remainder.select(~cs.by_name(*time_col_names)))
 
         # Concatenate all predictions with time columns
         assert time_columns is not None
@@ -669,7 +692,9 @@ class ColumnForecaster(BaseForecaster, _BaseComposition):
             y_remainder = y.select(["time"] + self.remainder_cols_)
             self.remainder_forecaster_.observe(y_remainder, X_actual, groups, X_future=X_future, X_forecast=X_forecast)
 
-        # Observe observed data
+        # Bookkeeping only: this meta-forecaster delegates bounded buffering
+        # to its child forecasters, so _y_observed/_X_observed are not used for
+        # prediction and are intentionally not truncated here.
         assert isinstance(self._y_observed, pl.DataFrame)
         self._y_observed = pl.concat([self._y_observed, y])
         if X_actual is not None:

--- a/src/yohou/compose/column_transformer.py
+++ b/src/yohou/compose/column_transformer.py
@@ -201,7 +201,10 @@ class ColumnTransformer(BaseTransformer, _BaseComposition):
     (e.g., 'deseason_sales') to prevent name collisions when multiple
     transformers produce columns with the same names. For panel data columns,
     the prefix is inserted after the group separator to preserve panel structure
-    (e.g., 'store_1__deseason_sales').
+    (e.g., 'store_1__deseason_sales'). This default differs from
+    `ColumnForecaster` (which defaults to ``verbose_feature_names_out=False``):
+    the transformer side prefixes by default for feature clarity, while the
+    forecaster side preserves original column names by default.
 
     The `observation_horizon` property returns the MAXIMUM across all column
     transformers, as the transformer needs enough history to satisfy the most
@@ -730,13 +733,13 @@ class ColumnTransformer(BaseTransformer, _BaseComposition):
 
         # validate estimators
         for t in transformers:
-            if t == "passthrough":
+            if t in ("drop", "passthrough"):
                 continue
             if not isinstance(t, BaseTransformer):
                 # Used to validate the transformers in the `transformers` list
                 raise TypeError(
                     "All estimators should be instances of `BaseTransformer` "
-                    "or be the string 'passthrough' "
+                    "or be the strings 'drop' or 'passthrough' "
                     f"'{t}' (type {type(t)}) doesn't"
                 )
 

--- a/src/yohou/compose/decomposition_pipeline.py
+++ b/src/yohou/compose/decomposition_pipeline.py
@@ -774,6 +774,12 @@ class DecompositionPipeline(BasePointForecaster, _BaseComposition):
         sklearn.exceptions.NotFittedError
             If the pipeline has not been fitted yet.
 
+        Notes
+        -----
+        If ``store_residuals=True``, the residuals computed for each component
+        during this call are appended to ``self.residuals_[name]``. When
+        ``store_residuals=False`` no residuals are accumulated.
+
         """
         check_is_fitted(self, ["forecasters_", "groups_"])
         y, X_actual, groups = validate_forecaster_data(
@@ -784,18 +790,19 @@ class DecompositionPipeline(BasePointForecaster, _BaseComposition):
             groups=groups,
         )
 
-        # Observe transformers first
+        # Observe and transform in one atomic step: observe_transform uses the
+        # pre-observe state to transform, then updates the buffer.  A separate
+        # observe() then transform() would transform against post-observe state
+        # and yield empty output for stateful transformers (e.g. differencing).
         if self.target_transformer_ is not None:
             assert isinstance(self.target_transformer_, BaseTransformer)
-            self.target_transformer_.observe(y)
-            y_t = self.target_transformer_.transform(y)
+            y_t = self.target_transformer_.observe_transform(y)
         else:
             y_t = y
 
         if X_actual is not None and self.feature_transformer_ is not None:
             assert isinstance(self.feature_transformer_, BaseTransformer)
-            self.feature_transformer_.observe(X_actual)
-            X_t = self.feature_transformer_.transform(X_actual)
+            X_t = self.feature_transformer_.observe_transform(X_actual)
         else:
             X_t = X_actual
 
@@ -827,11 +834,14 @@ class DecompositionPipeline(BasePointForecaster, _BaseComposition):
                 [pl.col("time")] + [(pl.col(col) - pl.col(f"{col}_pred")).alias(col) for col in target_cols]
             )
 
-            # Store residuals if requested
+            # Store residuals if requested. Initialize defensively: observe may
+            # run before any residuals were stored for this component (e.g. a
+            # forecaster added after fit, or store_residuals toggled on).
             if self.store_residuals:
-                self.residuals_[name] = pl.concat(
-                    [self.residuals_[name], residuals],
-                )
+                if not hasattr(self, "residuals_"):
+                    self.residuals_ = {}
+                prior = self.residuals_.get(name)
+                self.residuals_[name] = pl.concat([prior, residuals]) if prior is not None else residuals
 
         # Observe base class observation buffers
         self._y_observed = y_t
@@ -875,6 +885,14 @@ class DecompositionPipeline(BasePointForecaster, _BaseComposition):
         ------
         sklearn.exceptions.NotFittedError
             If the pipeline has not been fitted yet.
+
+        Notes
+        -----
+        Unlike ``observe``, ``rewind`` seeds every component forecaster with
+        the same full target ``y_t`` (in transformed space), not the
+        per-component residuals. This is intentional: ``rewind`` resets
+        observation state to a reference window rather than decomposing a new
+        signal.
 
         """
         check_is_fitted(self, ["forecasters_", "groups_"])

--- a/src/yohou/compose/decomposition_pipeline.py
+++ b/src/yohou/compose/decomposition_pipeline.py
@@ -888,11 +888,13 @@ class DecompositionPipeline(BasePointForecaster, _BaseComposition):
 
         Notes
         -----
-        Unlike ``observe``, ``rewind`` seeds every component forecaster with
-        the same full target ``y_t`` (in transformed space), not the
-        per-component residuals. This is intentional: ``rewind`` resets
-        observation state to a reference window rather than decomposing a new
-        signal.
+        Like ``observe``, ``rewind`` threads the decomposition residuals
+        through the component forecasters: each component is rewound on the
+        residual stream at its stage (the transformed target minus the sum of
+        all preceding components' predictions), mirroring what each component
+        was fitted on. The difference from ``observe`` is only that ``rewind``
+        resets each component's observation buffer to a reference window rather
+        than appending to it.
 
         """
         check_is_fitted(self, ["forecasters_", "groups_"])
@@ -917,9 +919,64 @@ class DecompositionPipeline(BasePointForecaster, _BaseComposition):
         else:
             X_t = X_actual
 
-        # Rewind all forecasters
+        # Rewind all forecasters, threading residuals through each stage so
+        # every component is rewound on the signal it was fitted on (the
+        # transformed target minus preceding components' predictions), not the
+        # full target. Predictions for the residuals are computed on a deepcopy
+        # (mirroring fit) so the real forecaster's buffer is left in the rewound
+        # state, not the observe-predict state.
+        residuals = y_t
         for _, forecaster in self.forecasters_:
-            forecaster.rewind(y_t, X_actual=X_t, X_future=X_future, X_forecast=X_forecast)
+            forecaster.rewind(residuals, X_actual=X_t, X_future=X_future, X_forecast=X_forecast)
+
+            forecaster_pred = deepcopy(forecaster)
+            forecaster_observation_horizon = forecaster_pred.observation_horizon
+            if forecaster_pred.feature_transformer is not None:
+                ft_ = forecaster_pred.feature_transformer_
+                if isinstance(ft_, dict):
+                    feature_observation_horizon = max(ft.observation_horizon for ft in ft_.values()) + 1
+                else:
+                    feature_observation_horizon = ft_.observation_horizon + 1
+                forecaster_observation_horizon = max(forecaster_observation_horizon, feature_observation_horizon)
+
+            if not forecaster_observation_horizon:
+                rewind_time = add_interval(residuals["time"][0], interval=forecaster_pred.interval_, n=-1)
+                y_rewind = pl.DataFrame(
+                    {col: [rewind_time] if col == "time" else [None] for col in y_t.columns},
+                    schema=y_t.schema,
+                )
+                X_rewind = None
+                if X_t is not None:
+                    X_rewind = pl.DataFrame(
+                        {col: [rewind_time] if col == "time" else [None] for col in X_t.columns},
+                        schema=X_t.schema,
+                    )
+            else:
+                y_rewind = residuals[:forecaster_observation_horizon]
+                X_rewind = X_t[:forecaster_observation_horizon] if X_t is not None else None
+
+            forecaster_pred.rewind(y=y_rewind, X_actual=X_rewind, X_future=X_future, X_forecast=X_forecast)
+
+            residuals_remaining = residuals[forecaster_observation_horizon:]
+            X_remaining = X_t[forecaster_observation_horizon:] if X_t is not None else None
+            y_pred = forecaster_pred.observe_predict(
+                y=residuals_remaining,
+                X_actual=X_remaining,
+                forecasting_horizon=forecaster.fit_forecasting_horizon_,
+                X_future=X_future,
+                X_forecast=X_forecast,
+            )
+
+            aligned = residuals.join(
+                y_pred.select(~cs.by_name("vintage_time")),
+                on="time",
+                how="inner",
+                suffix="_pred",
+            )
+            target_cols = [c for c in residuals.columns if c != "time"]
+            residuals = aligned.select(
+                [pl.col("time")] + [(pl.col(col) - pl.col(f"{col}_pred")).alias(col) for col in target_cols]
+            )
 
         # Rewind base class observation buffers
         self._y_observed = y_t

--- a/src/yohou/compose/feature_pipeline.py
+++ b/src/yohou/compose/feature_pipeline.py
@@ -117,7 +117,10 @@ class FeaturePipeline(BaseTransformer, _BaseComposition):
 
     The `observation_horizon` property accumulates across all steps, returning
     the sum of all transformer observation horizons. This indicates the total
-    amount of historical data required by the pipeline.
+    amount of historical data required by the pipeline. The sum is correct
+    because steps run sequentially, each consuming the previous step's output.
+    This contrasts with `FeatureUnion`, whose `observation_horizon` takes the
+    maximum across its parallel transformers.
 
     Supports time series-specific `observe()` method for incremental learning,
     allowing the pipeline to incorporate new observations without full retraining.
@@ -161,6 +164,12 @@ class FeaturePipeline(BaseTransformer, _BaseComposition):
     # BaseEstimator interface
     _required_parameters = ["steps"]
 
+    # sklearn's Pipeline reads ``transform_input`` in ``_get_metadata_for_step``.
+    # Yohou does not expose it as a constructor parameter (it is not a tunable
+    # estimator param), so it is a class attribute fixed to ``None``: this keeps
+    # sklearn's short-circuit working without leaking into ``get_params``.
+    transform_input = None
+
     _parameter_constraints: dict[str, Any] = {
         "steps": [list, Hidden(tuple)],
         "memory": [None, str, HasMethods(["cache"])],
@@ -175,7 +184,6 @@ class FeaturePipeline(BaseTransformer, _BaseComposition):
         verbose: bool = False,
     ) -> None:
         self.steps = steps
-        self.transform_input = None
         self.memory = memory
         self.verbose = verbose
 
@@ -664,7 +672,7 @@ class FeaturePipeline(BaseTransformer, _BaseComposition):
             FeaturePipeline with fitted steps.
         """
         routed_params = self._check_method_params(method="fit", props=params)
-        X_t = self._fit(X, y, routed_params)
+        X_t = self._fit(X, y, routed_params, raw_params=params)
         with _print_elapsed_time("FeaturePipeline", self._log_message(len(self.steps) - 1)):
             if self._final_estimator != "passthrough":
                 last_step_params = routed_params[self.steps[-1][0]]
@@ -673,7 +681,6 @@ class FeaturePipeline(BaseTransformer, _BaseComposition):
         # Set pipeline-level attributes for rewind/observe validation.
         # Individual steps are already fitted with their own attributes.
         self.X_schema_ = dict(X.select(~cs.by_name("time")).schema)
-        self._observation_horizon = self.observation_horizon
         self._update_X_observed(X)
 
         return self
@@ -714,11 +721,11 @@ class FeaturePipeline(BaseTransformer, _BaseComposition):
 
         Returns
         -------
-        X_t : ndarray of shape (n_samples, n_transformed_features)
-            Transformed samples.
+        X_t : pl.DataFrame
+            Transformed data.
         """
         routed_params = self._check_method_params(method="fit_transform", props=params)
-        X_t = self._fit(X, y, routed_params)
+        X_t = self._fit(X, y, routed_params, raw_params=params)
 
         last_step = self._final_estimator
         with _print_elapsed_time("FeaturePipeline", self._log_message(len(self.steps) - 1)):
@@ -753,7 +760,7 @@ class FeaturePipeline(BaseTransformer, _BaseComposition):
 
         Returns
         -------
-        X_t : ndarray of shape (n_samples, n_transformed_features)
+        X_t : pl.DataFrame
             Transformed data.
         """
         _raise_for_params(params, self, "transform")
@@ -967,7 +974,6 @@ class FeaturePipeline(BaseTransformer, _BaseComposition):
 
             (
                 method_mapping
-                .add(caller="predict", callee="transform")
                 .add(caller="predict", callee="transform")
                 .add(caller="predict_proba", callee="transform")
                 .add(caller="decision_function", callee="transform")

--- a/src/yohou/compose/feature_union.py
+++ b/src/yohou/compose/feature_union.py
@@ -451,6 +451,45 @@ class FeatureUnion(BaseTransformer, _BaseComposition):
 
         return observation_horizons
 
+    def _build_column_names(self, Xs: list[pl.DataFrame]) -> list[list[str]]:
+        """Compute per-transformer output column names.
+
+        Extracts each transformer's non-time output columns and, when
+        ``verbose_feature_names_out`` is True, prefixes them with the
+        transformer name. When False, raises if any output names collide.
+
+        Parameters
+        ----------
+        Xs : list of pl.DataFrame
+            Transformed outputs, one per transformer (each with a ``"time"``
+            column).
+
+        Returns
+        -------
+        list of list of str
+            Final column names for each transformer, in order.
+
+        """
+        transformer_names = [name for name, _, _ in self._iter()]
+        raw_column_names = [[col for col in X_t.columns if col != "time"] for X_t in Xs]
+
+        if self.verbose_feature_names_out:
+            return [
+                [panel_aware_prefix(col, name) for col in cols]
+                for name, cols in zip(transformer_names, raw_column_names, strict=False)
+            ]
+
+        flat_names = [col for cols in raw_column_names for col in cols]
+        counts = Counter(flat_names)
+        duplicates = [name for name, count in counts.items() if count > 1]
+        if duplicates:
+            raise ValueError(
+                f"Duplicate feature names found: {duplicates}. "
+                "Either use transformers that produce unique names or set "
+                "verbose_feature_names_out=True to add transformer name prefixes."
+            )
+        return raw_column_names
+
     @property
     def observation_horizon(self) -> int:
         """Maximum observation horizon across all transformers.
@@ -611,27 +650,7 @@ class FeatureUnion(BaseTransformer, _BaseComposition):
         Xs, transformers = zip(*results, strict=False)
         self._update_transformer_list(transformers)
 
-        # Extract actual column names from each DataFrame (excluding time)
-        transformer_names = [name for name, _, _ in self._iter()]
-        raw_column_names = [[col for col in X_t.columns if col != "time"] for X_t in Xs]
-
-        # Apply prefixes if verbose_feature_names_out is True
-        if self.verbose_feature_names_out:
-            column_names = []
-            for name, cols in zip(transformer_names, raw_column_names, strict=False):
-                column_names.append([panel_aware_prefix(col, name) for col in cols])
-        else:
-            column_names = raw_column_names
-            # Check for duplicates
-            flat_names = [col for cols in column_names for col in cols]
-            counts = Counter(flat_names)
-            duplicates = [name for name, count in counts.items() if count > 1]
-            if duplicates:
-                raise ValueError(
-                    f"Duplicate feature names found: {duplicates}. "
-                    "Either use transformers that produce unique names or set "
-                    "verbose_feature_names_out=True to add transformer name prefixes."
-                )
+        column_names = self._build_column_names(list(Xs))
 
         result = _hstack(
             list(Xs),
@@ -669,17 +688,7 @@ class FeatureUnion(BaseTransformer, _BaseComposition):
             time = X.select(cs.by_name("time"))
             return time
 
-        # Extract actual column names from each DataFrame (excluding time)
-        transformer_names = [name for name, _, _ in self._iter()]
-        raw_column_names = [[col for col in X_t.columns if col != "time"] for X_t in Xs]
-
-        # Apply prefixes if verbose_feature_names_out is True
-        if self.verbose_feature_names_out:
-            column_names = []
-            for name, cols in zip(transformer_names, raw_column_names, strict=False):
-                column_names.append([panel_aware_prefix(col, name) for col in cols])
-        else:
-            column_names = raw_column_names
+        column_names = self._build_column_names(list(Xs))
 
         result = _hstack(
             Xs,
@@ -692,9 +701,10 @@ class FeatureUnion(BaseTransformer, _BaseComposition):
         """Observe and transform X in parallel for each transformer, concatenate results.
 
         This method atomically observes each transformer with new data and
-        transforms it in parallel. The transformation uses the pre-observe state,
-        then updates the memory. This is more efficient and correct than calling
-        observe() then transform() separately.
+        transforms it, concurrently when ``n_jobs != 1`` and sequentially
+        otherwise. The transformation uses the pre-observe state, then updates
+        the memory. This is more efficient and correct than calling observe()
+        then transform() separately.
 
         Parameters
         ----------
@@ -725,17 +735,7 @@ class FeatureUnion(BaseTransformer, _BaseComposition):
             time = X.select(cs.by_name("time"))
             return time
 
-        # Extract actual column names from each DataFrame (excluding time)
-        transformer_names = [name for name, _, _ in self._iter()]
-        raw_column_names = [[col for col in X_t.columns if col != "time"] for X_t in Xs]
-
-        # Apply prefixes if verbose_feature_names_out is True
-        if self.verbose_feature_names_out:
-            column_names = []
-            for name, cols in zip(transformer_names, raw_column_names, strict=False):
-                column_names.append([panel_aware_prefix(col, name) for col in cols])
-        else:
-            column_names = raw_column_names
+        column_names = self._build_column_names(list(Xs))
 
         result = _hstack(
             Xs,
@@ -786,17 +786,7 @@ class FeatureUnion(BaseTransformer, _BaseComposition):
             time = X.select(cs.by_name("time"))
             return time
 
-        # Extract actual column names from each DataFrame (excluding time)
-        transformer_names = [name for name, _, _ in self._iter()]
-        raw_column_names = [[col for col in X_t.columns if col != "time"] for X_t in Xs]
-
-        # Apply prefixes if verbose_feature_names_out is True
-        if self.verbose_feature_names_out:
-            column_names = []
-            for name, cols in zip(transformer_names, raw_column_names, strict=False):
-                column_names.append([panel_aware_prefix(col, name) for col in cols])
-        else:
-            column_names = raw_column_names
+        column_names = self._build_column_names(list(Xs))
 
         result = _hstack(
             Xs,
@@ -828,7 +818,9 @@ class FeatureUnion(BaseTransformer, _BaseComposition):
                 .add(caller="fit_transform", callee="fit_transform")
                 .add(caller="fit_transform", callee="fit")
                 .add(caller="fit_transform", callee="transform")
-                .add(caller="transform", callee="transform"),
+                .add(caller="transform", callee="transform")
+                .add(caller="observe_transform", callee="observe_transform")
+                .add(caller="rewind_transform", callee="rewind_transform"),
             )
 
         return router

--- a/src/yohou/compose/forecasted_feature_forecaster.py
+++ b/src/yohou/compose/forecasted_feature_forecaster.py
@@ -81,9 +81,11 @@ class ForecastedFeatureForecaster(BaseForecaster):
         - "predicted": Split data, fit the feature forecaster on the first portion,
           and train the target on a rolling forecast over the second portion.
           Requires more data but matches train and serve forecast quality.
-        - "rewind": Fit the feature forecaster on full data, rewind to the
-          observation horizon, then roll forward producing one vintage per origin
-          and train the target on that rolling forecast. Uses all data for feature
+        - "rewind": Fit the feature forecaster on full data, rewind to
+          ``observation_horizon + 1`` rows (the extra row covers the transform
+          step), then roll forward producing one vintage per origin and train
+          the target on that rolling forecast. Requires
+          ``len(X_actual) > observation_horizon + 1``. Uses all data for feature
           learning while matching train and serve forecast quality. This is the
           default: it has no train/serve mismatch.
     split_ratio : float, default=0.5
@@ -287,7 +289,19 @@ class ForecastedFeatureForecaster(BaseForecaster):
         Raises
         ------
         ValueError
-            If X_actual is None (exogenous features are required).
+            If ``X_actual`` is None (exogenous features are required); if
+            ``forecasting_horizon < 1``; if ``strategy="rewind"`` and
+            ``len(X_actual) <= observation_horizon + 1``; or if
+            ``strategy="predicted"`` and the split leaves fewer than 2 rows
+            for either the feature-forecaster fit or the rolling forecast.
+
+        Notes
+        -----
+        When the target forecaster consumes exogenous features, its effective
+        training window starts at the first vintage the feature forecast
+        covers: ``y`` is filtered to ``time >= first_covered``. For
+        ``strategy="predicted"`` this excludes roughly the first
+        ``split_ratio`` fraction of ``y`` from target training.
 
         """
         if X_actual is None:
@@ -381,7 +395,7 @@ class ForecastedFeatureForecaster(BaseForecaster):
             obs_horizon = self.feature_forecaster_.observation_horizon
             # Need obs_horizon + 1 rows: obs_horizon for transformer memory + 1 for transform
             rewind_size = obs_horizon + 1
-            if obs_horizon < 0 or len(X_actual) <= rewind_size:
+            if len(X_actual) <= rewind_size:
                 raise ValueError(
                     f"Cannot use strategy='rewind' (the default): the feature forecaster's "
                     f"observation_horizon={obs_horizon} requires len(X_actual) > observation_horizon + 1, "
@@ -401,17 +415,21 @@ class ForecastedFeatureForecaster(BaseForecaster):
                 self.feature_forecaster_.observe(y=X_actual[rewind_size:], X_actual=None)
 
         else:  # strategy == "predicted"
-            n_split = int(len(y) * self.split_ratio)
+            # Split the feature series (X_actual) since that is what gets sliced
+            # for the feature forecaster below. Using len(X_actual) keeps the
+            # split point consistent across both portions even when X_actual and
+            # y differ in length.
+            n_split = int(len(X_actual) * self.split_ratio)
 
             if n_split < 2:
                 raise ValueError(
                     f"split_ratio={self.split_ratio} results in n_split={n_split}. "
-                    f"Increase split_ratio or provide more data (len(y)={len(y)})."
+                    f"Increase split_ratio or provide more data (len(X_actual)={len(X_actual)})."
                 )
-            if len(y) - n_split < 2:
+            if len(X_actual) - n_split < 2:
                 raise ValueError(
                     f"split_ratio={self.split_ratio} results in n_split={n_split}, "
-                    f"leaving only {len(y) - n_split} rows for target forecaster. "
+                    f"leaving only {len(X_actual) - n_split} rows for the feature forecast roll. "
                     f"Decrease split_ratio to leave at least 2 rows."
                 )
 
@@ -480,6 +498,9 @@ class ForecastedFeatureForecaster(BaseForecaster):
         # Set observation buffers for observe/rewind
         self._y_observed = y
         self._X_t_observed = X_actual
+        # Expose observed_time_ per the fitted-forecaster contract; it tracks
+        # the end of the data this meta-forecaster has observed (full y).
+        self.observed_time_ = y["time"][-1]
 
         return self
 
@@ -808,6 +829,9 @@ class ForecastedFeatureForecaster(BaseForecaster):
             X_forecast=X_forecast,
         )
 
+        # Advance the meta-forecaster's observed_time_ to the latest observation.
+        self.observed_time_ = y["time"][-1]
+
         return self
 
     def rewind(
@@ -872,6 +896,9 @@ class ForecastedFeatureForecaster(BaseForecaster):
             X_future=X_future,
             X_forecast=X_forecast,
         )
+
+        # Reset the meta-forecaster's observed_time_ to the rewind window end.
+        self.observed_time_ = y["time"][-1]
 
         return self
 

--- a/src/yohou/compose/local_panel_forecaster.py
+++ b/src/yohou/compose/local_panel_forecaster.py
@@ -128,7 +128,7 @@ class LocalPanelForecaster(BaseForecaster):
         Names of panel groups discovered at fit time.
     local_y_schema_ : dict of str to DataType
         Schema of unprefixed target columns (shared across all groups).
-    local_X_actual_schema_ : dict of str or None
+    local_X_actual_schema_ : dict[str, polars.DataType] or None
         Schema of unprefixed exogenous columns, or ``None`` if X_actual was not
         provided.
     interval_ : timedelta
@@ -359,6 +359,7 @@ class LocalPanelForecaster(BaseForecaster):
         self,
         forecasting_horizon: StrictInt | None = None,
         groups: list[str] | None = None,
+        predict_transformed: bool = False,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
         **params,
@@ -371,6 +372,8 @@ class LocalPanelForecaster(BaseForecaster):
             Number of steps ahead.  If ``None``, uses the value from ``fit``.
         groups : list of str or None, default=None
             Subset of groups to predict.  ``None`` predicts all groups.
+        predict_transformed : bool, default=False
+            If ``True``, return predictions in the transformed space.
         X_future : pl.DataFrame or None, default=None
             Known future features override. Re-derives step columns
             without mutating forecaster state.
@@ -384,7 +387,8 @@ class LocalPanelForecaster(BaseForecaster):
         Returns
         -------
         pl.DataFrame
-            Predictions with prefixed panel columns and ``"time"`` column.
+            Predictions with ``"vintage_time"`` (when present), ``"time"``,
+            and prefixed panel columns.
 
         """
         check_is_fitted(self, ["forecasters_"])
@@ -392,10 +396,16 @@ class LocalPanelForecaster(BaseForecaster):
         routed_params = process_routing(self, "predict", **params)
 
         groups: list[str] = groups if groups is not None else (self.groups_ or [])
-        horizon = forecasting_horizon or self.fit_forecasting_horizon_
+        horizon = forecasting_horizon if forecasting_horizon is not None else self.fit_forecasting_horizon_
 
         return self._predict_groups(
-            groups, horizon, routed_params, method="predict", X_future=X_future, X_forecast=X_forecast
+            groups,
+            horizon,
+            routed_params,
+            method="predict",
+            X_future=X_future,
+            X_forecast=X_forecast,
+            predict_transformed=predict_transformed,
         )
 
     @available_if(_forecaster_has("predict_interval"))
@@ -431,7 +441,8 @@ class LocalPanelForecaster(BaseForecaster):
         Returns
         -------
         pl.DataFrame
-            Interval predictions with prefixed panel columns.
+            Interval predictions with ``"vintage_time"`` (when present),
+            ``"time"``, and prefixed panel columns.
 
         """
         check_is_fitted(self, ["forecasters_"])
@@ -439,7 +450,7 @@ class LocalPanelForecaster(BaseForecaster):
         routed_params = process_routing(self, "predict_interval", **params)
 
         groups: list[str] = groups if groups is not None else (self.groups_ or [])
-        horizon = forecasting_horizon or self.fit_forecasting_horizon_
+        horizon = forecasting_horizon if forecasting_horizon is not None else self.fit_forecasting_horizon_
 
         return self._predict_groups(
             groups,
@@ -855,6 +866,7 @@ class LocalPanelForecaster(BaseForecaster):
         coverage_rates: list[float] | None = None,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
+        predict_transformed: bool = False,
     ) -> pl.DataFrame:
         """Predict (point or interval) per group and concatenate.
 
@@ -877,6 +889,8 @@ class LocalPanelForecaster(BaseForecaster):
             External forecast override with ``"vintage_time"`` and
             ``"time"`` columns. Re-derives step columns without mutating
             forecaster state.
+        predict_transformed : bool, default=False
+            If ``True``, return predictions in the transformed space.
 
         Returns
         -------
@@ -894,6 +908,10 @@ class LocalPanelForecaster(BaseForecaster):
 
             # Call the appropriate predict method
             predict_kwargs: dict[str, Any] = {"forecasting_horizon": horizon}
+            # predict_transformed is a parameter of point predict only; the
+            # interval predict_interval signature does not accept it.
+            if method == "predict":
+                predict_kwargs["predict_transformed"] = predict_transformed
             predict_kwargs.update(routed_params.forecaster.get(method, {}))
             if method == "predict_interval" and coverage_rates is not None:
                 predict_kwargs["coverage_rates"] = coverage_rates

--- a/src/yohou/compose/local_panel_forecaster.py
+++ b/src/yohou/compose/local_panel_forecaster.py
@@ -802,14 +802,18 @@ class LocalPanelForecaster(BaseForecaster):
     ) -> pl.DataFrame:
         """Reassemble per-group predictions into a panel DataFrame.
 
-        Extracts time columns from the first group, prefixes all other
-        columns with ``<group_name>__``, and concatenates horizontally.
+        Prefixes each group's value columns with ``<group_name>__`` and
+        joins the per-group frames on their time keys (``"time"`` and,
+        when present, ``"vintage_time"``). Joining on the time keys (rather
+        than concatenating horizontally by position) guarantees that values
+        are aligned by timestamp; a group with a misaligned time grid
+        surfaces as nulls instead of silently corrupted associations.
 
         Parameters
         ----------
         group_predictions : dict of str to pl.DataFrame
             Mapping from group name to prediction DataFrame. Each
-            DataFrame must have the same time index.
+            DataFrame must share the same time keys.
 
         Returns
         -------
@@ -817,22 +821,38 @@ class LocalPanelForecaster(BaseForecaster):
             Panel predictions with prefixed columns.
 
         """
-        all_preds: list[pl.DataFrame] = []
-        time_col: pl.DataFrame | None = None
+        result: pl.DataFrame | None = None
 
         for group_name, df in group_predictions.items():
-            if time_col is None:
-                time_cols = [c for c in ["time", "vintage_time"] if c in df.columns]
-                if time_cols:
-                    time_col = df.select(time_cols)
-
+            time_cols = [c for c in ["time", "vintage_time"] if c in df.columns]
             non_time = [c for c in df.columns if c not in ("time", "vintage_time")]
-            prefixed = df.select(non_time).rename({c: f"{group_name}__{c}" for c in non_time})
-            all_preds.append(prefixed)
+            prefixed = df.rename({c: f"{group_name}__{c}" for c in non_time})
 
-        result = pl.concat(all_preds, how="horizontal")
-        if time_col is not None:
-            result = pl.concat([time_col, result], how="horizontal")
+            if result is None:
+                result = prefixed
+            elif time_cols:
+                if result.height != prefixed.height:
+                    raise ValueError(
+                        f"Group '{group_name}' produced {prefixed.height} predictions, "
+                        f"but a previous group produced {result.height}. "
+                        "Per-group prediction time grids must align to form a panel."
+                    )
+                result = result.join(prefixed, on=time_cols, how="full", coalesce=True)
+                if result.height != prefixed.height:
+                    raise ValueError(
+                        f"Group '{group_name}' has a time grid that does not align with "
+                        "the other groups. Per-group prediction time grids must match "
+                        "to form a panel."
+                    )
+            else:
+                result = pl.concat([result, prefixed], how="horizontal")
+
+        if result is None:
+            return pl.DataFrame()
+
+        sort_cols = [c for c in ["vintage_time", "time"] if c in result.columns]
+        if sort_cols:
+            result = result.sort(sort_cols)
 
         return result
 

--- a/src/yohou/compose/utils.py
+++ b/src/yohou/compose/utils.py
@@ -23,8 +23,9 @@ def _hstack(Xs: list[pl.DataFrame], column_names: list[list[str]], observation_h
         Column names for each DataFrame.
 
     observation_horizons : list of int
-        Observation horizon for each transformer (used for fallback when
-        ``"time"`` column is absent).
+        Observation horizon for each transformer. Accepted for API
+        consistency; currently unused because alignment is driven entirely
+        by the ``"time"`` column intersection.
 
     Returns
     -------
@@ -95,9 +96,10 @@ def _rewind_transform_one(
 ) -> pl.DataFrame:
     """Rewind and transform data using a single transformer.
 
-    Applies rewind_transform semantics: transforms from scratch without using
-    pre-existing memory, discards the first observation_horizon rows, and
-    rewinds the internal state with the input data.
+    Delegates to ``transformer.rewind_transform()``, which transforms from
+    scratch without using pre-existing memory, discards warmup rows, and
+    rewinds the internal state with the input data. This wrapper does not
+    perform the row-discarding itself.
 
     Parameters
     ----------

--- a/src/yohou/compose/utils.py
+++ b/src/yohou/compose/utils.py
@@ -5,6 +5,8 @@ from typing import Any
 import polars as pl
 import polars.selectors as cs
 
+from yohou.base import BaseTransformer
+
 
 def _hstack(Xs: list[pl.DataFrame], column_names: list[list[str]], observation_horizons: list[int]) -> pl.DataFrame:
     """Stack transformed features horizontally, aligning observation horizons.
@@ -79,11 +81,19 @@ def _observe_transform_one(
         Transformed data.
 
     """
-    # Handle passthrough/FunctionTransformer which doesn't have observe_transform
+    # Stateful BaseTransformers must expose observe_transform; the transform()
+    # fallback is only legitimate for stateless transformers (e.g.
+    # FunctionTransformer used for passthrough). A BaseTransformer that reaches
+    # the fallback has lost its stateful method and would silently use stale
+    # state, so surface that as an error.
     if hasattr(transformer, "observe_transform"):
         X_transformed = transformer.observe_transform(X, **params.get("observe_transform", {}))
+    elif isinstance(transformer, BaseTransformer):
+        raise AttributeError(
+            f"{type(transformer).__name__} is a BaseTransformer but has no "
+            "'observe_transform' method; cannot observe-transform it statefully."
+        )
     else:
-        # Fall back to transform for stateless transformers (e.g., FunctionTransformer for passthrough)
         X_transformed = transformer.transform(X)
 
     if weight is None:
@@ -120,11 +130,17 @@ def _rewind_transform_one(
         Transformed data with warmup rows discarded.
 
     """
-    # Handle passthrough/transformers that might not have rewind_transform
+    # As in _observe_transform_one, the transform() fallback is only legitimate
+    # for stateless transformers; a BaseTransformer missing rewind_transform has
+    # lost its stateful method and must not silently fall back.
     if hasattr(transformer, "rewind_transform"):
         X_transformed = transformer.rewind_transform(X, **params.get("rewind_transform", {}))
+    elif isinstance(transformer, BaseTransformer):
+        raise AttributeError(
+            f"{type(transformer).__name__} is a BaseTransformer but has no "
+            "'rewind_transform' method; cannot rewind-transform it statefully."
+        )
     else:
-        # Fall back to transform for stateless transformers without rewind_transform
         X_transformed = transformer.transform(X)
 
     if weight is None:

--- a/src/yohou/datasets/_fetchers.py
+++ b/src/yohou/datasets/_fetchers.py
@@ -37,11 +37,24 @@ def _is_wasm() -> bool:
     return sys.platform == "emscripten"
 
 
-def _fetch_dataset_wasm(dataset_name: str, metadata: RemoteFileMetadata) -> Bunch:
-    """Download a pre-processed dataset from jsDelivr and return a Bunch."""
+def _fetch_dataset_wasm(
+    dataset_name: str,
+    metadata: RemoteFileMetadata,
+    n_series: int | None = None,
+) -> Bunch:
+    """Download a pre-processed dataset from jsDelivr and return a Bunch.
+
+    When ``n_series`` is given, the deserialized frame is sliced to the
+    first ``n_series`` value columns (the ``"time"`` column is always
+    retained) so the WASM path honours the same selection as the native
+    download path.
+    """
     url = f"{_CDN_BASE_URL}/{dataset_name}.bin"
     data = urlopen(url).read()  # noqa: S310
     frame = pl.DataFrame.deserialize(io.BytesIO(data), format="binary")
+    if n_series is not None:
+        value_cols = [c for c in frame.columns if c != "time"][:n_series]
+        frame = frame.select("time", *value_cols)
     feature_names = [c for c in frame.columns if c != "time"]
     return Bunch(
         frame=frame,
@@ -163,7 +176,7 @@ def _fetch_dataset(
 
     """
     if _is_wasm():
-        return _fetch_dataset_wasm(dataset_name, metadata)
+        return _fetch_dataset_wasm(dataset_name, metadata, n_series=n_series)
 
     data_home_str = get_data_home(data_home)
     dataset_dir = os.path.join(data_home_str, dataset_name)
@@ -861,10 +874,12 @@ def fetch_kdd_cup(
     Parameters
     ----------
     n_groups : int or None, default=5
-        Maximum number of station groups to include. Each station has
-        6 measurement series (PM2.5, PM10, NO2, CO, O3, SO2), so
-        ``n_groups=5`` loads 30 raw series. ``None`` loads all 59
-        stations (270 series).
+        Maximum number of station groups to include. Beijing stations
+        have 6 measurement series (PM2.5, PM10, NO2, CO, O3, SO2);
+        London stations carry a subset (typically PM2.5, PM10, NO2).
+        ``n_groups=5`` loads up to 30 raw series (fewer if London
+        stations are selected). ``None`` loads all 270 series from 59
+        stations.
     data_home : str, PathLike, or None
         Specify another download and cache folder for the datasets.
         By default all yohou data is stored in ``~/yohou_data/``.
@@ -875,6 +890,13 @@ def fetch_kdd_cup(
         Number of retries when HTTP errors are encountered.
     delay : float, default=1.0
         Number of seconds between retries.
+
+    Notes
+    -----
+    Internally, ``n_groups * 6`` raw series are requested from the TSF
+    parser and then restructured into station groups. If a station's
+    series are not contiguous in the file, some resulting groups may be
+    incomplete.
 
     Returns
     -------
@@ -1020,6 +1042,13 @@ def fetch_air_quality_classification(
     station_prefix = non_time[0].split("__")[0]
 
     pm25_col = f"{station_prefix}__pm2.5"
+    if pm25_col not in frame.columns:
+        raise ValueError(
+            f"fetch_air_quality_classification expected target column "
+            f"'{pm25_col}' in the KDD Cup dataset but it is absent. "
+            f"Available columns: {frame.columns}."
+        )
+
     feature_measurements = ["pm10", "no2", "co", "o3", "so2"]
     feature_cols = [f"{station_prefix}__{m}" for m in feature_measurements]
 
@@ -1041,7 +1070,7 @@ def fetch_air_quality_classification(
     y = frame.select("time", air_quality.alias("air_quality"))
     X_actual = frame.select("time", *feature_cols).rename({c: c.split("__")[1] for c in feature_cols})
 
-    classes = sorted(set(y["air_quality"].to_list()))
+    classes = sorted(y["air_quality"].unique().to_list())
 
     return Bunch(
         y=y,
@@ -1070,9 +1099,10 @@ def fetch_demand_classification(
 
     Downloads the Australian Electricity Demand dataset and bins
     Victoria's half-hourly demand into three levels (low, medium, high)
-    using tercile thresholds. The remaining four states (NSW, QLD, SA,
-    TAS) become exogenous features. Rows with null Victoria demand are
-    dropped.
+    using tercile thresholds. The remaining four states (NSW, QUN, SA,
+    TAS) become exogenous features. Note that the Monash dataset encodes
+    Queensland as ``qun`` (not the ISO abbreviation ``qld``). Rows with
+    null Victoria demand are dropped.
 
     Parameters
     ----------
@@ -1138,6 +1168,14 @@ def fetch_demand_classification(
     target_col = "vic__demand"
     feature_cols = ["nsw__demand", "qun__demand", "sa__demand", "tas__demand"]
 
+    missing = [c for c in (target_col, *feature_cols) if c not in frame.columns]
+    if missing:
+        raise ValueError(
+            f"fetch_demand_classification expected columns {missing} in the "
+            f"electricity demand dataset but they are absent. Available "
+            f"columns: {frame.columns}."
+        )
+
     # Drop rows with null target
     frame = frame.drop_nulls(subset=[target_col])
 
@@ -1157,7 +1195,7 @@ def fetch_demand_classification(
     y = frame.select("time", demand_level.alias("demand_level"))
     X_actual = frame.select("time", *feature_cols)
 
-    classes = sorted(set(y["demand_level"].to_list()))
+    classes = sorted(y["demand_level"].unique().to_list())
 
     return Bunch(
         y=y,
@@ -1170,6 +1208,6 @@ def fetch_demand_classification(
             "Australian Electricity Demand dataset (Monash/Zenodo). "
             "Victoria's half-hourly demand is binned into three tercile-based "
             "levels: low, medium, high. Features are the demand series from "
-            "the remaining four Australian states (NSW, QLD, SA, TAS)."
+            "the remaining four Australian states (NSW, QUN, SA, TAS)."
         ),
     )

--- a/src/yohou/datasets/_generators.py
+++ b/src/yohou/datasets/_generators.py
@@ -14,6 +14,23 @@ import polars as pl
 from sklearn.utils import Bunch
 
 
+def _forecast_index_grid(n_samples: int, forecasting_horizon: int) -> tuple[np.ndarray, np.ndarray]:
+    """Build vintage and target index arrays for X_forecast construction.
+
+    Reproduces, in vectorized form, the row order of the nested loop over
+    vintage indices ``i in range(forecasting_horizon, n_samples)`` and steps
+    ``step in range(1, forecasting_horizon + 1)``, keeping only pairs whose
+    target index ``i + step`` stays within the sample range. The row order is
+    preserved so downstream RNG draws stay numerically identical.
+    """
+    vintage = np.arange(forecasting_horizon, n_samples)
+    steps = np.arange(1, forecasting_horizon + 1)
+    vintage_grid = np.repeat(vintage, forecasting_horizon)
+    target_grid = vintage_grid + np.tile(steps, vintage.shape[0])
+    keep = target_grid < n_samples
+    return vintage_grid[keep], target_grid[keep]
+
+
 def make_exogenous_regression(
     *,
     n_samples: int = 200,
@@ -117,19 +134,15 @@ def make_exogenous_regression(
     X_actual = pl.DataFrame({"time": times, "temperature": actual_temp})
     X_future = pl.DataFrame({"time": times, "is_holiday": holidays})
 
-    forecast_rows: list[dict[str, object]] = []
-    for i in range(forecasting_horizon, n_samples):
-        for step in range(1, forecasting_horizon + 1):
-            if i + step < n_samples:
-                forecast_rows.append({
-                    "vintage_time": times[i],
-                    "time": times[i + step],
-                    "wx_temp": float(actual_temp[i + step] + forecast_bias + rng.normal(0, 0.3)),
-                })
+    vintage_idx, target_idx = _forecast_index_grid(n_samples, forecasting_horizon)
+    wx_noise = rng.normal(0, 0.3, vintage_idx.shape[0])
     X_forecast = pl.DataFrame(
-        forecast_rows,
+        {
+            "vintage_time": times.gather(vintage_idx),
+            "time": times.gather(target_idx),
+            "wx_temp": actual_temp[target_idx] + forecast_bias + wx_noise,
+        },
         schema={"vintage_time": times.dtype, "time": times.dtype, "wx_temp": pl.Float64},
-        orient="row",
     )
 
     frame = y.join(X_actual, on="time").join(X_future, on="time")
@@ -272,19 +285,15 @@ def make_exogenous_classification(
     X_actual = pl.DataFrame({"time": times, "pollutant": pollutant})
     X_future = pl.DataFrame({"time": times, "is_weekend": is_weekend})
 
-    forecast_rows: list[dict[str, object]] = []
-    for i in range(forecasting_horizon, n_samples):
-        for step in range(1, forecasting_horizon + 1):
-            if i + step < n_samples:
-                forecast_rows.append({
-                    "vintage_time": times[i],
-                    "time": times[i + step],
-                    "pollutant_forecast": float(pollutant[i + step] + forecast_bias + rng.normal(0, 2.0)),
-                })
+    vintage_idx, target_idx = _forecast_index_grid(n_samples, forecasting_horizon)
+    pollutant_noise = rng.normal(0, 2.0, vintage_idx.shape[0])
     X_forecast = pl.DataFrame(
-        forecast_rows,
+        {
+            "vintage_time": times.gather(vintage_idx),
+            "time": times.gather(target_idx),
+            "pollutant_forecast": pollutant[target_idx] + forecast_bias + pollutant_noise,
+        },
         schema={"vintage_time": times.dtype, "time": times.dtype, "pollutant_forecast": pl.Float64},
-        orient="row",
     )
 
     frame = y.join(X_actual, on="time").join(X_future, on="time")

--- a/src/yohou/datasets/_generators.py
+++ b/src/yohou/datasets/_generators.py
@@ -35,9 +35,12 @@ def make_exogenous_regression(
     - **X_future** (known future): a deterministic ``is_holiday`` indicator
       (Sundays = 1.0) covering the full time range.
     - **X_forecast** (external forecasts): weather temperature forecasts
-      with one vintage per observation, each covering the next
-      ``forecasting_horizon`` steps. Forecasts carry a small systematic
-      bias relative to actuals.
+      with one vintage per observation from index ``forecasting_horizon``
+      up to (but not including) the last observation, each covering the
+      next ``forecasting_horizon`` steps that remain within the sample.
+      The final observation produces no vintage because all of its
+      forecast steps fall outside the sample range. Forecasts carry a
+      small systematic bias relative to actuals.
 
     Parameters
     ----------
@@ -66,7 +69,9 @@ def make_exogenous_regression(
         X_forecast : pl.DataFrame
             External forecasts with columns
             ``["vintage_time", "time", "wx_temp"]``. One vintage per
-            observation from index ``forecasting_horizon`` onward.
+            observation from index ``forecasting_horizon`` up to (but not
+            including) the last observation; the final observation
+            produces no vintage.
         frame : pl.DataFrame
             ``y``, ``X_actual``, and ``X_future`` joined on ``"time"``.
             ``X_forecast`` is excluded because it has a different schema.
@@ -95,16 +100,17 @@ def make_exogenous_regression(
 
     """
     rng = np.random.default_rng(random_state)
-    times = pl.Series(
-        "time",
-        [datetime(2024, 1, 1) + timedelta(hours=i) for i in range(n_samples)],
-    )
+    times = pl.datetime_range(
+        datetime(2024, 1, 1),
+        datetime(2024, 1, 1) + timedelta(hours=n_samples - 1),
+        interval="1h",
+        eager=True,
+    ).alias("time")
     t = np.arange(n_samples, dtype=float)
 
     actual_temp = 15.0 + 5.0 * np.sin(2 * np.pi * t / 24) + rng.normal(0, 0.5, n_samples)
-    holidays = np.array([
-        1.0 if (datetime(2024, 1, 1) + timedelta(hours=i)).weekday() == 6 else 0.0 for i in range(n_samples)
-    ])
+    # Sundays = 1.0 (polars weekday(): Monday=1 .. Sunday=7).
+    holidays = (times.dt.weekday() == 7).cast(pl.Float64).to_numpy()
     price = 50.0 + 2.0 * actual_temp + 10.0 * holidays + rng.normal(0, noise, n_samples)
 
     y = pl.DataFrame({"time": times, "price": price})
@@ -120,7 +126,11 @@ def make_exogenous_regression(
                     "time": times[i + step],
                     "wx_temp": float(actual_temp[i + step] + forecast_bias + rng.normal(0, 0.3)),
                 })
-    X_forecast = pl.DataFrame(forecast_rows)
+    X_forecast = pl.DataFrame(
+        forecast_rows,
+        schema={"vintage_time": times.dtype, "time": times.dtype, "wx_temp": pl.Float64},
+        orient="row",
+    )
 
     frame = y.join(X_actual, on="time").join(X_future, on="time")
 
@@ -163,8 +173,12 @@ def make_exogenous_classification(
     - **X_future** (known future): a deterministic ``is_weekend``
       indicator covering the full time range.
     - **X_forecast** (external forecasts): pollutant concentration
-      forecasts with one vintage per observation, each covering the next
-      ``forecasting_horizon`` steps.
+      forecasts with one vintage per observation from index
+      ``forecasting_horizon`` up to (but not including) the last
+      observation, each covering the next ``forecasting_horizon`` steps
+      that remain within the sample. The final observation produces no
+      vintage because all of its forecast steps fall outside the sample
+      range.
 
     Classification thresholds on the continuous pollutant signal:
 
@@ -229,18 +243,19 @@ def make_exogenous_classification(
 
     """
     rng = np.random.default_rng(random_state)
-    times = pl.Series(
-        "time",
-        [datetime(2024, 1, 1) + timedelta(hours=i) for i in range(n_samples)],
-    )
+    times = pl.datetime_range(
+        datetime(2024, 1, 1),
+        datetime(2024, 1, 1) + timedelta(hours=n_samples - 1),
+        interval="1h",
+        eager=True,
+    ).alias("time")
     t = np.arange(n_samples, dtype=float)
 
     # Pollutant with 24h cycle centered at 50, amplitude 20
     pollutant = 50.0 + 20.0 * np.sin(2 * np.pi * t / 24) + rng.normal(0, 5.0, n_samples)
 
-    is_weekend = np.array([
-        1.0 if (datetime(2024, 1, 1) + timedelta(hours=i)).weekday() >= 5 else 0.0 for i in range(n_samples)
-    ])
+    # Saturday/Sunday = 1.0 (polars weekday(): Monday=1 .. Sunday=7).
+    is_weekend = (times.dt.weekday() >= 6).cast(pl.Float64).to_numpy()
 
     # Weekend effect: lower pollutant readings
     effective_pollutant = pollutant - 5.0 * is_weekend + rng.normal(0, noise, n_samples)
@@ -266,7 +281,11 @@ def make_exogenous_classification(
                     "time": times[i + step],
                     "pollutant_forecast": float(pollutant[i + step] + forecast_bias + rng.normal(0, 2.0)),
                 })
-    X_forecast = pl.DataFrame(forecast_rows)
+    X_forecast = pl.DataFrame(
+        forecast_rows,
+        schema={"vintage_time": times.dtype, "time": times.dtype, "pollutant_forecast": pl.Float64},
+        orient="row",
+    )
 
     frame = y.join(X_actual, on="time").join(X_future, on="time")
 

--- a/src/yohou/datasets/_tsf_parser.py
+++ b/src/yohou/datasets/_tsf_parser.py
@@ -60,6 +60,12 @@ def parse_tsf(
         *metadata* is a dict with keys ``"frequency"``, ``"horizon"``,
         ``"missing"``, ``"equallength"``, ``"relation"``, ``"n_series"``.
 
+    Raises
+    ------
+    ValueError
+        If the file contains no ``@data`` section, or if the frequency
+        string cannot be parsed into a polars duration.
+
     """
     line_iter = _iter_text_lines(source)
     attributes, header_meta = _parse_header(line_iter)
@@ -68,7 +74,7 @@ def parse_tsf(
 
     polars_freq = TSF_FREQUENCY_MAP.get(header_meta["frequency_raw"], header_meta["frequency_raw"])
 
-    has_timestamp = any(name == "start_timestamp" for name, _ in attributes)
+    has_timestamp = "start_timestamp" in attributes
 
     frame = _build_dataframe(
         series_list,
@@ -108,13 +114,14 @@ def _iter_text_lines(source: str | IO[bytes]) -> Iterator[str]:
 
 def _parse_header(
     line_iter: Iterator[str],
-) -> tuple[list[tuple[str, str]], dict]:
+) -> tuple[list[str], dict]:
     """Parse TSF header lines from a line iterator.
 
     Advances the iterator past the ``@data`` marker and returns
-    ``(attributes, header_meta)``.
+    ``(attributes, header_meta)``, where *attributes* is the list of
+    attribute names in declaration order.
     """
-    attributes: list[tuple[str, str]] = []
+    attributes: list[str] = []
     header_meta: dict = {
         "frequency_raw": "",
         "horizon": None,
@@ -128,10 +135,8 @@ def _parse_header(
         if not stripped or stripped.startswith("#"):
             continue
         if stripped.startswith("@attribute"):
-            parts = stripped.split()
-            attr_name = parts[1]
-            attr_type = parts[2] if len(parts) > 2 else "string"
-            attributes.append((attr_name, attr_type))
+            attr_name = stripped.split()[1]
+            attributes.append(attr_name)
         elif stripped.startswith("@frequency"):
             header_meta["frequency_raw"] = stripped.split()[1]
         elif stripped.startswith("@horizon"):
@@ -151,7 +156,7 @@ def _parse_header(
 
 def _parse_data_lines(
     line_iter: Iterator[str],
-    attributes: list[tuple[str, str]],
+    attributes: list[str],
     *,
     n_series: int | None = None,
 ) -> list[dict]:
@@ -176,7 +181,7 @@ def _parse_data_lines(
         start_timestamp = None
         extra_attrs: dict[str, str] = {}
 
-        for j, (attr_name, _attr_type) in enumerate(attributes):
+        for j, attr_name in enumerate(attributes):
             if attr_name == "start_timestamp":
                 start_timestamp = _parse_tsf_timestamp(attr_values[j])
             elif attr_name != "series_name":
@@ -231,7 +236,10 @@ def _generate_time_index(
     n: int,
     polars_freq: str,
 ) -> pl.Series:
-    """Generate a datetime time index of length *n*."""
+    """Generate a datetime time index of length *n*.
+
+    If *start* is None, defaults to ``datetime(2000, 1, 1)``.
+    """
     if start is None:
         start = datetime(2000, 1, 1)
 
@@ -377,7 +385,13 @@ def _build_panel_no_timestamp(
 
 
 def _panel_column_name(series: dict, value_column_name: str) -> str:
-    """Build a panel column name using yohou's ``__`` separator convention."""
+    """Build a panel column name using yohou's ``__`` separator convention.
+
+    If the series has extra attributes beyond ``series_name`` and
+    ``start_timestamp``, their values are joined with underscores
+    (lowercased, spaces replaced by underscores) and used as the column
+    prefix instead of the series name. Otherwise the series name is used.
+    """
     name = series["name"]
     extra = series.get("extra_attrs", {})
     if extra:

--- a/src/yohou/datasets/_tsf_parser.py
+++ b/src/yohou/datasets/_tsf_parser.py
@@ -339,27 +339,21 @@ def _build_panel_different_starts(
     value_column_name: str,
 ) -> pl.DataFrame:
     """Build panel DataFrame when series have different start timestamps."""
-    all_times: set[datetime] = set()
-    series_time_map: list[tuple[str, dict[datetime, float | None]]] = []
-
+    per_series: list[pl.DataFrame] = []
     for s in series_list:
         col_name = _panel_column_name(s, value_column_name)
         start = s["start_timestamp"]
         n = len(s["values"])
-        times = _generate_time_index(start, n, polars_freq).to_list()
-        time_val_map = dict(zip(times, s["values"], strict=True))
-        all_times.update(times)
-        series_time_map.append((col_name, time_val_map))
+        time_col = _generate_time_index(start, n, polars_freq).cast(pl.Datetime("us"))
+        per_series.append(
+            pl.DataFrame({"time": time_col, col_name: pl.Series(col_name, s["values"], dtype=pl.Float64)})
+        )
 
-    sorted_times = sorted(all_times)
-    time_col = pl.Series("time", sorted_times, dtype=pl.Datetime("us"))
+    result = per_series[0]
+    for frame in per_series[1:]:
+        result = result.join(frame, on="time", how="full", coalesce=True)
 
-    columns: dict[str, pl.Series] = {"time": time_col}
-    for col_name, time_val_map in series_time_map:
-        vals = [time_val_map.get(t) for t in sorted_times]
-        columns[col_name] = pl.Series(col_name, vals, dtype=pl.Float64)
-
-    return pl.DataFrame(columns)
+    return result.sort("time")
 
 
 def _build_panel_no_timestamp(

--- a/src/yohou/ensemble/_base.py
+++ b/src/yohou/ensemble/_base.py
@@ -314,11 +314,18 @@ class _BaseEnsembleForecaster:
         self.local_y_schema_ = dict(first_forecaster.local_y_schema_)
         self.local_X_actual_schema_ = getattr(first_forecaster, "local_X_actual_schema_", None)
         self.shared_X_actual_schema_ = getattr(first_forecaster, "shared_X_actual_schema_", None)
-        self.local_y_t_schema_ = self.local_y_schema_
-        self.local_X_t_schema_ = self.local_X_actual_schema_
+        self.local_y_t_schema_ = getattr(first_forecaster, "local_y_t_schema_", self.local_y_schema_)
+        # The transformed feature schema/buffer must reflect the post-pipeline
+        # space, which only the child knows; the raw X_actual is not a valid
+        # stand-in when a child wraps a feature transformer. Mirror the child's
+        # transformed state so the contract attributes are accurate. The
+        # ensemble itself never reads these on any predict path (predict,
+        # observe, and rewind all delegate to the children), so they exist
+        # solely to satisfy the BaseForecaster fitted-attribute contract.
+        self.local_X_t_schema_ = getattr(first_forecaster, "local_X_t_schema_", self.local_X_actual_schema_)
         self._y_observed = y
         self._X_observed = X_actual
-        self._X_t_observed = X_actual
+        self._X_t_observed = getattr(first_forecaster, "_X_t_observed", X_actual)
 
     def _compute_effective_weights(self) -> None:
         """Compute effective weights for surviving forecasters.

--- a/src/yohou/ensemble/_base.py
+++ b/src/yohou/ensemble/_base.py
@@ -120,7 +120,8 @@ class _BaseEnsembleForecaster:
         Raises
         ------
         ValueError
-            If names are not unique or tuples are malformed.
+            If names are not unique, tuples are malformed, names are not
+            strings, or forecasters are not ``BaseForecaster`` instances.
 
         """
         names = []
@@ -260,7 +261,7 @@ class _BaseEnsembleForecaster:
         Raises
         ------
         ValueError
-            If target column schemas differ across forecasters.
+            If target column names or dtypes differ across forecasters.
 
         """
         schemas = {}
@@ -270,11 +271,20 @@ class _BaseEnsembleForecaster:
 
         reference_name, reference_schema = next(iter(schemas.items()))
         for name, schema in schemas.items():
-            if schema != reference_schema:
+            if set(schema.keys()) != set(reference_schema.keys()):
                 raise ValueError(
                     f"Forecaster '{name}' predicts columns {set(schema.keys())} "
                     f"but '{reference_name}' predicts {set(reference_schema.keys())}. "
                     f"All base forecasters must predict the same target columns."
+                )
+            if schema != reference_schema:
+                mismatched = {
+                    col: (schema[col], reference_schema[col]) for col in schema if schema[col] != reference_schema[col]
+                }
+                raise ValueError(
+                    f"Forecaster '{name}' predicts column dtypes that differ from "
+                    f"'{reference_name}': {mismatched} (column: (this, reference)). "
+                    f"All base forecasters must predict the same target dtypes."
                 )
 
     def _derive_fitted_attributes(
@@ -320,6 +330,8 @@ class _BaseEnsembleForecaster:
         """
         if self.weights is not None:
             fitted_names = {name for name, _ in self.forecasters_}
+            # self.forecasters and self.weights always have equal length here
+            # (guaranteed by pre-fit validation); strict=True asserts that.
             self.weights_ = [
                 w for (name, _), w in zip(self.forecasters, self.weights, strict=True) if name in fitted_names
             ]
@@ -396,6 +408,11 @@ class _BaseEnsembleForecaster:
         -------
         pl.DataFrame
             Aggregated interval predictions.
+
+        Notes
+        -----
+        For the ``"envelope"`` strategy, columns whose names contain neither
+        ``"_lower_"`` nor ``"_upper_"`` fall back to mean aggregation.
 
         """
         time_cols = [c for c in ("vintage_time", "time") if c in predictions[0].columns]

--- a/src/yohou/ensemble/voting_class_proba.py
+++ b/src/yohou/ensemble/voting_class_proba.py
@@ -47,8 +47,8 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
 
         - ``"soft"``: weighted average of class probabilities.
         - ``"hard"``: majority vote of argmax predictions. Ties are
-          broken deterministically by choosing the first class in sorted
-          order (via ``numpy.argmax``).
+          broken deterministically by choosing the lexicographically first
+          tied class (via Python ``sorted``).
     weights : list of float or None, default=None
         Per-forecaster weights. Raw values are passed to
         ``numpy.average`` which normalizes internally. Only used with
@@ -66,8 +66,11 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
         Mapping from target column to sorted class labels.
     n_classes_ : dict of str to int
         Number of classes per target column.
-    label_to_code_ : dict of str to dict of str to float
+    label_to_code_ : dict of str to dict of str to int
         Mapping from target column to label-to-code dict.
+    weights_ : list of float or None
+        Effective per-forecaster weights after removing forecasters that
+        failed to fit. ``None`` when no weights were supplied.
 
     Examples
     --------
@@ -272,7 +275,13 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
         groups: list[str],
         **params,
     ) -> pl.DataFrame:
-        """Produce aggregated probability forecasts for one step.
+        """Produce aggregated probability forecasts for one fit-horizon block.
+
+        Required by the abstract base class. ``predict_class_proba`` is
+        overridden to dispatch directly, so this delegates to the same
+        soft/hard helpers to keep a single voting implementation. The earlier
+        standalone body redundantly called every child's ``predict_class_proba``
+        before also calling ``predict`` on the hard path (predicting twice).
 
         Parameters
         ----------
@@ -287,56 +296,9 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
             Aggregated probability predictions.
 
         """
-        predictions = []
-        for _name, forecaster in self.forecasters_:
-            y_proba = forecaster.predict_class_proba(  # ty: ignore[unresolved-attribute]
-                groups=groups,
-                **params,
-            )
-            predictions.append(y_proba)
-
-        time_df = predictions[0].select(["vintage_time", "time"])
-        proba_cols = [c for c in predictions[0].columns if c not in ("vintage_time", "time")]
-
         if self.method == "soft":
-            agg_exprs = []
-            for col in proba_cols:
-                values = np.column_stack([pred[col].to_numpy() for pred in predictions])
-                if self.weights_ is not None:
-                    aggregated = np.average(values, axis=1, weights=self.weights_)
-                else:
-                    aggregated = np.mean(values, axis=1)
-                agg_exprs.append(pl.Series(name=col, values=aggregated))
-            return time_df.with_columns(agg_exprs)
-
-        # Hard voting: majority vote converted to one-hot probabilities
-        # Collect argmax predictions from each forecaster
-        hard_predictions = []
-        for _name, forecaster in self.forecasters_:
-            y_pred = forecaster.predict(  # ty: ignore[unresolved-attribute]
-                groups=groups,
-                **params,
-            )
-            hard_predictions.append(y_pred)
-
-        target_cols = [c for c in hard_predictions[0].columns if c not in ("vintage_time", "time")]
-        result = time_df.clone()
-        for target_col in target_cols:
-            class_labels = self.classes_[target_col]
-            n_rows = len(hard_predictions[0])
-            winners = []
-            for row_idx in range(n_rows):
-                votes = [pred[target_col][row_idx] for pred in hard_predictions]
-                vote_counts = Counter(votes)
-                max_count = max(vote_counts.values())
-                candidates = sorted(label for label, count in vote_counts.items() if count == max_count)
-                winners.append(candidates[0])
-            for label in class_labels:
-                col_name = f"{target_col}_proba_{label}"
-                proba_values = [1.0 if w == label else 0.0 for w in winners]
-                result = result.with_columns(pl.Series(name=col_name, values=proba_values))
-
-        return result
+            return self._soft_vote_predict_class_proba(groups=groups, **params)
+        return self._hard_vote_predict_class_proba(groups=groups, **params)
 
     def predict_class_proba(  # ty: ignore[invalid-method-override]
         self,

--- a/src/yohou/ensemble/voting_class_proba.py
+++ b/src/yohou/ensemble/voting_class_proba.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from numbers import Integral
 from typing import Literal
 
@@ -23,6 +22,47 @@ from yohou.utils._compat import StrOptions, _BaseComposition, _fit_context, _rai
 from ._base import _BaseEnsembleForecaster
 
 __all__ = ["VotingClassProbaForecaster"]
+
+
+def _majority_vote(predictions: list[pl.DataFrame], target_col: str) -> list:
+    """Compute the per-row majority vote with lexicographic tie-break.
+
+    For each row, counts the votes contributed by every forecaster's
+    ``target_col`` and returns the most frequent label; ties are broken by
+    choosing the lexicographically smallest label. This is the vectorised
+    equivalent of a per-row ``Counter`` loop and preserves the same tie-break.
+
+    Parameters
+    ----------
+    predictions : list of pl.DataFrame
+        Per-forecaster prediction frames, each containing ``target_col``.
+    target_col : str
+        Name of the column carrying each forecaster's predicted label.
+
+    Returns
+    -------
+    list
+        One winning label per row, in row order.
+
+    """
+    n_rows = len(predictions[0])
+    votes = pl.DataFrame({
+        str(forecaster_idx): pred[target_col] for forecaster_idx, pred in enumerate(predictions)
+    }).with_row_index("__row__")
+
+    tallies = (
+        votes
+        .unpivot(index="__row__", value_name="__label__")
+        .group_by("__row__", "__label__")
+        .len("__count__")
+        .sort(["__row__", "__count__", "__label__"], descending=[False, True, False])
+        .group_by("__row__", maintain_order=True)
+        .first()
+        .sort("__row__")
+    )
+
+    winners_by_row = dict(zip(tallies["__row__"].to_list(), tallies["__label__"].to_list(), strict=True))
+    return [winners_by_row[row_idx] for row_idx in range(n_rows)]
 
 
 class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecaster, _BaseComposition):
@@ -453,15 +493,8 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
         result = time_df.clone()
         for target_col in target_cols:
             class_labels = self.classes_[target_col]
-            n_rows = len(predictions[0])
 
-            winners = []
-            for row_idx in range(n_rows):
-                votes = [pred[target_col][row_idx] for pred in predictions]
-                vote_counts = Counter(votes)
-                max_count = max(vote_counts.values())
-                candidates = sorted(label for label, count in vote_counts.items() if count == max_count)
-                winners.append(candidates[0])
+            winners = _majority_vote(predictions, target_col)
 
             for label in class_labels:
                 col_name = f"{target_col}_proba_{label}"
@@ -610,15 +643,7 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
 
         result = time_df.clone()
         for target_col in target_cols:
-            n_rows = len(predictions[0])
-            winners = []
-            for row_idx in range(n_rows):
-                votes = [pred[target_col][row_idx] for pred in predictions]
-                vote_counts = Counter(votes)
-                max_count = max(vote_counts.values())
-                candidates = sorted(label for label, count in vote_counts.items() if count == max_count)
-                winners.append(candidates[0])
-
+            winners = _majority_vote(predictions, target_col)
             result = result.with_columns(pl.Series(name=target_col, values=winners))
 
         return result

--- a/src/yohou/ensemble/voting_interval.py
+++ b/src/yohou/ensemble/voting_interval.py
@@ -281,7 +281,13 @@ class VotingIntervalForecaster(_BaseEnsembleForecaster, BaseIntervalForecaster, 
         coverage_rates: list[float] | None = None,
         **params,
     ) -> pl.DataFrame:
-        """Not used - VotingIntervalForecaster overrides predict_interval directly.
+        """Raise; voting aggregates children's intervals via predict_interval.
+
+        The base ``predict`` pipeline routes single-step prediction through
+        ``_predict_one``. ``VotingIntervalForecaster`` bypasses that path by
+        overriding ``predict_interval`` (and ``predict``) to aggregate the
+        children's predictions directly, so this method is intentionally never
+        reached and only exists to satisfy the abstract base contract.
 
         Parameters
         ----------
@@ -465,7 +471,9 @@ class VotingIntervalForecaster(_BaseEnsembleForecaster, BaseIntervalForecaster, 
             External forecasts with ``"vintage_time"`` and ``"time"``
             columns.
         **params : dict
-            Metadata routing parameters.
+            Metadata routing parameters. Routed to each child through the
+            ``predict`` routing namespace (there is no separate
+            ``observe_predict`` mapping).
 
         Returns
         -------

--- a/src/yohou/ensemble/voting_point.py
+++ b/src/yohou/ensemble/voting_point.py
@@ -312,7 +312,9 @@ class VotingPointForecaster(_BaseEnsembleForecaster, BasePointForecaster, _BaseC
         X_forecast : pl.DataFrame or None, default=None
             External forecasts.
         **params : dict
-            Metadata routing parameters.
+            Metadata routing parameters. Routed to each child through the
+            ``predict`` routing namespace (there is no separate
+            ``observe_predict`` mapping).
 
         Returns
         -------

--- a/src/yohou/interval/base.py
+++ b/src/yohou/interval/base.py
@@ -39,29 +39,6 @@ class BaseSimilarity(BaseEstimator, metaclass=abc.ABCMeta):
     _parameter_constraints: dict = {}
 
     @staticmethod
-    def _validate_no_nulls(df: pl.DataFrame, method_name: str) -> None:
-        """Raise if any column contains null or NaN values.
-
-        Parameters
-        ----------
-        df : pl.DataFrame
-            DataFrame to validate.
-        method_name : str
-            Name of the calling method (for the error message).
-
-        Raises
-        ------
-        ValueError
-            If any column contains null or NaN values.
-
-        """
-        null_cols = [col for col in df.columns if df[col].is_null().any()]
-        nan_cols = [col for col in df.select(cs.numeric()).columns if df[col].is_nan().any()]
-        bad_cols = sorted(set(null_cols + nan_cols))
-        if bad_cols:
-            raise ValueError(f"{method_name}() received data with null or NaN values in columns: {bad_cols}")
-
-    @staticmethod
     def _to_weights(
         distances: np.ndarray,
     ) -> np.ndarray[tuple[int, int], np.dtype[np.floating[Any]]]:
@@ -354,7 +331,7 @@ class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         Raises
         ------
         ValueError
-            If ``forecasting_horizon`` < 1, ``coverage_rates`` not in (0, 1],
+            If ``forecasting_horizon`` < 1, ``coverage_rates`` not in [0, 1],
             or if ``y`` / ``X_actual`` have invalid structure.
 
         """
@@ -622,7 +599,8 @@ class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             data.
         stride : int or None, default=None
             Step size for rolling update-predict.  If ``None``, defaults to
-            ``forecasting_horizon``.
+            the forecasting horizon used at fit time
+            (``fit_forecasting_horizon_``).
         X_future : pl.DataFrame or None, default=None
             Known future features with a ``"time"`` column.
         X_forecast : pl.DataFrame or None, default=None
@@ -643,7 +621,7 @@ class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             If the forecaster has not been fitted yet.
         ValueError
             If ``y`` / ``X_actual`` have invalid structure, ``coverage_rates`` not in
-            (0, 1], or ``groups`` contains names not seen during fit.
+            [0, 1], or ``groups`` contains names not seen during fit.
 
         """
         check_is_fitted(self, ["groups_", "local_y_schema_", "fit_forecasting_horizon_"])
@@ -682,7 +660,7 @@ class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         coverage_rates: list[StrictFloat] | None = None,
         **params,
     ) -> pl.DataFrame:
-        """Predicts `_fit_forecasting_horizon` steps from the observation horizon.
+        """Predicts `fit_forecasting_horizon_` steps from the observation horizon.
 
         Parameters
         ----------

--- a/src/yohou/interval/base.py
+++ b/src/yohou/interval/base.py
@@ -116,17 +116,6 @@ class BaseSimilarity(BaseEstimator, metaclass=abc.ABCMeta):
 
         return tags
 
-    @property
-    def discarded_time_stamps(self) -> None:
-        """Get discarded timestamps (placeholder property).
-
-        Returns
-        -------
-        None
-
-        """
-        return None
-
     @abc.abstractmethod
     def fit(
         self,

--- a/src/yohou/interval/reduction.py
+++ b/src/yohou/interval/reduction.py
@@ -261,8 +261,8 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
     ) -> "IntervalReductionForecaster":
         """Fit the forecaster to historical data.
 
-        Tabularizes the time series, fits the wrapped sklearn estimator,
-        and calibrates prediction intervals from residuals.
+        Tabularizes the time series and fits a pair of quantile-regression
+        estimators (a lower and an upper quantile) for each coverage rate.
 
         Parameters
         ----------

--- a/src/yohou/interval/reduction.py
+++ b/src/yohou/interval/reduction.py
@@ -426,18 +426,21 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
             y_pred_lower = self._estimator_predict_one(estimator_lower, groups=groups)
             y_pred_upper = self._estimator_predict_one(estimator_upper, groups=groups)
 
-            # Enforce monotonic bounds (lower <= upper) by column-wise min/max
-            # This handles cases where QuantileRegressor predictions cross
+            # Enforce monotonic bounds (lower <= upper) by column-wise min/max.
+            # This handles cases where QuantileRegressor predictions cross.
+            # Bounds are paired positionally, so column counts must match.
             lower_cols = y_pred_lower.columns
             upper_cols = y_pred_upper.columns
-            for lower_col, upper_col in zip(lower_cols, upper_cols, strict=False):
-                lower_vals = y_pred_lower.get_column(lower_col)
-                upper_vals = y_pred_upper.get_column(upper_col)
-                # Compute true lower and upper
-                true_lower = pl.when(lower_vals <= upper_vals).then(lower_vals).otherwise(upper_vals)
-                true_upper = pl.when(lower_vals <= upper_vals).then(upper_vals).otherwise(lower_vals)
-                y_pred_lower = y_pred_lower.with_columns(true_lower.alias(lower_col))
-                y_pred_upper = y_pred_upper.with_columns(true_upper.alias(upper_col))
+            lower_exprs = [
+                pl.min_horizontal(pl.col(lower_col), y_pred_upper.get_column(upper_col)).alias(lower_col)
+                for lower_col, upper_col in zip(lower_cols, upper_cols, strict=True)
+            ]
+            upper_exprs = [
+                pl.max_horizontal(y_pred_lower.get_column(lower_col), pl.col(upper_col)).alias(upper_col)
+                for lower_col, upper_col in zip(lower_cols, upper_cols, strict=True)
+            ]
+            y_pred_lower = y_pred_lower.with_columns(lower_exprs)
+            y_pred_upper = y_pred_upper.with_columns(upper_exprs)
 
             # Rename columns to include coverage rate
             # Use actual column names (prefixed for panel data, unprefixed for global)

--- a/src/yohou/interval/similarity.py
+++ b/src/yohou/interval/similarity.py
@@ -27,11 +27,16 @@ class DistanceSimilarity(BaseSimilarity):
     prediction intervals.
 
     The weight for the *i*-th historical observation given prediction
-    *j* is computed as:
+    *j* is computed with a numerically-stable softmax of negative
+    distances that reserves uniform mass for the (hypothetical) test
+    point over the calibration axis:
 
-    $$w_{ji} = \frac{\exp(-d(x_j, x_i))}{\sum_k \exp(-d(x_j, x_k))}$$
+    $$w_{ji} = \frac{\exp(-(d_{ji} - \max_k d_{jk}))}
+    {1 + \sum_k \exp(-(d_{jk} - \max_k d_{jk}))}$$
 
-    where *d* is the chosen distance metric.
+    where $d_{ji} = d(x_j, x_i)$ for the chosen distance metric. The
+    ``+1`` in the denominator reserves mass for the new test point
+    (Barber et al., 2023), so each row sums to strictly less than 1.
 
     Parameters
     ----------
@@ -190,8 +195,6 @@ class DistanceSimilarity(BaseSimilarity):
         """
         X_features = self._get_X(y_pred, X_actual)
         self._X_observed = X_features
-
-        self._n_discarded_indices = len(y_pred) - len(X_features)
 
         return self
 

--- a/src/yohou/interval/similarity.py
+++ b/src/yohou/interval/similarity.py
@@ -159,13 +159,16 @@ class DistanceSimilarity(BaseSimilarity):
         else:
             result = y_pred
 
-        for col in result.columns:
-            if col == "time":
-                continue
-            series = result[col]
-            if series.null_count() > 0 or series.cast(pl.Float64, strict=False).is_nan().sum() > 0:
+        value_cols = [col for col in result.columns if col != "time"]
+        if value_cols:
+            bad_mask = result.select(
+                (pl.col(col).is_null() | pl.col(col).cast(pl.Float64, strict=False).is_nan()).any().alias(col)
+                for col in value_cols
+            )
+            bad_cols = [col for col in value_cols if bad_mask[col][0]]
+            if bad_cols:
                 raise ValueError(
-                    f"Column '{col}' contains null or NaN values. DistanceSimilarity requires complete data."
+                    f"Column '{bad_cols[0]}' contains null or NaN values. DistanceSimilarity requires complete data."
                 )
         return result
 
@@ -306,9 +309,11 @@ class SeasonalSimilarity(BaseSimilarity):
 
     Parameters
     ----------
-    seasonalities : list of float
+    seasonalities : list of float or None, default=None
         Seasonal periods in time steps (e.g. ``[7.0, 365.25]`` for
-        weekly and yearly cycles on daily data).
+        weekly and yearly cycles on daily data). ``None`` is accepted at
+        construction but invalid; passing ``None`` raises ``ValueError``
+        at ``fit`` time, so a list must be provided before fitting.
     harmonics : dict mapping float to list of int, or None, default=None
         Harmonics to include per seasonality period. Keys must match
         entries in ``seasonalities``. Each value is a list of positive

--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -363,10 +363,11 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
     ) -> "SplitConformalForecaster":
-        """Observe new data and update the wrapped point forecaster.
+        """Observe new data and update conformity scores and the point forecaster.
 
-        Delegates to the wrapped point forecaster's ``observe()`` method
-        to update its observation buffers without refitting.
+        Updates conformity scores and similarity weights with the new
+        observations, then advances the wrapped point forecaster's
+        observation buffers without refitting.
 
         Parameters
         ----------
@@ -421,9 +422,11 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
     ) -> "SplitConformalForecaster":
-        """Rewind the wrapped point forecaster's observation buffers.
+        """Rewind conformity scores, similarity state, and the point forecaster.
 
-        Delegates to the wrapped point forecaster's ``rewind()`` method.
+        Removes the most recently observed conformity scores and similarity
+        state, then rewinds the wrapped point forecaster's observation
+        buffers, mirroring the order used by ``observe()``.
 
         Parameters
         ----------
@@ -456,11 +459,15 @@ class SplitConformalForecaster(BaseIntervalForecaster):
 
         y, X_actual, groups = validate_forecaster_data(self, y, X_actual, reset=False, groups=groups)
 
-        self.point_forecaster_.rewind(y=y, X_actual=X_actual, groups=groups, X_future=X_future, X_forecast=X_forecast)
+        # Rewind conformity / similarity state *before* the point forecaster
+        # rolls back, mirroring the order used by observe() so both methods
+        # maintain the same state invariant.
         if self.groups_ is None:
             self._rewind_standard(y, X_actual=X_actual)
         else:
             BasePanelForecaster._rewind_panel(self, y, X_actual=X_actual, groups=groups)
+
+        self.point_forecaster_.rewind(y=y, X_actual=X_actual, groups=groups, X_future=X_future, X_forecast=X_forecast)
         self.observed_time_ = self.point_forecaster_.observed_time_
         return self
 
@@ -562,7 +569,8 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             data.
         stride : int or None, default=None
             Step size for rolling update-predict.  If ``None``, defaults to
-            ``forecasting_horizon``.
+            the forecasting horizon used at fit time
+            (``fit_forecasting_horizon_``).
         predict_transformed : bool, default=False
             If ``True``, return predictions in the transformed space without
             applying inverse target transformation.
@@ -668,7 +676,8 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             are used.
         stride : int or None, default=None
             Step size for rolling update-predict.  If ``None``, defaults to
-            ``forecasting_horizon``.
+            the forecasting horizon used at fit time
+            (``fit_forecasting_horizon_``).
         X_future : pl.DataFrame or None, default=None
             Known future features with a ``"time"`` column.
         X_forecast : pl.DataFrame or None, default=None

--- a/src/yohou/interval/utils.py
+++ b/src/yohou/interval/utils.py
@@ -31,13 +31,24 @@ def weighted_quantile(x: npt.NDArray[np.float64], q: float, weights: npt.NDArray
     float
         The weighted quantile value.
 
+    Raises
+    ------
+    ValueError
+        If ``x`` and ``weights`` have different lengths, or if the weights
+        sum to zero (no calibration mass), which would otherwise yield an
+        undefined (infinite) quantile that silently corrupts interval bounds.
+
     """
     if len(x) != len(weights):
         raise ValueError(f"x and weights must have the same length, got {len(x)} and {len(weights)}")
 
     w_sum = np.sum(weights)
     if w_sum == 0:
-        return float("inf")
+        raise ValueError(
+            "weighted_quantile received weights that sum to zero; cannot compute a "
+            "weighted quantile. This usually means all similarity weights collapsed "
+            "to zero for the current prediction context."
+        )
 
     # Normalize so the weighted CDF reaches 1, making all quantile levels computable
     w_norm = weights / w_sum

--- a/src/yohou/model_selection/__init__.py
+++ b/src/yohou/model_selection/__init__.py
@@ -1,6 +1,7 @@
 """Model selection tools including cross-validation and hyperparameter search."""
 
 from .search import (
+    BaseSearchCV,
     GridSearchCV,
     RandomizedSearchCV,
 )
@@ -18,6 +19,7 @@ from .validation import (
 )
 
 __all__ = [
+    "BaseSearchCV",
     "BaseSplitter",
     "ExpandingWindowSplitter",
     "GridSearchCV",

--- a/src/yohou/model_selection/search.py
+++ b/src/yohou/model_selection/search.py
@@ -500,8 +500,6 @@ class BaseSearchCV(BaseForecaster, MetaEstimatorMixin, metaclass=ABCMeta):
         refit_metric : str
             Name of the metric to use for refitting.
         """
-        refit_metric = "score"
-
         if self.scoring is None:
             raise ValueError("scoring parameter cannot be None")
 
@@ -858,7 +856,10 @@ class BaseSearchCV(BaseForecaster, MetaEstimatorMixin, metaclass=ABCMeta):
                 n_candidates = len(candidate_params)
 
                 if self.verbose > 0:
-                    pass
+                    print(  # noqa: T201
+                        f"Fitting {n_splits} folds for each of {n_candidates} "
+                        f"candidates, totalling {n_candidates * n_splits} fits"
+                    )
 
                 out = parallel(
                     delayed(_fit_and_score)(
@@ -1193,11 +1194,11 @@ class BaseSearchCV(BaseForecaster, MetaEstimatorMixin, metaclass=ABCMeta):
         _raise_for_params(params, self, "observe_predict")
         return self.best_forecaster_.observe_predict(
             y,
-            X_actual,
-            forecasting_horizon,
-            groups,
-            stride,
-            predict_transformed,
+            X_actual=X_actual,
+            forecasting_horizon=forecasting_horizon,
+            groups=groups,
+            stride=stride,
+            predict_transformed=predict_transformed,
             X_future=X_future,
             X_forecast=X_forecast,
             **params,
@@ -1208,6 +1209,7 @@ class BaseSearchCV(BaseForecaster, MetaEstimatorMixin, metaclass=ABCMeta):
         self,
         y: pl.DataFrame,
         X_actual: pl.DataFrame | None = None,
+        forecasting_horizon: int | None = None,
         coverage_rates: list[float] | None = None,
         groups: list[str] | None = None,
         X_future: pl.DataFrame | None = None,
@@ -1228,6 +1230,9 @@ class BaseSearchCV(BaseForecaster, MetaEstimatorMixin, metaclass=ABCMeta):
             Actual feature observations with a ``"time"`` column aligned
             with ``y``. Sliced and observed incrementally at each step
             of the rolling loop.
+        forecasting_horizon : int or None, default=None
+            Number of time steps to forecast into the future.  If ``None``,
+            uses the horizon specified at fit time.
         coverage_rates : list of float or None, default=None
             Coverage levels for prediction intervals (e.g., ``[0.9, 0.95]``
             for 90 % and 95 % intervals).  If ``None``, defaults to the rates
@@ -1254,7 +1259,8 @@ class BaseSearchCV(BaseForecaster, MetaEstimatorMixin, metaclass=ABCMeta):
         _raise_for_params(params, self, "observe_predict_interval")
         return self.best_forecaster_.observe_predict_interval(
             y,
-            X_actual,
+            X_actual=X_actual,
+            forecasting_horizon=forecasting_horizon,
             coverage_rates=coverage_rates,
             groups=groups,
             X_future=X_future,
@@ -1397,7 +1403,8 @@ class GridSearchCV(BaseSearchCV):
 
     scoring : BaseScorer or dict of {str: BaseScorer}
         Strategy to evaluate the performance of the cross-validated model
-        on the test set.
+        on the test set.  Required; although the constructor default is
+        ``None``, passing ``None`` raises ``ValueError`` at ``fit`` time.
 
         If a single BaseScorer instance, the same scorer is used for all
         folds and stored in cv_results_ with key 'score'.
@@ -1796,7 +1803,8 @@ class RandomizedSearchCV(BaseSearchCV):
 
     scoring : BaseScorer or dict of {str: BaseScorer}
         Strategy to evaluate the performance of the cross-validated model
-        on the test set.
+        on the test set.  Required; although the constructor default is
+        ``None``, passing ``None`` raises ``ValueError`` at ``fit`` time.
 
         If a single BaseScorer instance, the same scorer is used for all
         folds and stored in cv_results_ with key 'score'.

--- a/src/yohou/model_selection/search.py
+++ b/src/yohou/model_selection/search.py
@@ -332,7 +332,7 @@ class BaseSearchCV(BaseForecaster, MetaEstimatorMixin, metaclass=ABCMeta):
 
     _parameter_constraints: dict = {
         "forecaster": [HasMethods(["fit", "predict"])],
-        "scoring": [None, callable, dict],
+        "scoring": [callable, dict],
         "n_jobs": [numbers.Integral, None],
         "refit": ["boolean", str, callable],
         "cv": [numbers.Integral, HasMethods(["split", "get_n_splits"]), None],

--- a/src/yohou/model_selection/split.py
+++ b/src/yohou/model_selection/split.py
@@ -3,7 +3,7 @@
 import numbers
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterator
 from typing import Any, ClassVar
 
 import numpy as np
@@ -191,7 +191,11 @@ class ExpandingWindowSplitter(BaseSplitter):
         Number of splits. Must be at least 2.
     max_train_size : int, default=None
         Maximum size for a single training set. If None, all available
-        training data is used.
+        training data is used. When set, the training window becomes
+        bounded-expanding: it still ends at the start of each test window but
+        is capped at the ``max_train_size`` most-recent rows, effectively
+        turning the splitter into a sliding window once enough data has
+        accumulated.
     test_size : int, default=None
         Used to limit the size of the test set. Defaults to
         ``n_samples // (n_splits + 1)``, which is the maximum allowed
@@ -333,11 +337,16 @@ class ExpandingWindowSplitter(BaseSplitter):
         if test_size >= n_samples:
             raise ValueError(f"test_size={test_size} should be less than the number of samples={n_samples}.")
 
-        test_starts = range(n_samples - n_splits * test_size, n_samples, test_size)
+        first_test_start = n_samples - n_splits * test_size
+        if first_test_start < 0:
+            raise ValueError(
+                f"Cannot create n_splits={n_splits} non-overlapping test windows of "
+                f"test_size={test_size} from n_samples={n_samples}: this needs at least "
+                f"{n_splits * test_size} samples for the test windows alone. "
+                f"Reduce n_splits or test_size, or provide more data."
+            )
 
-        for test_start in test_starts:
-            if test_start < 0:
-                continue
+        for test_start in range(first_test_start, n_samples, test_size):
             yield np.arange(test_start, test_start + test_size, dtype=np.intp)
 
     def get_n_splits(
@@ -630,20 +639,19 @@ class SlidingWindowSplitter(BaseSplitter):
 
 
 def check_cv(
-    cv: int | BaseSplitter | Iterable[tuple[np.ndarray[Any, Any], np.ndarray[Any, Any]]] | None = 5,
+    cv: int | BaseSplitter | None = 5,
     forecasting_horizon: int = 1,
 ) -> BaseSplitter:
     """Input checker utility for building a cross-validator.
 
     Parameters
     ----------
-    cv : int, cross-validation generator or an iterable, default=5
+    cv : int or cross-validation generator, default=5
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
         - None, to use the default 5-fold time series cross validation,
         - integer, to specify the number of folds in a time series `Splitter`,
-        - `BaseSplitter` instance,
-        - An iterable yielding (train, test) splits as arrays of indices.
+        - `BaseSplitter` instance.
     forecasting_horizon : int >= 1, default=1
         Horizon to forecast recursively.
 
@@ -685,7 +693,9 @@ def check_cv_alignment(
     -------
     dict
         ``n_vintages``
-            Number of predict calls per fold (1 initial + test_size // stride).
+            Number of predict calls per fold
+            (``1 + ceil(test_size / stride)``); for example ``test_size=10``
+            and ``stride=4`` give ``4`` vintages.
         ``steps_per_vintage``
             List of step counts per vintage.  All entries equal
             ``forecasting_horizon`` except possibly the last.

--- a/src/yohou/model_selection/utils.py
+++ b/src/yohou/model_selection/utils.py
@@ -81,23 +81,21 @@ def _check_scoring(forecaster: BaseForecaster, scoring: object) -> BaseScorer | 
     forecaster : BaseForecaster
         The forecaster for which the scoring will be applied.
 
-    scoring : list, tuple or dict
+    scoring : BaseScorer or dict of {str: BaseScorer}
         Strategy to evaluate the performance of the cross-validated model on
         the test set.
 
         The possibilities are:
 
-        - a list or tuple of unique strings;
-        - a callable returning a dictionary where they keys are the metric
-          names and the values are the metric scores;
-        - a dictionary with metric names as keys and callables a values.
-
-        See [Multimetric Grid Search](https://scikit-learn.org/stable/auto_examples/model_selection/plot_multi_metric_evaluation.html) for an example.
+        - a single ``BaseScorer`` instance;
+        - a dictionary mapping scorer names (``str``) to ``BaseScorer``
+          instances for multimetric scoring.
 
     Returns
     -------
-    scorers_dict : dict
-        A dict mapping each scorer name to its validated scorer.
+    BaseScorer or dict of {str: BaseScorer}
+        The single scorer is returned unchanged; a dict is validated and
+        returned as-is.
     """
     if isinstance(scoring, BaseScorer):
         scorers = scoring
@@ -127,8 +125,9 @@ def _check_scoring(forecaster: BaseForecaster, scoring: object) -> BaseScorer | 
 class _MultimetricScorer:
     """Callable for multimetric scoring used to avoid repeated calls.
 
-    Avoids repeated calls
-    to `predict_proba`, `predict`, and `decision_function`.
+    Avoids repeated calls to ``observe_predict``, ``observe_predict_interval``,
+    and ``observe_predict_class_proba`` by caching the single prediction call
+    shared across all scorers.
 
     `_MultimetricScorer` will return a dictionary of scores corresponding to
     the scorers in the dictionary. Note that `_MultimetricScorer` can be
@@ -345,8 +344,6 @@ def _fit_and_score(
         else:
             sorted_keys = sorted(parameters)  # Ensure deterministic o/p
             params_msg = ", ".join(f"{k}={parameters[k]}" for k in sorted_keys)
-    if verbose > 9:
-        pass
 
     # Adjust length of sample weights
     fit_params = fit_params if fit_params is not None else {}
@@ -453,8 +450,14 @@ def _fit_and_score(
                 raise ValueError("return_train_score requires a scorer.")
             # forecaster is stateful and needs to be rewound to predict the past
             score_params_train = _check_method_params(y, params=score_params, indices=train)
-            train_rewind = train[: -len(test)]
-            test_rewind = train[-len(test) :]
+            # ``train`` carries absolute row indices into the original ``y``,
+            # but ``y_train`` is already sliced to ``len(train)`` rows whose
+            # positions run 0..len(train)-1. Use relative positions here so the
+            # rewind/predict split indexes ``y_train`` correctly regardless of
+            # where the training window starts (e.g. SlidingWindowSplitter).
+            n_train_rewind = len(train) - len(test)
+            train_rewind = np.arange(n_train_rewind)
+            test_rewind = np.arange(n_train_rewind, len(train))
             y_train_rewind, X_actual_train_rewind = _safe_split(forecaster, y_train, X_actual_train, train_rewind)
             y_train_test, X_actual_train_test = _safe_split(
                 forecaster, y_train, X_actual_train, test_rewind, train_rewind
@@ -501,6 +504,7 @@ def _fit_and_score(
         # Right align the result_msg
         end_msg += "." * (80 - len(end_msg) - len(result_msg))
         end_msg += result_msg
+        print(end_msg)  # noqa: T201
 
     if scorer is not None:
         result["test_scores"] = test_scores

--- a/src/yohou/model_selection/utils.py
+++ b/src/yohou/model_selection/utils.py
@@ -554,7 +554,10 @@ def _resolve_response_method(scorer: BaseScorer | _MultimetricScorer) -> str:
     return max(methods, key=lambda m: _RESPONSE_METHOD_PRIORITY[m])
 
 
-# Backward-compat shims for yohou-optuna <= 0.1.0a1
+# Intentional backward-compat shims for yohou-optuna <= 0.1.0a1. These thin
+# wrappers over _get_response_methods are not used elsewhere in the main source
+# tree, but they are a public-facing compatibility surface relied on by the
+# yohou-optuna integration and its tests, so they are kept deliberately.
 def _needs_interval_predictions(scorer: BaseScorer | _MultimetricScorer) -> bool:
     """Check if any scorer requires interval predictions."""
     return "predict_interval" in _get_response_methods(scorer)
@@ -740,9 +743,12 @@ def _predict(
     # observe_predict produces overlapping prediction windows when the last
     # observation chunk is smaller than stride. Deduplicate (keeping the most
     # recently informed prediction) and sort so downstream scorers receive a
-    # clean, monotonically increasing time column.
+    # clean, monotonically increasing time column. Deduplicate on the full
+    # vintage key so rows that differ only in vintage_time are preserved.
     # TODO: Address this formally in scorers
-    return y_pred.unique(subset=["time"], keep="last").sort("time")
+    dedup_subset = ["vintage_time", "time"] if "vintage_time" in y_pred.columns else ["time"]
+    sort_cols = [col for col in ("time", "vintage_time") if col in y_pred.columns]
+    return y_pred.unique(subset=dedup_subset, keep="last").sort(sort_cols)
 
 
 def _score(

--- a/src/yohou/plotting/_utils.py
+++ b/src/yohou/plotting/_utils.py
@@ -62,6 +62,7 @@ LINE_DASH_SEQUENCE: list[str] = [
     "longdash",
     "longdashdot",
 ]
+"""Ordered Plotly dash styles for distinguishing multiple line series."""
 
 
 @dataclass(frozen=True)
@@ -84,7 +85,9 @@ class RenderContext:
         ``facet_by="group"``, group name when ``facet_by="member"``,
         column name when ``facet_by="column"``).
     entity_idx : int
-        Index of the overlaid entity in the color palette.
+        Index of the overlaid entity in the color palette. In non-panel
+        (column) mode this is always 0; such callbacks should use
+        ``display_name`` to look up colours from their own mapping.
     row : int
         Subplot row (1-indexed).
     col : int
@@ -139,9 +142,6 @@ def _subplot_spacing(n: int, base: float = 0.3, floor: float = 0.04) -> float:
         ``max(floor, base / n)``
     """
     return max(floor, base / max(n, 1))
-
-
-"""Ordered Plotly dash styles for distinguishing multiple line series."""
 
 
 def set_config(
@@ -514,6 +514,11 @@ def resolve_color_palette(color_palette: list[str] | None, n: int) -> list[str]:
     -------
     list[str]
         List of exactly *n* colour hex codes.
+
+    Raises
+    ------
+    ValueError
+        If *color_palette* is a non-None empty list.
 
     Examples
     --------
@@ -1198,12 +1203,20 @@ def facet_figure(
     subplot_h_spacing : float | None, default=None
         Horizontal spacing between subplots.
     resampler : bool | Literal["widget"] | None, default=None
-        Resampler mode.
+        Resampler mode.  ``False`` uses a plain ``go.Figure``, ``True`` a
+        ``FigureResampler``, ``"widget"`` a ``FigureWidgetResampler``, and
+        ``None`` reads from :func:`get_config` (default ``False``).
 
     Returns
     -------
     go.Figure
         Plotly figure with faceted subplots.
+
+    Raises
+    ------
+    ValueError
+        If both *columns* and *column_groups* are specified in non-panel
+        mode.
 
     Examples
     --------

--- a/src/yohou/plotting/diagnostics.py
+++ b/src/yohou/plotting/diagnostics.py
@@ -142,7 +142,6 @@ def plot_autocorrelation(
         groups = []
 
     if groups is not None:
-        _panel_cols = resolve_panel_columns(df, groups, columns)
         _color_mgr = PanelColorManager(color_palette)
         _acf_legend = LegendTracker()
 
@@ -265,15 +264,14 @@ def _compute_acf_values(series: pl.Series, max_lags: int) -> list[float]:
 
     """
     mean_val = series.mean()
+    centered = series - mean_val
+    denominator = float((centered**2).sum())
     acf_values: list[float] = []
     for lag in range(max_lags + 1):
         if lag == 0:
             acf_values.append(1.0)
         else:
-            s1 = series[:-lag] - mean_val
-            s2 = series[lag:] - mean_val
-            numerator = float((s1 * s2).sum())
-            denominator = float(((series - mean_val) ** 2).sum())
+            numerator = float((centered[:-lag] * centered[lag:]).sum())
             acf_values.append(numerator / denominator if denominator != 0 else 0.0)
     return acf_values
 
@@ -437,7 +435,6 @@ def plot_partial_autocorrelation(
         groups = []
 
     if groups is not None:
-        _panel_cols = resolve_panel_columns(df, groups, columns)
         _pacf_color_mgr = PanelColorManager(color_palette)
         _pacf_legend = LegendTracker()
 
@@ -946,8 +943,6 @@ def plot_seasonality(
         Plot height in pixels.
     connect_gaps : bool, default=False
         If True, connect lines across missing data gaps.
-    show_legend : bool, default=True
-        Whether to display the legend.
     resampler : bool | Literal["widget"] | None, default=None
         Enable plotly-resampler for large datasets.  ``True`` returns a
         ``FigureResampler``, ``"widget"`` a ``FigureWidgetResampler``,
@@ -1695,9 +1690,11 @@ def plot_lag_scatter(
         Input DataFrame with 'time' column and numeric columns.
     columns : str | list[str] | None, default=None
         Column(s) to analyse. If None, uses all numeric columns except 'time'.
-    lags : list[int] | None, default=None
+    lags : int | list[int] | None, default=None
         Lag values to plot. Each lag gets its own subplot when there are
-        multiple entries.  Defaults to ``[1]`` when ``None``.
+        multiple entries. If an int, generates lags ``[1, 2, ..., lags]``.
+        If a list, uses the exact values provided. Defaults to ``[1]``
+        when ``None``.
     seasonality : str | None, default=None
         When set, colour markers by season.  Accepts ``"month"``,
         ``"quarter"``, ``"weekday"``, ``"week"`` or ``"hour"``.

--- a/src/yohou/plotting/diagnostics.py
+++ b/src/yohou/plotting/diagnostics.py
@@ -263,17 +263,18 @@ def _compute_acf_values(series: pl.Series, max_lags: int) -> list[float]:
         ACF values from lag 0 to *max_lags* inclusive.
 
     """
-    mean_val = series.mean()
-    centered = series - mean_val
+    centered = series.to_numpy().astype(float)
+    centered = centered - centered.mean()
     denominator = float((centered**2).sum())
-    acf_values: list[float] = []
-    for lag in range(max_lags + 1):
-        if lag == 0:
-            acf_values.append(1.0)
-        else:
-            numerator = float((centered[:-lag] * centered[lag:]).sum())
-            acf_values.append(numerator / denominator if denominator != 0 else 0.0)
-    return acf_values
+    n = centered.shape[0]
+    # Full autocovariance via numpy correlation; the second half holds the
+    # non-negative lags starting at lag 0.
+    autocov = np.correlate(centered, centered, mode="full")[n - 1 : n + max_lags]
+    if denominator == 0:
+        return [1.0] + [0.0] * max_lags
+    acf = (autocov / denominator).tolist()
+    acf[0] = 1.0
+    return acf
 
 
 def _compute_pacf(

--- a/src/yohou/plotting/evaluation.py
+++ b/src/yohou/plotting/evaluation.py
@@ -339,8 +339,9 @@ def plot_residuals(
     height : int | None, default=None
         Plot height in pixels.
     resampler : bool | Literal["widget"] | None, default=None
-        Enable plotly-resampler for large datasets. ``"figure"`` creates a
-        ``FigureResampler``, ``"widget"`` a ``FigureWidgetResampler``.
+        Enable plotly-resampler for large datasets. ``True`` creates a
+        ``FigureResampler``, ``"widget"`` a ``FigureWidgetResampler``;
+        ``False`` or ``None`` uses a plain ``go.Figure``.
     marker_size : float, default=4
         Marker size for scatter plots.
     marker_opacity : float, default=0.6
@@ -832,16 +833,20 @@ def plot_calibration(
 
     >>> import polars as pl
     >>> import numpy as np
+    >>> from datetime import datetime, timedelta
     >>> from yohou.plotting import plot_calibration
 
     >>> # Create sample data
     >>> n = 100
-    >>> y_truth = pl.DataFrame({"y": np.random.randn(n)})
+    >>> rng = np.random.default_rng(0)
+    >>> times = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+    >>> y_truth = pl.DataFrame({"time": times, "y": rng.standard_normal(n)})
     >>> y_pred_int = pl.DataFrame({
-    ...     "y_upper_0.9": np.random.randn(n) + 1.65,
-    ...     "y_lower_0.9": np.random.randn(n) - 1.65,
-    ...     "y_upper_0.95": np.random.randn(n) + 1.96,
-    ...     "y_lower_0.95": np.random.randn(n) - 1.96,
+    ...     "time": times,
+    ...     "y_upper_0.9": rng.standard_normal(n) + 1.65,
+    ...     "y_lower_0.9": rng.standard_normal(n) - 1.65,
+    ...     "y_upper_0.95": rng.standard_normal(n) + 1.96,
+    ...     "y_lower_0.95": rng.standard_normal(n) - 1.96,
     ... })
 
     >>> # Plot calibration
@@ -1323,7 +1328,7 @@ def _compute_componentwise_scores(
     if len(score_columns) == 1:
         score_values = scores_df[score_columns[0]]
     else:
-        score_values = scores_df.select(score_columns).mean().transpose().to_series()
+        score_values = scores_df.select(score_columns).mean_horizontal()
 
     keep_cols = ["time"]
     if "vintage_time" in scores_df.columns:
@@ -1422,9 +1427,9 @@ def plot_score_time_series(
     connect_gaps : bool, default=False
         Whether to connect gaps in the data with lines.
     resampler : bool | Literal["widget"] | None, default=None
-        Enable plotly-resampler for large datasets.  ``True`` or
-        ``"widget"`` creates a ``FigureWidgetResampler``; ``False`` or
-        ``None`` uses a plain ``go.Figure``.
+        Enable plotly-resampler for large datasets.  ``True`` creates a
+        ``FigureResampler``, ``"widget"`` a ``FigureWidgetResampler``;
+        ``False`` or ``None`` uses a plain ``go.Figure``.
     line_width : float, default=2.0
         Width of score lines.
     line_dash : str, default="solid"
@@ -1444,7 +1449,9 @@ def plot_score_time_series(
     TypeError
         If y_truth or y_pred is not a Polars DataFrame.
     ValueError
-        If DataFrames are empty or missing required columns.
+        If DataFrames are empty or missing required columns, if *scorer*
+        is a dict (multi-scorer) and panel data is detected in *y_truth*,
+        or if *scorer* is a dict and ``facet_by="vintage"``.
 
     Examples
     --------
@@ -2101,7 +2108,8 @@ def plot_score_distribution(
                     if cn in ("time", "vintage_time")
                     or (cn.startswith(f"{gname}__") and (_col_filter is None or _member_name(cn) in _col_filter))
                 ]
-                y_pred_dict_g[mname] = y_pred_m.select(gp_cols) if len(gp_cols) > 2 else y_pred_m
+                has_group_col = any(cn not in ("time", "vintage_time") for cn in gp_cols)
+                y_pred_dict_g[mname] = y_pred_m.select(gp_cols) if has_group_col else y_pred_m
             _render(pfig, y_truth_g, y_pred_dict_g, colors, first_cw, show_legend and g_idx == 0, row=r, col=c_i)
 
         first_scorer = next(iter(scorer_dict.values()))
@@ -2664,7 +2672,8 @@ def plot_score_per_step(
                     if cn in ("time", "vintage_time")
                     or (cn.startswith(f"{gname}__") and (_col_filter is None or _member_name(cn) in _col_filter))
                 ]
-                y_pred_dict_g[mname] = y_pred_m.select(gp_cols) if len(gp_cols) > 2 else y_pred_m
+                has_group_col = any(cn not in ("time", "vintage_time") for cn in gp_cols)
+                y_pred_dict_g[mname] = y_pred_m.select(gp_cols) if has_group_col else y_pred_m
             _render_horizon(
                 pfig,
                 y_truth_g,

--- a/src/yohou/plotting/exploration.py
+++ b/src/yohou/plotting/exploration.py
@@ -1496,18 +1496,21 @@ def plot_outliers(
         Column(s) to analyze. If None, uses all numeric columns except 'time'.
     method : {"zscore", "iqr", "percentile"}, default="zscore"
         Outlier detection method:
-        - "zscore": points with |z-score| > threshold (default 3.0)
-        - "iqr": points outside [Q1 - threshold*IQR, Q3 + threshold*IQR] (default 1.5)
-        - "percentile": points above the threshold-th percentile or below
-          the (100-threshold)-th percentile (default 95.0, flags outer 5%)
+        - "zscore": points with |z-score| > *threshold*
+        - "iqr": points outside [Q1 - threshold*IQR, Q3 + threshold*IQR]
+        - "percentile": points above the *threshold*-th percentile or below
+          the (100 - *threshold*)-th percentile (e.g. ``threshold=95``
+          flags the outer 5%)
     threshold : float, default=3.0
-        Detection threshold. Interpretation depends on *method*.
+        Detection threshold. Interpretation depends on *method*. The default
+        of ``3.0`` suits ``"zscore"``; use a value such as ``1.5`` for
+        ``"iqr"`` and a value such as ``95`` for ``"percentile"``.
     groups : list[str] | None, default=None
         Panel group prefixes to plot.
     facet_by : Literal["group", "member"] | None, default="member"
         Faceting axis for panel data.  ``"group"`` creates one subplot per
-        group, ``"member"`` one per member.  ``None`` disables faceting.
-        Ignored for non-panel data.
+        group, ``"member"`` one per member.  ``None`` falls back to
+        ``"member"``.  Ignored for non-panel data.
     facet_n_cols : int, default=2
         Number of columns in facet grid.
     color_palette : list[str] | None, default=None
@@ -1524,8 +1527,6 @@ def plot_outliers(
         Plot width in pixels.
     height : int | None, default=None
         Plot height in pixels.
-    show_legend : bool, default=True
-        Whether to display the legend.
     connect_gaps : bool, default=False
         If True, connect lines across missing data gaps.
     resampler : bool | Literal["widget"] | None, default=None
@@ -1715,7 +1716,7 @@ def plot_outliers(
             col=ctx.col,
         )
 
-        df_outliers = df.filter(mask)
+        df_outliers = ctx.sub_df.filter(mask)
         if len(df_outliers) > 0:
             ctx.fig.add_trace(
                 go.Scatter(
@@ -1891,14 +1892,6 @@ def plot_resampling_comparison(
     validate_plotting_data(df_resampled)
     validate_plotting_params(width=width, height=height)
 
-    # Get styling parameters
-    original_width = original_line_width
-    original_opacity = original_line_opacity
-    original_dash = original_line_dash
-    resampled_width = resampled_line_width
-    resampled_opacity = resampled_line_opacity
-    resampled_dash = resampled_line_dash
-
     if groups is None and columns is None and _auto_detect_panel(df_resampled):
         groups = []
 
@@ -1917,8 +1910,8 @@ def plot_resampling_comparison(
                         x=df_original["time"],
                         y=df_original[orig_col],
                         mode="lines",
-                        line={"color": _colors[0], "width": original_width, "dash": original_dash},
-                        opacity=original_opacity,
+                        line={"color": _colors[0], "width": original_line_width, "dash": original_line_dash},
+                        opacity=original_line_opacity,
                         name=original_label,
                         showlegend=False,
                     ),
@@ -1931,8 +1924,8 @@ def plot_resampling_comparison(
                     x=ctx.sub_df["time"],
                     y=ctx.sub_df[base],
                     mode="lines+markers",
-                    line={"color": _colors[0], "width": resampled_width, "dash": resampled_dash},
-                    opacity=resampled_opacity,
+                    line={"color": _colors[0], "width": resampled_line_width, "dash": resampled_line_dash},
+                    opacity=resampled_line_opacity,
                     name=resampled_label,
                     showlegend=False,
                 ),
@@ -1978,8 +1971,8 @@ def plot_resampling_comparison(
                 y=df_original[base],
                 mode="lines",
                 name=f"{base} ({original_label})",
-                line={"color": col_color, "width": original_width, "dash": original_dash},
-                opacity=original_opacity,
+                line={"color": col_color, "width": original_line_width, "dash": original_line_dash},
+                opacity=original_line_opacity,
                 connectgaps=connect_gaps,
                 hovertemplate=f"<b>{base} ({original_label})</b><br>%{{x}}<br>%{{y:.2f}}<extra></extra>",
             ),
@@ -1992,8 +1985,8 @@ def plot_resampling_comparison(
                 y=ctx.sub_df[base],
                 mode="lines+markers",
                 name=f"{base} ({resampled_label})",
-                line={"color": col_color, "width": resampled_width, "dash": resampled_dash},
-                opacity=resampled_opacity,
+                line={"color": col_color, "width": resampled_line_width, "dash": resampled_line_dash},
+                opacity=resampled_line_opacity,
                 connectgaps=connect_gaps,
                 hovertemplate=f"<b>{base} ({resampled_label})</b><br>%{{x}}<br>%{{y:.2f}}<extra></extra>",
             ),

--- a/src/yohou/plotting/forecasting.py
+++ b/src/yohou/plotting/forecasting.py
@@ -1382,8 +1382,7 @@ def _render_forecast_trace(
         if not has_point and not has_intervals:
             continue
 
-        if has_point:
-            assert pred_col is not None
+        if pred_col is not None:
             x_fc = m_pred["time"]
             y_fc = m_pred[pred_col]
             if show_transition and y_train is not None and col in y_train.columns:
@@ -2453,11 +2452,15 @@ def _clean_series(series: pl.Series) -> np.ndarray:
     """
     import warnings  # noqa: PLC0415
 
-    values = series.to_list()
-    clean = pl.Series(values).interpolate().forward_fill().backward_fill()
-    n_interpolated = sum(v is None or (isinstance(v, float) and np.isnan(v)) for v in values) - sum(
-        v is None or (isinstance(v, float) and np.isnan(v)) for v in clean.to_list()
-    )
+    def _n_missing(s: pl.Series) -> int:
+        """Count null and (for float columns) NaN entries in ``s``."""
+        n = s.null_count()
+        if s.dtype.is_float():
+            n += int(s.is_nan().fill_null(False).sum())
+        return n
+
+    clean = series.interpolate().forward_fill().backward_fill()
+    n_interpolated = _n_missing(series) - _n_missing(clean)
     if n_interpolated > 0:
         warnings.warn(
             f"Interpolated {n_interpolated} NaN value(s) before decomposition.",

--- a/src/yohou/plotting/model_selection.py
+++ b/src/yohou/plotting/model_selection.py
@@ -231,7 +231,8 @@ def plot_cv_results_scatter(
         Whether higher score values are better. When False, scores are negated
         for display so that metrics like ``neg_mean_squared_error`` appear as
         positive values. The best-point detection still operates on the
-        original (un-negated) scores.
+        original (un-negated) scores, selecting the maximum when
+        ``higher_is_better`` is True and the minimum otherwise.
     highlight_best : bool, default=True
         Whether to highlight the best parameter value.
     color_palette : list[str] | None, default=None
@@ -339,8 +340,10 @@ def plot_cv_results_scatter(
     if highlight_best and ranks is not None:
         best_idx = list(ranks).index(1)
     elif highlight_best:
-        # Fall back to finding max raw score (before negation)
-        best_idx = list(mean_scores_raw).index(max(mean_scores_raw))
+        # Fall back to the optimal raw score (before negation); the direction
+        # depends on whether higher or lower raw scores are better.
+        best_raw = max(mean_scores_raw) if higher_is_better else min(mean_scores_raw)
+        best_idx = list(mean_scores_raw).index(best_raw)
 
     # Add scatter trace with optional error bars
     error_y = None

--- a/src/yohou/plotting/signal.py
+++ b/src/yohou/plotting/signal.py
@@ -66,8 +66,8 @@ def plot_phase(
         Panel group prefixes to plot.
     facet_by : Literal["group", "member"] | None, default="member"
         Faceting axis for panel data.  ``"group"`` creates one subplot per
-        group, ``"member"`` one per member.  ``None`` disables faceting.
-        Ignored for non-panel data.
+        group, ``"member"`` one per member.  ``None`` falls back to
+        ``"member"``.  Ignored for non-panel data.
     facet_n_cols : int, default=2
         Number of columns in facet grid.
     color_palette : list[str] | None, default=None
@@ -131,7 +131,7 @@ def plot_phase(
 
         def _render_phase(ctx: RenderContext) -> None:
             """Render phase spectrum for a single panel group."""
-            base = [c for c in ctx.sub_df.columns if c != "time"][0]
+            base = ctx.display_name
             y_arr = ctx.sub_df[base].to_numpy().astype(float)
             spectrum = np.fft.rfft(y_arr)
             freqs = np.fft.rfftfreq(len(y_arr))
@@ -177,7 +177,6 @@ def plot_phase(
     plot_columns = validate_plotting_data(df, columns=columns, exclude=["time"])
     _colors = resolve_color_palette(color_palette, len(plot_columns))
     _col_colors = dict(zip(plot_columns, _colors, strict=False))
-    unit = "degrees" if use_degrees else "radians"
 
     def _render_phase(ctx: RenderContext) -> None:
         """Render phase spectrum for one column into a subplot."""
@@ -251,8 +250,9 @@ def plot_spectrum(
 
     Creates a periodogram showing the power spectral density via FFT, useful
     for identifying dominant frequencies and periodic patterns in the data.
-    Hover text always includes the corresponding period (1/frequency) and
-    detected peaks are annotated with their period in sample units.
+    In non-panel mode, hover text includes the corresponding period
+    (1/frequency) and detected peaks are annotated with their period in
+    sample units; these enrichments are not applied to panel facets.
 
     Parameters
     ----------
@@ -266,8 +266,8 @@ def plot_spectrum(
         Panel group prefixes to plot.
     facet_by : Literal["group", "member"] | None, default="member"
         Faceting axis for panel data.  ``"group"`` creates one subplot per
-        group, ``"member"`` one per member.  ``None`` disables faceting.
-        Ignored for non-panel data.
+        group, ``"member"`` one per member.  ``None`` falls back to
+        ``"member"``.  Ignored for non-panel data.
     facet_n_cols : int, default=2
         Number of columns in facet grid.
     color_palette : list[str] | None, default=None
@@ -289,9 +289,11 @@ def plot_spectrum(
     line_width : float, default=2.0
         Width of the line traces.
     show_peaks : bool, default=False
-        Whether to annotate dominant frequency peaks.
+        Whether to annotate dominant frequency peaks. Only has an effect in
+        non-panel mode; ignored when faceting panel data.
     n_peaks : int, default=3
-        Number of peaks to annotate when ``show_peaks`` is True.
+        Number of peaks to annotate when ``show_peaks`` is True. Only has an
+        effect in non-panel mode.
 
     Returns
     -------
@@ -336,7 +338,7 @@ def plot_spectrum(
 
         def _render_periodogram(ctx: RenderContext) -> None:
             """Render spectral periodogram with optional log scaling for a single column."""
-            base = [c for c in ctx.sub_df.columns if c != "time"][0]
+            base = ctx.display_name
             y_arr = ctx.sub_df[base].to_numpy()
             freqs, psd = scipy_periodogram(y_arr)
             ctx.fig.add_trace(

--- a/src/yohou/plotting/signal.py
+++ b/src/yohou/plotting/signal.py
@@ -117,7 +117,6 @@ def plot_phase(
     """
     use_degrees = angle_unit == "degree"
     unit = "degrees" if use_degrees else "radians"
-    validate_plotting_data(df)
     validate_plotting_params(width=width, height=height)
 
     # Auto-detect panel data
@@ -125,6 +124,7 @@ def plot_phase(
         groups = []
 
     if groups is not None:
+        validate_plotting_data(df)
         _panel_cols = resolve_panel_columns(df, groups, columns)
         _panel_colors = resolve_color_palette(color_palette, len(_panel_cols))
         _legend_tracker = LegendTracker()
@@ -324,7 +324,6 @@ def plot_spectrum(
     [`plot_phase`][yohou.plotting.plot_phase] : Plot phase spectrum.
     """
     # Validate inputs
-    validate_plotting_data(df)
     validate_plotting_params(width=width, height=height)
 
     # Auto-detect panel data
@@ -332,6 +331,7 @@ def plot_spectrum(
         groups = []
 
     if groups is not None:
+        validate_plotting_data(df)
         _panel_cols = resolve_panel_columns(df, groups, columns)
         _panel_colors = resolve_color_palette(color_palette, len(_panel_cols))
         _legend_tracker = LegendTracker()

--- a/src/yohou/point/base.py
+++ b/src/yohou/point/base.py
@@ -21,7 +21,7 @@ class BasePointForecaster(BaseForecaster, metaclass=abc.ABCMeta):
     target_transformer : instance of `BaseTransformer` or None, default=None
         Transformer used to transform the target time series into the new target.
     feature_transformer : instance of `BaseTransformer` or None, default=None
-        Transformer used to transform the target time series into features.
+        Transformer used to transform the feature time series (``X_actual``) into features.
     target_as_feature : {"transformed", "raw"} or None, default="transformed"
         Controls whether the target is included as a feature.
         ``"transformed"`` includes the transformed target, ``"raw"``
@@ -34,6 +34,11 @@ class BasePointForecaster(BaseForecaster, metaclass=abc.ABCMeta):
     Subclasses must implement ``_predict_one`` to produce point
     predictions for a single forecast step.  The ``forecaster_type``
     tag is set to ``POINT``.
+
+    Concrete naive forecasters (``SeasonalNaive``, ``MeanSeasonalNaive``)
+    fix ``target_transformer``, ``feature_transformer``, and
+    ``target_as_feature`` to ``None`` and do not expose them as constructor
+    parameters.
 
     See Also
     --------
@@ -187,7 +192,10 @@ class BasePointForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         sklearn.exceptions.NotFittedError
             If the forecaster has not been fitted yet.
         ValueError
-            If ``groups`` contains names not seen during fit.
+            If ``groups`` contains names not seen during fit, or if
+            ``forecasting_horizon > fit_forecasting_horizon_`` and the
+            forecaster was fitted with ``X_forecast`` (recursive prediction
+            cannot re-derive vintage-dependent step columns across blocks).
 
         """
         check_is_fitted(
@@ -215,12 +223,12 @@ class BasePointForecaster(BaseForecaster, metaclass=abc.ABCMeta):
 
         def derive_observation_fn(forecaster, y_pred_step_inv):
             """Derive observation from inverse-transformed prediction."""
-            if self.groups_ is None:
-                y = y_pred_step_inv.select(["time"] + list(self.local_y_schema_.keys()))
+            if forecaster.groups_ is None:
+                y = y_pred_step_inv.select(["time"] + list(forecaster.local_y_schema_.keys()))
             else:
                 y_columns = ["time"]
-                for group_name in self.groups_:
-                    y_columns.extend([f"{group_name}__{col}" for col in self.local_y_schema_])
+                for group_name in forecaster.groups_:
+                    y_columns.extend([f"{group_name}__{col}" for col in forecaster.local_y_schema_])
                 y = y_pred_step_inv.select(y_columns)
             return y
 
@@ -274,17 +282,21 @@ class BasePointForecaster(BaseForecaster, metaclass=abc.ABCMeta):
             data.
         stride : int or None, default=None
             Step size for rolling update-predict.  If ``None``, defaults to
-            ``forecasting_horizon``.
+            ``fit_forecasting_horizon_`` (the horizon used at fit time).
         predict_transformed : bool, default=False
             If ``True``, return predictions in the transformed space without
             applying inverse target transformation.
         X_future : pl.DataFrame or None, default=None
-            Known future features with a ``"time"`` column.
+            Known future features with a ``"time"`` column. Silently ignored
+            (with a ``UserWarning``) when the forecaster has
+            ``requires_exogenous=False``.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"``
             columns. Vintage times do not need to align exactly with
             observation times; the latest vintage at or before each
             observation time is selected automatically (as-of matching).
+            Silently ignored (with a ``UserWarning``) when the forecaster
+            has ``requires_exogenous=False``.
         **params : dict
             Metadata to route to nested estimators.
 

--- a/src/yohou/point/naive.py
+++ b/src/yohou/point/naive.py
@@ -15,6 +15,30 @@ from .base import BasePointForecaster
 __all__ = ["MeanSeasonalNaive", "SeasonalNaive"]
 
 
+def _tile_to_horizon(pattern: pl.DataFrame, horizon: int, seasonality: int) -> pl.DataFrame:
+    """Repeat a seasonal pattern cyclically to fill the forecasting horizon.
+
+    Parameters
+    ----------
+    pattern : pl.DataFrame
+        Seasonal pattern (value columns only, no ``"time"`` column).
+    horizon : int
+        Number of rows to produce.
+    seasonality : int
+        Seasonal period length of ``pattern``.
+
+    Returns
+    -------
+    pl.DataFrame
+        ``pattern`` repeated and trimmed to ``horizon`` rows.
+
+    """
+    if horizon > seasonality:
+        n_repeats = (horizon + seasonality - 1) // seasonality
+        pattern = pl.concat([pattern] * n_repeats)
+    return pattern.head(horizon)
+
+
 class SeasonalNaive(BasePointForecaster):
     """Seasonal naive forecaster that repeats values from previous season.
 
@@ -111,7 +135,7 @@ class SeasonalNaive(BasePointForecaster):
         groups: list[str],
         **params,
     ) -> pl.DataFrame:
-        """Predicts `_fit_forecasting_horizon` steps from the observation horizon.
+        """Predict ``fit_forecasting_horizon_`` steps from the observation horizon.
 
         Parameters
         ----------
@@ -129,13 +153,8 @@ class SeasonalNaive(BasePointForecaster):
         # Non-panel data
         if self.groups_ is None:
             assert isinstance(self._y_observed, pl.DataFrame)
-            y_pred = self._y_observed.select(~cs.by_name("time"))
-            if self.fit_forecasting_horizon_ > self.seasonality:
-                # Number of full repetitions needed
-                n_repeats = int((self.fit_forecasting_horizon_ + self.seasonality - 1) // self.seasonality)
-                y_pred = pl.concat([y_pred] * n_repeats)
-
-            y_pred = y_pred.head(self.fit_forecasting_horizon_)
+            pattern = self._y_observed.select(~cs.by_name("time"))
+            y_pred = _tile_to_horizon(pattern, self.fit_forecasting_horizon_, self.seasonality)
 
         # Panel data
         else:
@@ -144,14 +163,8 @@ class SeasonalNaive(BasePointForecaster):
             for panel_group_name in groups:
                 y_group = self._y_observed[panel_group_name]
                 assert isinstance(y_group, pl.DataFrame)
-                y_pred_group = y_group.select(~cs.by_name("time"))
-
-                if self.fit_forecasting_horizon_ > self.seasonality:
-                    # Number of full repetitions needed
-                    n_repeats = (self.fit_forecasting_horizon_ + self.seasonality - 1) // self.seasonality
-                    y_pred_group = pl.concat([y_pred_group] * n_repeats)
-
-                y_pred_group = y_pred_group.head(self.fit_forecasting_horizon_)
+                pattern = y_group.select(~cs.by_name("time"))
+                y_pred_group = _tile_to_horizon(pattern, self.fit_forecasting_horizon_, self.seasonality)
 
                 # Rename columns to add panel prefix
                 y_pred_group = y_pred_group.rename({col: f"{panel_group_name}__{col}" for col in y_pred_group.columns})
@@ -291,11 +304,15 @@ class MeanSeasonalNaive(BasePointForecaster):
         if self.n_seasons == 1:
             return y_values
 
-        result = {}
-        for col in y_values.columns:
-            values = y_values[col].to_numpy().reshape(self.n_seasons, self.seasonality)
-            result[col] = values.mean(axis=0).tolist()
-        return pl.DataFrame(result)
+        return (
+            y_values
+            .with_row_index("_pos")
+            .with_columns((pl.col("_pos") % self.seasonality).alias("_pos"))
+            .group_by("_pos", maintain_order=True)
+            .agg(pl.all().mean())
+            .sort("_pos")
+            .drop("_pos")
+        )
 
     def _predict_one(
         self,
@@ -321,13 +338,8 @@ class MeanSeasonalNaive(BasePointForecaster):
         if self.groups_ is None:
             assert isinstance(self._y_observed, pl.DataFrame)
             y_values = self._y_observed.select(~cs.by_name("time"))
-            y_pred = self._compute_mean_pattern(y_values)
-
-            if self.fit_forecasting_horizon_ > self.seasonality:
-                n_repeats = int((self.fit_forecasting_horizon_ + self.seasonality - 1) // self.seasonality)
-                y_pred = pl.concat([y_pred] * n_repeats)
-
-            y_pred = y_pred.head(self.fit_forecasting_horizon_)
+            pattern = self._compute_mean_pattern(y_values)
+            y_pred = _tile_to_horizon(pattern, self.fit_forecasting_horizon_, self.seasonality)
 
         # Panel data
         else:
@@ -337,13 +349,8 @@ class MeanSeasonalNaive(BasePointForecaster):
                 y_group = self._y_observed[panel_group_name]
                 assert isinstance(y_group, pl.DataFrame)
                 y_values = y_group.select(~cs.by_name("time"))
-                y_pred_group = self._compute_mean_pattern(y_values)
-
-                if self.fit_forecasting_horizon_ > self.seasonality:
-                    n_repeats = (self.fit_forecasting_horizon_ + self.seasonality - 1) // self.seasonality
-                    y_pred_group = pl.concat([y_pred_group] * n_repeats)
-
-                y_pred_group = y_pred_group.head(self.fit_forecasting_horizon_)
+                pattern = self._compute_mean_pattern(y_values)
+                y_pred_group = _tile_to_horizon(pattern, self.fit_forecasting_horizon_, self.seasonality)
 
                 # Rename columns to add panel prefix
                 y_pred_group = y_pred_group.rename({col: f"{panel_group_name}__{col}" for col in y_pred_group.columns})

--- a/src/yohou/point/reduction.py
+++ b/src/yohou/point/reduction.py
@@ -212,7 +212,10 @@ class PointReductionForecaster(BaseReductionForecaster, BasePointForecaster):
             feature transformer.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"``
-            columns. Bypasses the feature transformer.
+            columns. Bypasses the feature transformer. When provided,
+            recursive prediction (``forecasting_horizon > fit_forecasting_horizon_``
+            at predict time) is not supported and raises a ``ValueError``;
+            use ``ForecastedFeatureForecaster`` for that use case.
         **params : dict
             Metadata to route to nested estimators.
 
@@ -246,7 +249,7 @@ class PointReductionForecaster(BaseReductionForecaster, BasePointForecaster):
         groups: list[str],
         **params,
     ) -> pl.DataFrame:
-        """Predicts `_fit_forecasting_horizon` steps from the observation horizon.
+        """Predict ``fit_forecasting_horizon_`` steps from the observation horizon.
 
         Parameters
         ----------

--- a/src/yohou/preprocessing/calendar.py
+++ b/src/yohou/preprocessing/calendar.py
@@ -267,7 +267,9 @@ class HolidayFeatureTransformer(BaseTransformer):
     ----------
     holidays : pl.DataFrame or None, default=None
         DataFrame with a ``"date"`` column containing holiday dates.
-        The column must be of ``Date`` or ``Datetime`` type.
+        The column must be of ``Date`` or ``Datetime`` type. ``None`` is only
+        a signature default; a DataFrame must be supplied before calling
+        ``fit`` (passing ``None`` raises ``ValueError`` at fit time).
     days_to_next : bool, default=False
         If ``True``, produce a ``holiday_days_to_next`` integer column
         with the number of days until the next holiday (null if none).
@@ -279,6 +281,12 @@ class HolidayFeatureTransformer(BaseTransformer):
     ----------
     holiday_dates_ : list of date
         Sorted list of holiday dates used for matching.
+
+    Raises
+    ------
+    ValueError
+        At fit time if ``holidays`` is ``None``, is not a polars DataFrame,
+        lacks a ``"date"`` column, or that column is not a Date/Datetime type.
 
     See Also
     --------
@@ -362,10 +370,7 @@ class HolidayFeatureTransformer(BaseTransformer):
 
         """
         dates = X["time"].cast(pl.Date)
-        holiday_set = set(self.holiday_dates_)
-        is_holiday = dates.map_elements(lambda d: 1 if d in holiday_set else 0, return_dtype=pl.Int32).alias(
-            f"{self._PREFIX}_indicator"
-        )
+        is_holiday = dates.is_in(self.holiday_dates_).cast(pl.Int32).alias(f"{self._PREFIX}_indicator")
 
         new_cols = [is_holiday]
 
@@ -391,27 +396,25 @@ class HolidayFeatureTransformer(BaseTransformer):
                         )
                     )
             else:
-                idx_next = np.searchsorted(holiday_arr, dates_arr, side="left")
-                idx_prev = idx_next - 1
-
                 if self.days_to_next:
-                    to_next = []
-                    for i, idx in enumerate(idx_next):
-                        if idx < len(holiday_arr):
-                            delta = int((holiday_arr[idx] - dates_arr[i]) / np.timedelta64(1, "D"))
-                            to_next.append(delta)
-                        else:
-                            to_next.append(None)
+                    # Smallest holiday h with h >= t (side="left" includes exact matches).
+                    idx_next = np.searchsorted(holiday_arr, dates_arr, side="left")
+                    valid = idx_next < len(holiday_arr)
+                    deltas = (holiday_arr[np.clip(idx_next, 0, len(holiday_arr) - 1)] - dates_arr) // np.timedelta64(
+                        1, "D"
+                    )
+                    to_next = [int(d) if v else None for d, v in zip(deltas, valid, strict=True)]
                     new_cols.append(pl.Series(f"{self._PREFIX}_days_to_next", to_next, dtype=pl.Int32))
 
                 if self.days_since_last:
-                    since_last = []
-                    for i, idx in enumerate(idx_prev):
-                        if idx >= 0:
-                            delta = int((dates_arr[i] - holiday_arr[idx]) / np.timedelta64(1, "D"))
-                            since_last.append(delta)
-                        else:
-                            since_last.append(None)
+                    # Largest holiday h with h <= t (side="right" minus 1 includes exact matches,
+                    # so a date that is itself a holiday yields 0).
+                    idx_prev = np.searchsorted(holiday_arr, dates_arr, side="right") - 1
+                    valid = idx_prev >= 0
+                    deltas = (dates_arr - holiday_arr[np.clip(idx_prev, 0, len(holiday_arr) - 1)]) // np.timedelta64(
+                        1, "D"
+                    )
+                    since_last = [int(d) if v else None for d, v in zip(deltas, valid, strict=True)]
                     new_cols.append(pl.Series(f"{self._PREFIX}_days_since_last", since_last, dtype=pl.Int32))
 
         return X.select(pl.col("time")).with_columns(*new_cols)

--- a/src/yohou/preprocessing/function.py
+++ b/src/yohou/preprocessing/function.py
@@ -382,8 +382,8 @@ class FunctionTransformer(BaseTransformer):
             more numeric columns.
         X_p : pl.DataFrame or None, default=None
             Past observations to prepend before transformation. If provided
-            and warmup_ > 0, the function is applied to the concatenation of
-            X_p and X, then only the X portion is returned.
+            and ``_observation_horizon > 0``, the function is applied to the
+            concatenation of X_p and X, then only the X portion is returned.
         **params : dict
             Metadata to route to nested estimators.
 
@@ -392,6 +392,13 @@ class FunctionTransformer(BaseTransformer):
         pl.DataFrame
             Transformed time series with a ``"time"`` column and transformed
             value columns.
+
+        Notes
+        -----
+        When ``X_p`` is ``None`` and ``_observation_horizon > 0``, the first
+        ``_observation_horizon`` rows (which contain NaN from insufficient
+        history) are dropped, so the output is shorter than the input. Pass
+        ``X_p`` to avoid this row loss.
 
         """
         check_is_fitted(self, ["X_schema_", "feature_names_in_", "n_features_in_", "_observation_horizon"])

--- a/src/yohou/preprocessing/imputation.py
+++ b/src/yohou/preprocessing/imputation.py
@@ -14,6 +14,7 @@ from yohou.base import BaseTransformer
 from yohou.preprocessing.sklearn_base import SklearnTransformer
 from yohou.utils import Tags, validate_transformer_data
 from yohou.utils._compat import Interval, StrOptions, _check_feature_names_in, _fit_context
+from yohou.utils.validation import interval_to_timedelta
 
 __all__ = [
     "SeasonalImputer",
@@ -44,6 +45,9 @@ class SimpleImputer(SklearnTransformer):
     missing_values : int, float, str, or np.nan, default=np.nan
         The placeholder for missing values. All occurrences of missing_values
         will be imputed.
+    copy : bool, default=True
+        Passed through to sklearn's SimpleImputer to control whether a copy of
+        X is created. If False, imputation may be done in-place where possible.
 
     Attributes
     ----------
@@ -150,7 +154,9 @@ class TransformedSpaceKNNImputer(BaseTransformer):
     >>> X_imputed["value"].null_count()
     0
 
-    With a lag transformer (window-based KNN):
+    With a lag transformer the imputation happens in the projected lag space,
+    so the output contains the lag columns (``value_lag_1``, ``value_lag_2``,
+    ``value_lag_3``), not the original ``value`` column:
 
     >>> from yohou.preprocessing import LagTransformer
     >>> X = pl.DataFrame({
@@ -164,7 +170,7 @@ class TransformedSpaceKNNImputer(BaseTransformer):
     >>> imputer.fit(X)
     TransformedSpaceKNNImputer(...)
     >>> X_t = imputer.transform(X)
-    >>> X_t["value_lag_3"].null_count()
+    >>> X_t["value_lag_3"].null_count()  # null count in the lag-space output
     0
 
     See Also
@@ -244,14 +250,16 @@ class TransformedSpaceKNNImputer(BaseTransformer):
             self.transformer_ = deepcopy(self.transformer)
             self.transformer_.fit(X)
             X_projected = self.transformer_.transform(X)
-            # Inherit observation_horizon from the inner transformer
-            if hasattr(self.transformer_, "_observation_horizon"):
-                self._observation_horizon = self.transformer_.observation_horizon
         else:
             self.transformer_ = None
             X_projected = X
 
         BaseTransformer.fit(self, X, y, **params)
+
+        # Inherit observation_horizon from the inner transformer after the base
+        # fit, so it is not overwritten by BaseTransformer.fit's own sync step.
+        if self.transformer_ is not None:
+            self._observation_horizon = self.transformer_.observation_horizon
 
         # Fit sklearn KNNImputer on the (optionally transformed) data
         X_no_time = X_projected.select(~cs.by_name("time"))
@@ -449,8 +457,26 @@ class SimpleTimeImputer(BaseTransformer):
             elif self.method_ == "backward":
                 imputed = col.backward_fill(limit=self.limit)
             elif self.method_ == "nearest":
-                # Use forward then backward to get nearest
-                imputed = col.forward_fill().backward_fill()
+                # Fill each null with the value closest in time, comparing the
+                # distance to the previous and next known observations. Ties go
+                # to the trailing (forward) anchor.
+                known_time = pl.when(col.is_not_null()).then(pl.col("time")).otherwise(None)
+                prev_val = col.forward_fill(limit=self.limit)
+                next_val = col.backward_fill(limit=self.limit)
+                prev_time = known_time.forward_fill(limit=self.limit)
+                next_time = known_time.backward_fill(limit=self.limit)
+                imputed = (
+                    pl
+                    .when(col.is_not_null())
+                    .then(col)
+                    .when(prev_val.is_null())
+                    .then(next_val)
+                    .when(next_val.is_null())
+                    .then(prev_val)
+                    .when((next_time - pl.col("time")) < (pl.col("time") - prev_time))
+                    .then(next_val)
+                    .otherwise(prev_val)
+                )
             elif self.method_ == "fill_both":
                 # Forward fill then backward fill
                 imputed = col.forward_fill(limit=self.limit).backward_fill(limit=self.limit)
@@ -485,8 +511,10 @@ class SeasonalImputer(BaseTransformer):
     """Seasonal decomposition-based imputation for missing values.
 
     Imputes missing values by leveraging seasonal patterns in the data.
-    Missing values are replaced with the seasonally-adjusted expected value
-    based on the seasonal component estimated from non-missing data.
+    Missing values are replaced with the mean (or median) of the non-missing
+    observations that fall at the same position within each seasonal cycle.
+    This is simple modular averaging by season, not a trend/seasonal
+    decomposition.
 
     Parameters
     ----------
@@ -546,6 +574,20 @@ class SeasonalImputer(BaseTransformer):
         self.period = period
         self.fill_method = fill_method
 
+    def _season_index_expr(self) -> pl.Expr:
+        """Build a polars expression for the time-anchored season index.
+
+        The index counts whole sampling steps between each timestamp and the
+        first fitted timestamp, modulo ``period``. This keeps the seasonal
+        bucket of any timestamp stable regardless of where a transform slice
+        starts.
+        """
+        if self._step_seconds_ is None:
+            # Irregular interval: fall back to row position within the frame.
+            return pl.arange(0, pl.len()) % self.period
+        offset = (pl.col("time") - self._first_time_).dt.total_seconds() / self._step_seconds_
+        return (offset.round().cast(pl.Int64) % self.period).cast(pl.Int64)
+
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X: pl.DataFrame, y: pl.DataFrame | None = None, **params) -> "SeasonalImputer":
         """Fit the imputer by computing seasonal values.
@@ -569,33 +611,38 @@ class SeasonalImputer(BaseTransformer):
         X = validate_transformer_data(self, X=X, reset=True)
         BaseTransformer.fit(self, X, y, **params)
 
+        # Anchor the season index to the first observed timestamp so that
+        # transform on any sub-range of the series uses the same seasonal
+        # bucket as fit did for the same timestamps.
+        self._first_time_ = X["time"][0]
+        step = interval_to_timedelta(self.interval_)
+        self._step_seconds_ = step.total_seconds() if step is not None else None
+
         # Compute seasonal values for each column
         data_cols = [c for c in X.columns if c != "time"]
         self.seasonal_values_: dict[str, np.ndarray] = {}
 
         # Add season index
-        X_with_season = X.with_columns((pl.arange(0, len(X)) % self.period).alias("_season_idx"))
+        X_with_season = X.with_columns(self._season_index_expr().alias("_season_idx"))
+
+        # Aggregate all columns per season in a single grouped pass. Nulls and
+        # NaNs are excluded so empty seasons remain null (mapped to NaN below).
+        def _stat(col: str) -> pl.Expr:
+            """Per-season mean or median of ``col``, ignoring nulls and NaNs."""
+            expr = pl.col(col).fill_nan(None).drop_nulls()
+            return (expr.mean() if self.fill_method == "seasonal_mean" else expr.median()).alias(col)
+
+        season_stats = X_with_season.group_by("_season_idx").agg([_stat(c) for c in data_cols])
+
+        # Index aggregated rows by season for direct lookup.
+        stats_by_season = {row["_season_idx"]: row for row in season_stats.to_dicts()}
 
         for col_name in data_cols:
-            seasonal_vals = np.zeros(self.period)
-
+            seasonal_vals = np.full(self.period, np.nan)
             for season_idx in range(self.period):
-                season_data = (
-                    X_with_season
-                    .filter(pl.col("_season_idx") == season_idx)[col_name]
-                    .drop_nulls()
-                    .drop_nans()
-                    .to_numpy()
-                )
-
-                if len(season_data) > 0:
-                    if self.fill_method == "seasonal_mean":
-                        seasonal_vals[season_idx] = np.mean(season_data)
-                    else:  # seasonal_median
-                        seasonal_vals[season_idx] = np.median(season_data)
-                else:
-                    seasonal_vals[season_idx] = np.nan
-
+                row = stats_by_season.get(season_idx)
+                if row is not None and row[col_name] is not None:
+                    seasonal_vals[season_idx] = row[col_name]
             self.seasonal_values_[col_name] = seasonal_vals
 
         return self
@@ -617,6 +664,9 @@ class SeasonalImputer(BaseTransformer):
         # Get data columns
         data_cols = [c for c in X.columns if c != "time"]
 
+        # Time-anchored season index for each row of this slice.
+        season_idx_arr = X.select(self._season_index_expr().alias("_season_idx"))["_season_idx"].to_numpy()
+
         # Impute each column
         result_cols = {"time": X["time"]}
 
@@ -630,8 +680,7 @@ class SeasonalImputer(BaseTransformer):
 
                 # Replace with seasonal values
                 for i in np.where(null_mask)[0]:
-                    season_idx = i % self.period
-                    values[i] = seasonal_vals[season_idx]
+                    values[i] = seasonal_vals[season_idx_arr[i]]
 
             result_cols[col_name] = pl.Series(values)
 

--- a/src/yohou/preprocessing/resampling.py
+++ b/src/yohou/preprocessing/resampling.py
@@ -24,8 +24,8 @@ class Downsampler(BaseTransformer):
     ----------
     interval : str
         Target time interval (e.g., "1h", "1d", "5m", "30s").
-        Uses polars duration string syntax. Must be larger than the input
-        data's interval.
+        Uses polars duration string syntax. Must be greater than or equal to
+        the input data's interval.
     aggregation : {"mean", "sum", "min", "max", "first", "last", "median"}, default="mean"
         Aggregation function to apply within each time bin:
         - "mean": Average values in each bin
@@ -174,6 +174,13 @@ class Downsampler(BaseTransformer):
             .agg(agg_exprs)
         )
 
+        # group_by_dynamic prepends _lower_boundary/_upper_boundary columns when
+        # include_boundaries=True; drop them so the output schema is just "time"
+        # plus the original feature columns (they are not reported by
+        # get_feature_names_out and duplicate the "time" anchor).
+        if self.include_boundaries:
+            result = result.drop(["_lower_boundary", "_upper_boundary"], strict=False)
+
         return result
 
     def get_feature_names_out(self, input_features: list[str] | None = None) -> list[str]:
@@ -212,7 +219,7 @@ class Upsampler(BaseTransformer):
     interpolation : {"linear", "nearest", "forward", "backward"}, default="linear"
         Interpolation method to fill new time points:
         - "linear": Linear interpolation between known points
-        - "nearest": Use nearest known value (forward then backward fill)
+        - "nearest": Use the known value closest in time (ties go to the following value)
         - "forward": Forward fill (carry last observation forward)
         - "backward": Backward fill (carry next observation backward)
 
@@ -309,8 +316,8 @@ class Upsampler(BaseTransformer):
         time_min = X["time"].min()
         time_max = X["time"].max()
 
-        # Assert non-null (X should have at least one row after fit validation)
-        assert time_min is not None and time_max is not None, "Empty time series"
+        if time_min is None or time_max is None:
+            raise ValueError("Upsampler received an empty time series.")
 
         # Generate new timestamps (cast to datetime for type narrowing)
         new_times = pl.datetime_range(
@@ -329,9 +336,29 @@ class Upsampler(BaseTransformer):
             for col in data_cols:
                 joined = joined.with_columns(pl.col(col).interpolate())
         elif self.interpolation == "nearest":
-            # Forward fill then backward fill for nearest approximation
+            # Fill each new timestamp with the value closest in time, comparing
+            # distance to the previous and next known observations. Ties go to
+            # the trailing (forward) anchor.
             for col in data_cols:
-                joined = joined.with_columns(pl.col(col).fill_null(strategy="forward").fill_null(strategy="backward"))
+                value = pl.col(col)
+                known_time = pl.when(value.is_not_null()).then(pl.col("time")).otherwise(None)
+                prev_val = value.forward_fill()
+                next_val = value.backward_fill()
+                prev_time = known_time.forward_fill()
+                next_time = known_time.backward_fill()
+                joined = joined.with_columns(
+                    pl
+                    .when(value.is_not_null())
+                    .then(value)
+                    .when(prev_val.is_null())
+                    .then(next_val)
+                    .when(next_val.is_null())
+                    .then(prev_val)
+                    .when((next_time - pl.col("time")) < (pl.col("time") - prev_time))
+                    .then(next_val)
+                    .otherwise(prev_val)
+                    .alias(col)
+                )
         elif self.interpolation == "forward":
             for col in data_cols:
                 joined = joined.with_columns(pl.col(col).forward_fill())

--- a/src/yohou/preprocessing/signal.py
+++ b/src/yohou/preprocessing/signal.py
@@ -224,6 +224,37 @@ class NumericalFilter(BaseTransformer):
 
         return pl.DataFrame(result_cols)
 
+    def observe_transform(self, X: pl.DataFrame, **params) -> pl.DataFrame:
+        """Transform new data and update state without clearing filter delays.
+
+        The base ``observe_transform`` routes through ``rewind()``, which would
+        clear the filter delay state ``zi_`` and reintroduce chunk-boundary
+        transients. This override preserves ``zi_`` so streaming/chunked
+        processing continues seamlessly.
+
+        Parameters
+        ----------
+        X : pl.DataFrame
+            Input time series with a ``"time"`` column (datetime) and one or
+            more numeric columns.
+        **params : dict
+            Metadata to route to nested estimators.
+
+        Returns
+        -------
+        pl.DataFrame
+            Transformed time series with a ``"time"`` column and transformed
+            value columns.
+
+        """
+        check_is_fitted(self, ["X_schema_", "feature_names_in_", "n_features_in_"])
+        X = validate_transformer_data(self, X=X, reset=False, check_continuity=True)
+
+        X_t = self.transform(X, **params)
+        # Update observed window without clearing the filter delay state.
+        self._update_X_observed(X)
+        return X_t
+
     def get_feature_names_out(self, input_features: list[str] | None = None) -> list[str]:
         """Get output feature names for transformation.
 
@@ -288,8 +319,9 @@ class NumericalIntegrator(BaseTransformer):
     **Statefulness**: The integrator maintains the last transformed value
     between transform calls via ``_X_t_observed_``. This enables accurate
     streaming integration where each chunk continues seamlessly from the
-    previous one. The last input values are stored in ``_X_observed`` for
-    proper trapezoid boundary calculation.
+    previous one. The last input values are stored in ``_last_X_value_`` for
+    proper trapezoid boundary calculation (this is a per-column last-input
+    buffer, distinct from the parent-class ``_X_observed`` observation window).
 
     Use ``rewind()`` to clear the integration state and start fresh.
 
@@ -381,9 +413,12 @@ class NumericalIntegrator(BaseTransformer):
         for col_name in data.columns:
             col_values = data[col_name].to_numpy()
 
-            # Handle chunk boundary with trapezoid rule
+            # Handle the single inter-chunk interval with the trapezoid rule.
+            # This bridge applies regardless of the intra-chunk integration
+            # order (trapezoid or simpson); a single interval has no Simpson
+            # form, so the trapezoidal half-step is the correct correction.
             boundary_integral = 0.0
-            if col_name in self._last_X_value_ and self.method == "cumulative_trapezoid":
+            if col_name in self._last_X_value_:
                 # Add half-step for proper boundary: 0.5 * (last + first) * dt
                 last_val = self._last_X_value_[col_name]
                 boundary_integral = 0.5 * (last_val + col_values[0]) * dt
@@ -434,29 +469,6 @@ class NumericalIntegrator(BaseTransformer):
         self._update_X_observed(X)
         return X_t
 
-    def fit_transform(self, X: pl.DataFrame, y: pl.DataFrame | None = None, **params) -> pl.DataFrame:
-        """Fit and transform in one step.
-
-        Parameters
-        ----------
-        X : pl.DataFrame
-            Input time series with a ``"time"`` column (datetime) and one or
-            more numeric columns.
-        y : pl.DataFrame or None, default=None
-            Ignored.  Present for API compatibility.
-        **params : dict
-            Metadata to route to nested estimators.
-
-        Returns
-        -------
-        pl.DataFrame
-            Transformed time series with a ``"time"`` column and transformed
-            value columns.
-
-        """
-        self.fit(X, y)
-        return self.transform(X, **params)
-
     def _inverse_transform(self, X_t: pl.DataFrame, X_p: pl.DataFrame | None = None) -> pl.DataFrame:
         """Differentiate to reverse integration.
 
@@ -465,7 +477,8 @@ class NumericalIntegrator(BaseTransformer):
         X_t : pl.DataFrame
             Integrated time series.
         X_p : pl.DataFrame or None
-            Not used for this stateless transformer.
+            Not used; the inverse is applied statically regardless of the
+            running integration state.
 
         Returns
         -------

--- a/src/yohou/preprocessing/sklearn_base.py
+++ b/src/yohou/preprocessing/sklearn_base.py
@@ -213,6 +213,12 @@ class SklearnTransformer(BaseClassWrapper, BaseTransformer):
         time = X.select(cs.by_name("time"))
         X_no_time = X.select(~cs.by_name("time"))
 
+        # An empty observe window (e.g. observation_horizon == 0 during rewind)
+        # yields a zero-row frame. sklearn's check_array rejects 0 samples, so
+        # short-circuit: an empty input transforms to an empty output.
+        if X_no_time.height == 0:
+            return X
+
         # Apply scaling transformation
         X_scaled_no_time = self.instance_.transform(X_no_time)
 

--- a/src/yohou/preprocessing/sklearn_base.py
+++ b/src/yohou/preprocessing/sklearn_base.py
@@ -2,7 +2,7 @@
 
 This module provides ``SklearnTransformer`` and ``SklearnScaler``, wrappers that integrate
 sklearn transformers and scalers into the Yohou pipeline. It preserves polars DataFrame
-structure and the "time" column while applying sklearn scaling transformations to numeric
+structure and the "time" column while applying sklearn transformations to numeric
 columns.
 """
 
@@ -58,7 +58,7 @@ class SklearnTransformer(BaseClassWrapper, BaseTransformer):
     """Wrapper to integrate sklearn transformers into the Yohou pipeline.
 
     Preserves the polars DataFrame structure and "time" column while applying
-    sklearn scaling transformations to numeric columns.
+    sklearn transformations to numeric columns.
 
     This class can be used to:
 
@@ -145,8 +145,8 @@ class SklearnTransformer(BaseClassWrapper, BaseTransformer):
     def fit(self, X: pl.DataFrame, y: pl.DataFrame | None = None, **params) -> "SklearnTransformer":
         """Fit the transformer to the data.
 
-        Computes scaling parameters (e.g., mean, std, min, max) from the
-        training data, excluding the "time" column.
+        Fits the underlying sklearn transformer on the training data,
+        excluding the "time" column.
 
         Parameters
         ----------
@@ -247,7 +247,7 @@ class SklearnTransformer(BaseClassWrapper, BaseTransformer):
 
         """
         check_is_fitted(self, ["instance_"])
-        X_t, _ = validate_transformer_data(self, X=X_t, reset=False, inverse=True, check_continuity=False)
+        X_t, _ = validate_transformer_data(self, X=X_t, reset=False, inverse=True)
 
         # Strip time column before inverse transforming
         time = X_t.select(cs.by_name("time"))

--- a/src/yohou/preprocessing/sklearn_wrappers.py
+++ b/src/yohou/preprocessing/sklearn_wrappers.py
@@ -529,6 +529,9 @@ class PolynomialFeatures(SklearnTransformer):
     n_output_features_ : int
         The total number of polynomial output features.
 
+    powers_ : ndarray of shape (n_output_features_, n_features_in_)
+        Exponent for each of the inputs in the output.
+
     Examples
     --------
     >>> import polars as pl
@@ -799,7 +802,9 @@ class SplineTransformer(SklearnTransformer):
         features will raise an error.
 
     include_bias : bool, default=True
-        If True, then the last spline element inside each bin is dropped.
+        If False, then the last spline element inside the data range of each
+        feature is dropped. Set to True (default) to keep it and include a
+        redundant basis column.
 
     order : {'C', 'F'}, default='C'
         Order of output array.

--- a/src/yohou/preprocessing/time_features.py
+++ b/src/yohou/preprocessing/time_features.py
@@ -10,6 +10,7 @@ from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted
 
 from yohou.base import BaseTransformer
+from yohou.utils.validation import interval_to_timedelta
 
 
 class FourierFeatureTransformer(BaseTransformer):
@@ -17,8 +18,9 @@ class FourierFeatureTransformer(BaseTransformer):
 
     Creates sin/cos feature pairs at specified harmonics of a given
     seasonal period, useful for encoding cyclical patterns as inputs
-    to reduction forecasters. Output columns are prefixed with
-    ``fourier_``.
+    to reduction forecasters. The output contains only the ``"time"``
+    column and the generated Fourier columns (prefixed with ``fourier_``);
+    all original input feature columns are dropped.
 
     For each harmonic $k$ and seasonal period $S$, the features at
     time step $t$ are:
@@ -103,6 +105,12 @@ class FourierFeatureTransformer(BaseTransformer):
 
         self.first_time_ = X["time"][0]
 
+        # Fixed sampling step (seconds) from the fitted interval, used so that
+        # transform produces consistent Fourier phases regardless of which
+        # sub-range of the series is passed (including single-row chunks).
+        step = interval_to_timedelta(self.interval_)
+        self._step_seconds_ = step.total_seconds() if step is not None else None
+
         s = f"{self.seasonality}"
         generated_names = []
         for k in self.harmonics_:
@@ -128,14 +136,26 @@ class FourierFeatureTransformer(BaseTransformer):
 
         """
         interval = self.interval_
-        time_diff = X["time"] - self.first_time_
+        first_time = self.first_time_
         if interval.endswith("mo") or interval.endswith("y"):
-            t = np.arange(len(X), dtype=np.float64)
+            # Anchor month/year offsets to the fitted first timestamp via
+            # calendar arithmetic, so phases continue past the fit origin.
+            months = (
+                ((X["time"].dt.year() - first_time.year) * 12 + (X["time"].dt.month() - first_time.month))
+                .to_numpy()
+                .astype(np.float64)
+            )
+            if interval.endswith("y"):
+                t = months / 12.0
+            else:
+                mo_count = int(interval.replace("mo", ""))
+                t = months / mo_count
         else:
-            t = time_diff.dt.total_seconds().to_numpy().astype(np.float64)
-            first_diff = (X["time"][1] - X["time"][0]).total_seconds() if len(X) > 1 else 1.0
-            if first_diff != 0:
-                t = t / first_diff
+            t = (X["time"] - first_time).dt.total_seconds().to_numpy().astype(np.float64)
+            # Normalise by the fixed sampling step from fit (not the spacing of
+            # the incoming chunk), avoiding wrong angles on single-row chunks.
+            if self._step_seconds_ and self._step_seconds_ != 0:
+                t = t / self._step_seconds_
 
         feature_cols = []
         s = f"{self.seasonality}"
@@ -176,7 +196,8 @@ class TimeIndexTransformer(BaseTransformer):
 
     Produces integer or normalized time step indices starting from the
     first observed timestamp, useful as trend features for reduction
-    forecasters.
+    forecasters. The output contains only the ``"time"`` column and the
+    generated index columns; all original input feature columns are dropped.
 
     The base index at time step $t$ is:
 

--- a/src/yohou/preprocessing/window.py
+++ b/src/yohou/preprocessing/window.py
@@ -591,9 +591,7 @@ class RollingStatisticsTransformer(BaseTransformer):
             return col.rolling_quantile(0.25, window_size=self.window_size)
         elif stat == "q75":
             return col.rolling_quantile(0.75, window_size=self.window_size)
-        else:
-            msg = f"Unknown statistic: {stat}"
-            raise ValueError(msg)
+        raise AssertionError("unreachable: statistic validated in _fit")
 
     def _transform(self, X: pl.DataFrame) -> pl.DataFrame:
         """Transform X by computing rolling statistics.

--- a/src/yohou/preprocessing/window.py
+++ b/src/yohou/preprocessing/window.py
@@ -10,8 +10,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from yohou.base import BaseTransformer
 from yohou.utils import tabularize, validate_transformer_data
-from yohou.utils._compat import Interval, _check_feature_names_in, _fit_context
-from yohou.utils.tags import Tags
+from yohou.utils._compat import Interval, _check_feature_names_in
 
 __all__ = [
     "ExponentialMovingAverage",
@@ -217,59 +216,21 @@ class MeanLagTransformer(BaseTransformer):
         "n_lags": [Interval(numbers.Integral, 1, None, closed="left")],
     }
 
+    _tags = {"stateful": True}
+
     def __init__(self, lag: StrictInt | list[StrictInt] = 1, n_lags: StrictInt = 1):
         self.lag = lag
         self.n_lags = n_lags
 
-    def __sklearn_tags__(self) -> Tags:
-        """Get estimator tags.
+    @property
+    def observation_horizon(self) -> int:  # noqa: D102
+        """Return the number of past observations needed."""
+        lags = self.lag if isinstance(self.lag, list) else [self.lag]
+        return max(lags) * self.n_lags
 
-        Returns
-        -------
-        Tags
-            Estimator tags with yohou-specific attributes.
-
-        """
-        tags = super().__sklearn_tags__()
-        assert tags.transformer_tags is not None
-        tags.transformer_tags.stateful = True
-        return tags
-
-    @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X: pl.DataFrame, y: pl.DataFrame | None = None, **params) -> "MeanLagTransformer":
-        """Fit the transformer to input data.
-
-        Parameters
-        ----------
-        X : pl.DataFrame
-            Input time series with a ``"time"`` column (datetime) and one or
-            more numeric columns.
-
-        y : pl.DataFrame or None, default=None
-            Ignored.  Present for API compatibility with yohou pipelines.
-
-        **params : dict
-            Metadata to route to nested estimators.
-
-        Returns
-        -------
-        self
-            The fitted transformer instance.
-
-        Raises
-        ------
-        ValueError
-            If ``X`` has fewer rows than ``max(lags) * n_lags``.
-
-        """
+    def _fit(self, X: pl.DataFrame, y: pl.DataFrame | None = None) -> None:
+        """Fit the internal model."""
         self.lags_: list[int] = self.lag if isinstance(self.lag, list) else [self.lag]
-
-        self._observation_horizon = max(self.lags_) * self.n_lags
-        X = validate_transformer_data(self, X=X, reset=True)
-
-        BaseTransformer.fit(self, X, y, **params)
-
-        return self
 
     def transform(self, X: pl.DataFrame, **params) -> pl.DataFrame:
         """Transform the input time series.
@@ -435,7 +396,6 @@ class SlidingWindowFunctionTransformer(BaseTransformer):
         # Apply function over sliding windows
         kwargs = self.kw_args if self.kw_args is not None else {}
         results = []
-        time_values = []
 
         n_rows = len(X)
         for i in range(n_rows - self.window_size + 1):
@@ -452,13 +412,10 @@ class SlidingWindowFunctionTransformer(BaseTransformer):
             else:
                 results.append({col: float(result) for col in data_cols})
 
-            # Time index is always the last point in the window
-            time_idx = i + self.window_size - 1
-            time_values.append(X["time"][time_idx])
-
-        # Build output DataFrame
+        # The output time is the last point of each window, i.e. a single slice
+        # of the original time column rather than per-iteration scalar lookups.
         result_df = pl.DataFrame(results)
-        time_df = pl.DataFrame({"time": time_values})
+        time_df = pl.DataFrame({"time": X["time"][self.window_size - 1 :]})
 
         return pl.concat([time_df, result_df], how="horizontal")
 

--- a/src/yohou/stationarity/base.py
+++ b/src/yohou/stationarity/base.py
@@ -14,6 +14,7 @@ from sklearn.pipeline import Pipeline
 from yohou.base import BaseTransformer
 from yohou.point import BasePointForecaster
 from yohou.utils._compat import StrOptions
+from yohou.utils.panel import get_group_df
 from yohou.utils.tags import Tags
 
 
@@ -179,7 +180,12 @@ class _BaseTrendForecaster(BasePointForecaster):
 
         # Panel data
         if groups is not None:
-            first_observed_time = dict.fromkeys(groups, y["time"][target_observation_horizon])
+            first_observed_time = {
+                group: get_group_df(df=y, group_name=group, schema=self.local_y_schema_)["time"][
+                    target_observation_horizon
+                ]
+                for group in groups
+            }
             self._first_observed_time |= first_observed_time
 
         # Non-panel data

--- a/src/yohou/stationarity/base.py
+++ b/src/yohou/stationarity/base.py
@@ -142,8 +142,8 @@ class _BaseTrendForecaster(BasePointForecaster):
             state to. Must align with ``y``.
         groups : list of str or None, default=None
             Group prefixes for panel data:
-            - If None: predict for all groups
-            - If list of str: predict only for the specified panel groups
+            - If None: rewinds observation state for all fitted groups
+            - If list of str: rewinds only the specified panel groups
             Parameter is ignored if the forecaster was not fitted on panel data.
         X_future : pl.DataFrame or None, default=None
             Known future features with a ``"time"`` column.
@@ -308,7 +308,7 @@ class _BaseTrendForecaster(BasePointForecaster):
         groups: list[str],
         **params,
     ) -> pl.DataFrame:
-        """Predicts `_fit_forecasting_horizon` steps from the observation horizon.
+        """Predicts `fit_forecasting_horizon_` steps from the observation horizon.
 
         Parameters
         ----------
@@ -375,8 +375,10 @@ class _BaseSeasonalityForecaster(_BaseTrendForecaster):
 
     Parameters
     ----------
-    seasonality : int
+    seasonality : int or float
         Length of seasonal cycle (number of time steps).
+        ``PatternSeasonalityForecaster`` requires an integer period, while
+        ``FourierSeasonalityForecaster`` accepts a float (e.g. ``365.25``).
     target_transformer : BaseTransformer, optional
         Transformer applied to target before forecasting.
     panel_strategy : {"global", "multivariate"}, default="global"
@@ -400,7 +402,7 @@ class _BaseSeasonalityForecaster(_BaseTrendForecaster):
 
         Parameters
         ----------
-        seasonality : int
+        seasonality : int or float
             Length of seasonal cycle.
         target_transformer : BaseTransformer, optional
             Transformer for target variable.

--- a/src/yohou/stationarity/seasonality.py
+++ b/src/yohou/stationarity/seasonality.py
@@ -1,6 +1,5 @@
 """Seasonality forecaster implementation."""
 
-import numbers
 from typing import Literal
 
 import numpy as np
@@ -12,7 +11,7 @@ from sklearn.linear_model import ElasticNet
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer
 
-from yohou.utils._compat import Interval, StrOptions
+from yohou.utils._compat import StrOptions
 
 from .base import _BaseSeasonalityForecaster
 
@@ -222,14 +221,10 @@ class PatternSeasonalityForecaster(_BaseSeasonalityForecaster):
             assert isinstance(truncated_length, int)
             y_truncated = y_t[:truncated_length]
 
-            # Add cycle and position indices
-            cycle_indices = [i // self.seasonality for i in range(truncated_length)]
-            position_indices = [i % self.seasonality for i in range(truncated_length)]
+            # Add the within-cycle position index for each row.
+            position_indices = pl.int_range(truncated_length, eager=True) % self.seasonality
 
-            y_with_indices = y_truncated.with_columns(
-                pl.Series("cycle", cycle_indices),
-                pl.Series("position", position_indices),
-            )
+            y_with_indices = y_truncated.with_columns(position_indices.alias("position"))
 
             # Group by position and aggregate
             if self.method == "average":
@@ -242,7 +237,7 @@ class PatternSeasonalityForecaster(_BaseSeasonalityForecaster):
                 ])
 
             # Sort by position to maintain order
-            pattern = pattern.sort("position").select(cs.all().exclude(["position", "cycle"]))
+            pattern = pattern.sort("position").select(cs.all().exclude("position"))
 
         return pattern
 
@@ -251,7 +246,7 @@ class PatternSeasonalityForecaster(_BaseSeasonalityForecaster):
         groups: list[str],
         **params,
     ) -> pl.DataFrame:
-        """Predicts `_fit_forecasting_horizon` steps from the observation horizon.
+        """Predicts `fit_forecasting_horizon_` steps from the observation horizon.
 
         Parameters
         ----------
@@ -281,9 +276,7 @@ class PatternSeasonalityForecaster(_BaseSeasonalityForecaster):
                     continue
 
                 # Extract values at specified phases
-                pattern_values = self.seasonal_pattern_[col_name].to_list()
-                pred_values = [pattern_values[phase] for phase in X_phases.to_list()]
-                y_pred[col_name] = pred_values
+                y_pred[col_name] = self.seasonal_pattern_[col_name].gather(X_phases)
 
             y_pred = pl.DataFrame(y_pred)
 
@@ -304,9 +297,7 @@ class PatternSeasonalityForecaster(_BaseSeasonalityForecaster):
                 y_pred_group = {}
                 for col_name in y_t_columns:
                     # Extract values at specified phases
-                    pattern_values = pattern[col_name].to_list()
-                    pred_values = [pattern_values[phase] for phase in X_phases.to_list()]
-                    y_pred_group[f"{panel_group_name}__{col_name}"] = pred_values
+                    y_pred_group[f"{panel_group_name}__{col_name}"] = pattern[col_name].gather(X_phases)
 
                 y_pred.append(pl.DataFrame(y_pred_group))
 
@@ -326,8 +317,9 @@ class FourierSeasonalityForecaster(_BaseSeasonalityForecaster):
     ----------
     seasonality : float
         Seasonal period length (can be non-integer, e.g., 365.25 for yearly).
-    harmonics : list of int, default=[1]
+    harmonics : list of int or None, default=None
         List of Fourier harmonics to use (e.g., [1, 2, 3] uses first 3 harmonics).
+        When ``None``, a single first harmonic ``[1]`` is used at fit time.
     estimator : RegressorMixin, default=ElasticNet()
         Regression model used to fit Fourier coefficients.
     target_transformer : BaseTransformer, optional
@@ -385,8 +377,7 @@ class FourierSeasonalityForecaster(_BaseSeasonalityForecaster):
     _parameter_constraints: dict = {
         **_BaseSeasonalityForecaster._parameter_constraints,
         "harmonics": [list, None],
-        "alpha": [Interval(numbers.Real, 0, None, closed="left")],
-        "l1_ratio": [Interval(numbers.Real, 0, 1, closed="both")],
+        "estimator": [RegressorMixin],
     }
 
     def __init__(
@@ -398,12 +389,11 @@ class FourierSeasonalityForecaster(_BaseSeasonalityForecaster):
         panel_strategy="global",
     ):
         super().__init__(
-            seasonality=int(seasonality),
+            seasonality=seasonality,
             target_transformer=target_transformer,
             panel_strategy=panel_strategy,
         )
 
-        self.seasonality = seasonality
         self.harmonics = harmonics
         self.estimator = estimator
 

--- a/src/yohou/stationarity/transformers.py
+++ b/src/yohou/stationarity/transformers.py
@@ -23,6 +23,70 @@ __all__ = [
 ]
 
 
+def _inverse_seasonal_diff(
+    transformer: BaseTransformer,
+    X_t: pl.DataFrame,
+    X_p: pl.DataFrame | None,
+    seasonality: int,
+) -> pl.DataFrame:
+    """Reverse seasonal differencing via a seasonal cumulative sum.
+
+    Shared by :class:`SeasonalDifferencing` and
+    :class:`AbsoluteSeasonalReturn`, whose forward transforms (and thus
+    inverses) are identical seasonal differences.
+
+    Parameters
+    ----------
+    transformer : BaseTransformer
+        The calling transformer, used for data validation and to read
+        ``feature_names_in_`` / ``observation_horizon``.
+    X_t : pl.DataFrame
+        Transformed (differenced) series to invert.
+    X_p : pl.DataFrame or None
+        Prior context rows needed to seed the reconstruction.
+    seasonality : int
+        Seasonal lag of the differencing.
+
+    Returns
+    -------
+    pl.DataFrame
+        The reconstructed (level) series.
+
+    """
+    X_t, X_p = validate_transformer_data(
+        transformer,
+        X=X_t,
+        reset=False,
+        inverse=True,
+        X_p=X_p,
+        observation_horizon=transformer.observation_horizon,
+        stateful=True,
+    )
+
+    time = X_t.select(cs.by_name("time"))
+    X_t.columns = X_p.columns
+    X = pl.concat([X_p, X_t])
+
+    # Get the columns and their dtypes (excluding "time")
+    X_no_time = X.select(~cs.by_name("time"))
+    cols_and_dtypes = list(zip(X_no_time.columns, X_no_time.dtypes, strict=False))
+
+    def inverse_diff_col(series: pl.Series) -> pl.Series:
+        """Reverse seasonal differencing for a single series."""
+        arr = series.to_numpy().copy()
+        for i in range(len(X_p), len(arr)):
+            arr[i] += arr[i - seasonality]
+        return pl.Series(arr)
+
+    X = X_no_time.with_columns([
+        pl.col(col).map_batches(inverse_diff_col, return_dtype=dtype) for col, dtype in cols_and_dtypes
+    ])[len(X_p) :]
+    X.columns = transformer.feature_names_in_
+    X = pl.concat([time, X], how="horizontal")
+
+    return X
+
+
 class BoxCoxTransformer(BaseTransformer):
     r"""Box-Cox power transformation time series transformer.
 
@@ -354,39 +418,7 @@ class SeasonalDifferencing(BaseTransformer):
 
     def _inverse_transform(self, X_t: pl.DataFrame, X_p: pl.DataFrame | None = None) -> pl.DataFrame:
         """Inverse-transform the time series."""
-        X_t, X_p = validate_transformer_data(
-            self,
-            X=X_t,
-            reset=False,
-            inverse=True,
-            X_p=X_p,
-            observation_horizon=self.observation_horizon,
-            stateful=True,
-        )
-
-        time = X_t.select(cs.by_name("time"))
-        X_t.columns = X_p.columns
-        X = pl.concat([X_p, X_t])
-
-        # Get the columns and their dtypes (excluding "time")
-        X_no_time = X.select(~cs.by_name("time"))
-        cols_and_dtypes = list(zip(X_no_time.columns, X_no_time.dtypes, strict=False))
-
-        def inverse_diff_col(series: pl.Series) -> pl.Series:
-            """Reverse seasonal differencing for a single series."""
-            # Convert to numpy for in-place mutation
-            arr = series.to_numpy().copy()
-            for i in range(len(X_p), len(arr)):
-                arr[i] += arr[i - self.seasonality]
-            return pl.Series(arr)
-
-        X = X_no_time.with_columns([
-            pl.col(col).map_batches(inverse_diff_col, return_dtype=dtype) for col, dtype in cols_and_dtypes
-        ])[len(X_p) :]
-        X.columns = self.feature_names_in_
-        X = pl.concat([time, X], how="horizontal")
-
-        return X
+        return _inverse_seasonal_diff(self, X_t, X_p, self.seasonality)
 
     def get_feature_names_out(self, input_features: list[str] | None = None) -> list[str]:
         """Get output feature names for transformation.
@@ -559,7 +591,7 @@ class SeasonalReturn(BaseTransformer):
 
     Parameters
     ----------
-    seasonality : int > 1, default=1
+    seasonality : int >= 1, default=1
         Seasonality lag for computing returns.
 
     offset : float >= 0.0, default=0.0
@@ -717,7 +749,7 @@ class AbsoluteSeasonalReturn(BaseTransformer):
 
     Parameters
     ----------
-    seasonality : int > 1, default=1
+    seasonality : int >= 1, default=1
         Seasonality lag for computing differences.
 
     offset : float >= 0.0, default=0.0
@@ -791,39 +823,13 @@ class AbsoluteSeasonalReturn(BaseTransformer):
         return X_t
 
     def _inverse_transform(self, X_t: pl.DataFrame, X_p: pl.DataFrame | None = None) -> pl.DataFrame:
-        """Inverse-transform the time series."""
-        X_t, X_p = validate_transformer_data(
-            self,
-            X=X_t,
-            reset=False,
-            inverse=True,
-            X_p=X_p,
-            observation_horizon=self.observation_horizon,
-            stateful=True,
-        )
+        """Inverse-transform the time series.
 
-        time = X_t.select(cs.by_name("time"))
-        X_t.columns = X_p.columns
-        X = pl.concat([X_p, X_t])
-
-        # Get the columns and their dtypes (excluding "time")
-        X_no_time = X.select(~cs.by_name("time"))
-        cols_and_dtypes = list(zip(X_no_time.columns, X_no_time.dtypes, strict=False))
-
-        def inverse_diff_col(series: pl.Series) -> pl.Series:
-            """Reverse seasonal differencing for a single series."""
-            arr = series.to_numpy().copy()
-            for i in range(len(X_p), len(arr)):
-                arr[i] += arr[i - self.seasonality]
-            return pl.Series(arr)
-
-        X = X_no_time.with_columns([
-            pl.col(col).map_batches(inverse_diff_col, return_dtype=dtype) for col, dtype in cols_and_dtypes
-        ])[len(X_p) :]
-        X.columns = self.feature_names_in_
-        X = pl.concat([time, X], how="horizontal")
-
-        return X
+        The reconstruction is the seasonal cumulative sum, identical to
+        :class:`SeasonalDifferencing`, so it reuses the shared
+        :func:`_inverse_seasonal_diff` helper.
+        """
+        return _inverse_seasonal_diff(self, X_t, X_p, self.seasonality)
 
     def get_feature_names_out(self, input_features: list[str] | None = None) -> list[str]:
         """Get output feature names for transformation.

--- a/src/yohou/stationarity/transformers.py
+++ b/src/yohou/stationarity/transformers.py
@@ -114,7 +114,12 @@ class BoxCoxTransformer(BaseTransformer):
 
     Notes
     -----
-    Box-Cox requires strictly positive input data.
+    Box-Cox requires strictly positive input data: ``x + offset`` must be
+    greater than zero for every value. The ``min_value`` input tag reports
+    ``-offset`` as the exclusive lower bound (``0.0`` when ``offset == 0.0``);
+    supplying exactly ``-offset`` produces a non-positive argument (e.g.
+    ``log(0) = -inf`` when ``lmbda == 0``), so callers must ensure strict
+    positivity.
 
     References
     ----------
@@ -172,8 +177,11 @@ class BoxCoxTransformer(BaseTransformer):
         """
         tags = super().__sklearn_tags__()
         assert tags.input_tags is not None
-        # Box-Cox requires positive data (after offset)
-        tags.input_tags.min_value = -self.offset if self.offset > 0.0 else 0.0
+        # Box-Cox requires strictly positive ``x + offset``, so the smallest
+        # admissible input is the exclusive lower bound ``-offset`` (which is
+        # ``0.0`` when ``offset == 0.0``). The bound is exclusive: feeding
+        # exactly ``-offset`` yields a non-positive argument to the transform.
+        tags.input_tags.min_value = -self.offset
         return tags
 
     def _transform(self, X: pl.DataFrame) -> pl.DataFrame:
@@ -933,38 +941,30 @@ class ASinhTransformer(BaseTransformer):
         self.median_: dict[str, float] = {}
         self.mad_: dict[str, float] = {}
 
-        for col in X_numeric.columns:
-            col_data = X_numeric.get_column(col)
-            median_val = col_data.median()
-            # Cast to float for numeric operations (polars median returns numeric type)
-            self.median_[col] = (
-                float(median_val) if median_val is not None else 0.0  # ty: ignore[invalid-argument-type]
-            )
+        if X_numeric.columns:
+            # Per-column median in a single pass.
+            median_row = X_numeric.select(pl.all().median()).row(0, named=True)
+            self.median_ = {col: (float(val) if val is not None else 0.0) for col, val in median_row.items()}
 
-            # Compute MAD: median(|X - median(X)|) * scale
-            abs_dev = (col_data - self.median_[col]).abs()
-            mad_val = abs_dev.median()
-            mad_scaled = (
-                float(mad_val) * self.scale if mad_val is not None else 1.0  # ty: ignore[invalid-argument-type]
-            )
-
-            # Avoid division by zero
-            self.mad_[col] = mad_scaled if mad_scaled != 0.0 else 1.0
+            # MAD: median(|X - median(X)|) * scale, computed for all columns at once.
+            mad_row = X_numeric.select(
+                (pl.col(col) - self.median_[col]).abs().median().alias(col) for col in X_numeric.columns
+            ).row(0, named=True)
+            for col, mad_val in mad_row.items():
+                mad_scaled = float(mad_val) * self.scale if mad_val is not None else 1.0
+                # Avoid division by zero
+                self.mad_[col] = mad_scaled if mad_scaled != 0.0 else 1.0
 
     def _transform(self, X: pl.DataFrame) -> pl.DataFrame:
         """Transform the input time series."""
         time = X.select(cs.by_name("time"))
         X_numeric = X.select(~cs.by_name("time"))
 
-        # Apply asinh((X - median) / MAD) for each column
-        transformed_cols = []
-        for col in X_numeric.columns:
-            col_data = X_numeric.get_column(col).to_numpy()
-            normalized = (col_data - self.median_[col]) / self.mad_[col]
-            transformed = pl.Series(panel_aware_prefix(col, "asinh"), np.arcsinh(normalized))
-            transformed_cols.append(transformed)
-
-        X_t = pl.DataFrame(transformed_cols)
+        # Apply asinh((X - median) / MAD) across all columns in one pass.
+        X_t = X_numeric.select(
+            ((pl.col(col) - self.median_[col]) / self.mad_[col]).arcsinh().alias(panel_aware_prefix(col, "asinh"))
+            for col in X_numeric.columns
+        )
         X_t = pl.concat([time, X_t], how="horizontal")
 
         return X_t

--- a/src/yohou/testing/class_proba.py
+++ b/src/yohou/testing/class_proba.py
@@ -18,9 +18,7 @@ import polars as pl
 from yohou.utils import inspect_panel
 
 
-def check_class_proba_prediction_structure(
-    forecaster, y_test: pl.DataFrame, X_actual_test: pl.DataFrame | None = None
-) -> None:
+def check_class_proba_prediction_structure(forecaster, y_test: pl.DataFrame) -> None:
     """Check class-probability predictions have correct column structure.
 
     Validates that ``predict_class_proba`` output contains ``"vintage_time"``
@@ -33,8 +31,6 @@ def check_class_proba_prediction_structure(
         Fitted class-probability forecaster instance.
     y_test : pl.DataFrame
         Test target data.
-    X_actual_test : pl.DataFrame or None, default=None
-        Test features.
 
     Raises
     ------
@@ -68,9 +64,7 @@ def check_class_proba_prediction_structure(
                 assert col_name in y_pred.columns, f"Missing probability column: {col_name}"
 
 
-def check_class_proba_prediction_bounds(
-    forecaster, y_test: pl.DataFrame, X_actual_test: pl.DataFrame | None = None
-) -> None:
+def check_class_proba_prediction_bounds(forecaster, y_test: pl.DataFrame) -> None:
     """Check all probability values are in [0, 1].
 
     Parameters
@@ -79,8 +73,6 @@ def check_class_proba_prediction_bounds(
         Fitted class-probability forecaster instance.
     y_test : pl.DataFrame
         Test target data.
-    X_actual_test : pl.DataFrame or None, default=None
-        Test features.
 
     Raises
     ------
@@ -102,9 +94,7 @@ def check_class_proba_prediction_bounds(
         assert max_val <= 1.0, f"Probability column {col} has values > 1 (max={max_val})"
 
 
-def check_class_proba_prediction_sums(
-    forecaster, y_test: pl.DataFrame, X_actual_test: pl.DataFrame | None = None
-) -> None:
+def check_class_proba_prediction_sums(forecaster, y_test: pl.DataFrame) -> None:
     """Check probabilities sum to approximately 1.0 per row per target.
 
     Parameters
@@ -113,8 +103,6 @@ def check_class_proba_prediction_sums(
         Fitted class-probability forecaster instance.
     y_test : pl.DataFrame
         Test target data.
-    X_actual_test : pl.DataFrame or None, default=None
-        Test features.
 
     Raises
     ------
@@ -215,9 +203,7 @@ def check_class_proba_classes_attribute(forecaster) -> None:
         )
 
 
-def check_class_proba_predict_returns_labels(
-    forecaster, y_test: pl.DataFrame, X_actual_test: pl.DataFrame | None = None
-) -> None:
+def check_class_proba_predict_returns_labels(forecaster, y_test: pl.DataFrame) -> None:
     """Check predict() returns argmax class labels, not probabilities.
 
     Validates that ``predict()`` returns a DataFrame with string class labels
@@ -229,8 +215,6 @@ def check_class_proba_predict_returns_labels(
         Fitted class-probability forecaster instance.
     y_test : pl.DataFrame
         Test target data.
-    X_actual_test : pl.DataFrame or None, default=None
-        Test features.
 
     Raises
     ------

--- a/src/yohou/testing/class_proba.py
+++ b/src/yohou/testing/class_proba.py
@@ -132,16 +132,16 @@ def check_class_proba_prediction_sums(
             for target_col, class_labels in forecaster.classes_.items():
                 proba_cols = [f"{group_prefix}__{target_col}_proba_{label}" for label in class_labels]
                 row_sums = y_pred.select(proba_cols).sum_horizontal()
-                for i, s in enumerate(row_sums):
-                    assert abs(s - 1.0) < 1e-6, (
-                        f"Probabilities for {group_prefix}__{target_col} at row {i} sum to {s}, expected ~1.0"
-                    )
+                max_err = (row_sums - 1.0).abs().max()
+                assert max_err < 1e-6, (
+                    f"Probabilities for {group_prefix}__{target_col} sum to at most {1.0 + max_err}, expected ~1.0"
+                )
     else:
         for target_col, class_labels in forecaster.classes_.items():
             proba_cols = [f"{target_col}_proba_{label}" for label in class_labels]
             row_sums = y_pred.select(proba_cols).sum_horizontal()
-            for i, s in enumerate(row_sums):
-                assert abs(s - 1.0) < 1e-6, f"Probabilities for {target_col} at row {i} sum to {s}, expected ~1.0"
+            max_err = (row_sums - 1.0).abs().max()
+            assert max_err < 1e-6, f"Probabilities for {target_col} sum to at most {1.0 + max_err}, expected ~1.0"
 
 
 def check_class_proba_prediction_types(forecaster) -> None:

--- a/src/yohou/testing/forecaster.py
+++ b/src/yohou/testing/forecaster.py
@@ -11,6 +11,8 @@ from sklearn.base import clone
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_is_fitted
 
+from .contract import _safe_equal, check_clone_preserves_params
+
 __all__ = [
     "check_clone_preserves_forecaster_params",
     "check_fit_predict_with_X_forecast",
@@ -36,6 +38,56 @@ __all__ = [
 ]
 
 
+def _assert_observed_time_consistent(forecaster, phase: str) -> None:
+    """Assert ``observed_time_`` matches the last time in the observation buffers.
+
+    Shared precondition for the observe/rewind buffer checks: before the
+    mutating call, the forecaster's ``observed_time_`` must equal the last
+    ``"time"`` value held in ``_y_observed`` and ``_X_t_observed``. Handles
+    both panel (dict-valued buffers) and non-panel (frame-valued) layouts, and
+    tolerates ``None`` group buffers (``observation_horizon == 0``).
+
+    Parameters
+    ----------
+    forecaster : BaseForecaster
+        Fitted forecaster instance, inspected before observe()/rewind().
+    phase : str
+        Either ``"observe"`` or ``"rewind"``, used only in assertion messages.
+
+    Raises
+    ------
+    AssertionError
+        If ``observed_time_`` disagrees with a buffer's last time.
+
+    """
+    observed_time = forecaster.observed_time_
+
+    if forecaster._y_observed is not None:
+        if isinstance(forecaster._y_observed, dict):
+            first_group = next(iter(forecaster._y_observed.keys()))
+            first_group_y = forecaster._y_observed[first_group]
+            if first_group_y is not None:
+                assert observed_time[first_group] == first_group_y["time"][-1], (
+                    f"observed_time_ should match last time in _y_observed before {phase}()"
+                )
+        else:
+            assert observed_time == forecaster._y_observed["time"][-1], (
+                f"observed_time_ should match last time in _y_observed before {phase}()"
+            )
+
+    if forecaster._X_t_observed is not None:
+        if isinstance(forecaster._X_t_observed, dict):
+            first_group = next(iter(forecaster._X_t_observed.keys()))
+            if forecaster._X_t_observed[first_group] is not None:
+                assert observed_time[first_group] == forecaster._X_t_observed[first_group]["time"][-1], (
+                    f"observed_time_ should match last time in _X_t_observed before {phase}()"
+                )
+        else:
+            assert observed_time == forecaster._X_t_observed["time"][-1], (
+                f"observed_time_ should match last time in _X_t_observed before {phase}()"
+            )
+
+
 def check_fit_sets_forecaster_attributes(
     forecaster,
     y: pl.DataFrame,
@@ -46,9 +98,12 @@ def check_fit_sets_forecaster_attributes(
 ) -> None:
     """Check fit() sets required forecaster attributes.
 
-    Validates that fit() creates all required attributes for forecasters including
-    fit_forecasting_horizon_, interval_, groups_, local_y_schema_,
-    observation buffers, and transformer references.
+    Verifies that fit() fully initializes the stateful lifecycle so that
+    observe(), rewind(), and predict() can be called immediately afterward:
+    the horizon and schema attributes that downstream calls read, the
+    observation buffers that observe()/rewind() mutate, and the fitted
+    transformer references when transformers are configured. The specific
+    attribute names and the step-column contract live in the assertions below.
 
     Parameters
     ----------
@@ -215,9 +270,7 @@ def check_predict_time_columns(forecaster, y_test: pl.DataFrame, X_actual_test: 
 
 def check_observe_extends_observations(
     forecaster,
-    y_train: pl.DataFrame,
     y_observe: pl.DataFrame,
-    X_actual_train: pl.DataFrame | None = None,
     X_actual_observe: pl.DataFrame | None = None,
     X_future: pl.DataFrame | None = None,
     X_forecast: pl.DataFrame | None = None,
@@ -228,12 +281,8 @@ def check_observe_extends_observations(
     ----------
     forecaster : BaseForecaster
         Fitted forecaster instance
-    y_train : pl.DataFrame
-        Original training data
     y_observe : pl.DataFrame
         New data for update
-    X_actual_train : pl.DataFrame, optional
-        Features for training
     X_actual_observe : pl.DataFrame, optional
         Features for update
     X_future : pl.DataFrame, optional
@@ -250,41 +299,8 @@ def check_observe_extends_observations(
     # Store original buffer length
     original_observed_time = forecaster.observed_time_
 
-    # Handle both panel (dict) and non-panel (DataFrame or scalar) data
-    if forecaster._y_observed is not None:
-        if isinstance(forecaster._y_observed, dict):
-            # Panel data: observed_time_ is a dict
-            # Check the first group as a representative
-            first_group = next(iter(forecaster._y_observed.keys()))
-            first_group_y = forecaster._y_observed[first_group]
-            # _y_observed[group] can be None when observation_horizon == 0
-            if first_group_y is not None:
-                original_y_observed_last_time = first_group_y["time"][-1]
-                assert original_observed_time[first_group] == original_y_observed_last_time, (
-                    "observed_time_ should match last time in _y_observed before observe()"
-                )
-        else:
-            # Non-panel data: observed_time_ is a scalar
-            original_y_observed_last_time = forecaster._y_observed["time"][-1]
-            assert original_observed_time == original_y_observed_last_time, (
-                "observed_time_ should match last time in _y_observed before observe()"
-            )
-
-    if forecaster._X_t_observed is not None:
-        if isinstance(forecaster._X_t_observed, dict):
-            # Panel data
-            first_group = next(iter(forecaster._X_t_observed.keys()))
-            if forecaster._X_t_observed[first_group] is not None:
-                original_X_t_observed_last_time = forecaster._X_t_observed[first_group]["time"][-1]
-                assert original_observed_time[first_group] == original_X_t_observed_last_time, (
-                    "observed_time_ should match last time in _X_t_observed before observe()"
-                )
-        else:
-            # Non-panel data
-            original_X_t_observed_last_time = forecaster._X_t_observed["time"][-1]
-            assert original_observed_time == original_X_t_observed_last_time, (
-                "observed_time_ should match last time in _X_t_observed before observe()"
-            )
+    # Precondition: observed_time_ agrees with the observation buffers.
+    _assert_observed_time_consistent(forecaster, "observe")
 
     # Update with new data
     forecaster.observe(y_observe, X_actual_observe, X_future=X_future, X_forecast=X_forecast)
@@ -341,9 +357,7 @@ def check_observe_extends_observations(
 
 def check_rewind_replaces_observations(
     forecaster,
-    y_train: pl.DataFrame,
     y_reset: pl.DataFrame,
-    X_actual_train: pl.DataFrame | None = None,
     X_actual_reset: pl.DataFrame | None = None,
     X_future: pl.DataFrame | None = None,
     X_forecast: pl.DataFrame | None = None,
@@ -354,12 +368,8 @@ def check_rewind_replaces_observations(
     ----------
     forecaster : BaseForecaster
         Fitted forecaster instance
-    y_train : pl.DataFrame
-        Original training data
     y_reset : pl.DataFrame
         New data for reset
-    X_actual_train : pl.DataFrame, optional
-        Features for training
     X_actual_reset : pl.DataFrame, optional
         Features for reset
     X_future : pl.DataFrame, optional
@@ -373,43 +383,8 @@ def check_rewind_replaces_observations(
         If observation buffers are not replaced correctly
 
     """
-    # Store original buffer length
-    original_observed_time = forecaster.observed_time_
-
-    # Handle both panel (dict) and non-panel (DataFrame or scalar) data
-    if forecaster._y_observed is not None:
-        if isinstance(forecaster._y_observed, dict):
-            # Panel data
-            first_group = next(iter(forecaster._y_observed.keys()))
-            first_group_y = forecaster._y_observed[first_group]
-            # _y_observed[group] can be None when observation_horizon == 0
-            if first_group_y is not None:
-                original_y_observed_last_time = first_group_y["time"][-1]
-                assert original_observed_time[first_group] == original_y_observed_last_time, (
-                    "observed_time_ should match last time in _y_observed before rewind()"
-                )
-        else:
-            # Non-panel data
-            original_y_observed_last_time = forecaster._y_observed["time"][-1]
-            assert original_observed_time == original_y_observed_last_time, (
-                "observed_time_ should match last time in _y_observed before rewind()"
-            )
-
-    if forecaster._X_t_observed is not None:
-        if isinstance(forecaster._X_t_observed, dict):
-            # Panel data
-            first_group = next(iter(forecaster._X_t_observed.keys()))
-            if forecaster._X_t_observed[first_group] is not None:
-                original_X_t_observed_last_time = forecaster._X_t_observed[first_group]["time"][-1]
-                assert original_observed_time[first_group] == original_X_t_observed_last_time, (
-                    "observed_time_ should match last time in _X_t_observed before rewind()"
-                )
-        else:
-            # Non-panel data
-            original_X_t_observed_last_time = forecaster._X_t_observed["time"][-1]
-            assert original_observed_time == original_X_t_observed_last_time, (
-                "observed_time_ should match last time in _X_t_observed before rewind()"
-            )
+    # Precondition: observed_time_ agrees with the observation buffers.
+    _assert_observed_time_consistent(forecaster, "rewind")
 
     # Reset to new data
     forecaster.rewind(y_reset, X_actual_reset, X_future=X_future, X_forecast=X_forecast)
@@ -465,9 +440,7 @@ def check_rewind_replaces_observations(
 
 def check_rewind_propagates_to_transformers(
     forecaster,
-    y_train: pl.DataFrame,
     y_reset: pl.DataFrame,
-    X_actual_train: pl.DataFrame | None = None,
     X_actual_reset: pl.DataFrame | None = None,
     X_future: pl.DataFrame | None = None,
     X_forecast: pl.DataFrame | None = None,
@@ -481,12 +454,8 @@ def check_rewind_propagates_to_transformers(
     ----------
     forecaster : BaseForecaster
         Fitted forecaster instance with transformers
-    y_train : pl.DataFrame
-        Original training data
     y_reset : pl.DataFrame
         New data for reset
-    X_actual_train : pl.DataFrame, optional
-        Features for training
     X_actual_reset : pl.DataFrame, optional
         Features for reset
     X_future : pl.DataFrame, optional
@@ -637,8 +606,12 @@ def check_prediction_types_property(forecaster) -> None:
 def check_clone_preserves_forecaster_params(forecaster) -> None:
     """Check sklearn's clone() preserves init parameters.
 
-    Enhanced version that handles nested estimators and meta-forecasters like
-    DecompositionPipeline and ColumnForecaster with list of (name, estimator) tuples.
+    Delegates the shallow-param and nested-estimator contract to the shared,
+    family-agnostic ``check_clone_preserves_params`` (which uses ``_safe_equal``
+    and so tolerates DataFrame/array-valued params whose ``==`` is not a bool).
+    Adds the forecaster-specific check for ``(name, estimator, columns)``
+    3-tuples (e.g. ``ColumnForecaster``): the trailing ``columns`` element must
+    survive clone unchanged.
 
     Parameters
     ----------
@@ -651,110 +624,25 @@ def check_clone_preserves_forecaster_params(forecaster) -> None:
         If cloned forecaster has different parameters
 
     """
-    forecaster_clone = clone(forecaster)
+    check_clone_preserves_params(forecaster)
 
-    # Get parameters
+    forecaster_clone = clone(forecaster)
     original_params = forecaster.get_params(deep=False)
     cloned_params = forecaster_clone.get_params(deep=False)
 
-    # Check same parameter keys
-    assert set(original_params.keys()) == set(cloned_params.keys()), (
-        f"clone() should have same parameter keys, got {set(cloned_params.keys())} vs {set(original_params.keys())}"
-    )
-
-    # Check parameter values (for nested estimators, check type)
-    for key in original_params:
-        orig_val = original_params[key]
+    for key, orig_val in original_params.items():
         cloned_val = cloned_params[key]
-
-        # For None values
-        if orig_val is None:
-            assert cloned_val is None, f"Parameter {key}: expected None, got {cloned_val}"
-        # For list of (name, estimator) tuples (meta-estimators like DecompositionPipeline, FeaturePipeline)
-        elif isinstance(orig_val, list) and len(orig_val) > 0 and isinstance(orig_val[0], tuple):
-            assert isinstance(cloned_val, list), f"Parameter {key}: expected list, got {type(cloned_val)}"
-            assert len(orig_val) == len(cloned_val), f"Parameter {key}: different lengths"
-
-            for i, (orig_item, cloned_item) in enumerate(zip(orig_val, cloned_val, strict=False)):
-                assert isinstance(orig_item, tuple), f"Parameter {key}[{i}]: expected tuple"
-                assert isinstance(cloned_item, tuple), f"Parameter {key}[{i}]: expected tuple"
-                assert len(orig_item) in (2, 3), (
-                    f"Parameter {key}[{i}]: expected (name, estimator) or (name, estimator, columns) tuple, got length {len(orig_item)}"
-                )
-                assert len(cloned_item) == len(orig_item), (
-                    f"Parameter {key}[{i}]: clone tuple length {len(cloned_item)} != original {len(orig_item)}"
+        if not (isinstance(orig_val, list) and orig_val and isinstance(orig_val[0], tuple)):
+            continue
+        for i, (orig_item, cloned_item) in enumerate(zip(orig_val, cloned_val, strict=True)):
+            if not (isinstance(orig_item, tuple) and isinstance(cloned_item, tuple)):
+                continue
+            if len(orig_item) == 3 and len(cloned_item) == 3:
+                orig_cols, cloned_cols = orig_item[-1], cloned_item[-1]
+                assert _safe_equal(orig_cols, cloned_cols), (
+                    f"Parameter {key}[{i}] columns: {cloned_cols!r} != {orig_cols!r}"
                 )
 
-                orig_name, orig_est = orig_item[0], orig_item[1]
-                cloned_name, cloned_est = cloned_item[0], cloned_item[1]
-
-                # Names should match exactly
-                assert orig_name == cloned_name, f"Parameter {key}[{i}]: different names {cloned_name} != {orig_name}"
-
-                # Estimators should be different instances but same type
-                assert type(orig_est) is type(cloned_est), (
-                    f"Parameter {key}[{i}] estimator: different types {type(cloned_est)} vs {type(orig_est)}"
-                )
-                assert orig_est is not cloned_est, (
-                    f"Parameter {key}[{i}] estimator: should be cloned, not same instance"
-                )
-
-                # Check estimator params match
-                if hasattr(orig_est, "get_params"):
-                    orig_est_params = orig_est.get_params(deep=True)  # ty: ignore[call-non-callable]
-                    cloned_est_params = cloned_est.get_params(deep=True)  # ty: ignore[unresolved-attribute]
-                    for param_key in orig_est_params:
-                        orig_param = orig_est_params.get(param_key)
-                        cloned_param = cloned_est_params.get(param_key)
-                        if hasattr(orig_param, "get_params"):
-                            assert type(orig_param) is type(cloned_param), (
-                                f"Parameter {key}[{i}]__{param_key}: different types"
-                            )
-                        elif orig_param != cloned_param:
-                            assert orig_param == cloned_param, (
-                                f"Parameter {key}[{i}]__{param_key}: {cloned_param} != {orig_param}"
-                            )
-
-                # For 3-tuples (name, estimator, columns), compare the columns element
-                if len(orig_item) == 3:
-                    orig_cols = orig_item[2]
-                    cloned_cols = cloned_item[2]
-                    assert orig_cols == cloned_cols, f"Parameter {key}[{i}] columns: {cloned_cols} != {orig_cols}"
-        elif isinstance(orig_val, type):
-            assert orig_val is cloned_val, (
-                f"Parameter {key}: class type should be preserved by clone, got {cloned_val} vs {orig_val}"
-            )
-        # For estimator instances, check type and params (recursively)
-        elif hasattr(orig_val, "get_params"):
-            assert type(orig_val) is type(cloned_val), (
-                f"Parameter {key}: different types {type(cloned_val)} vs {type(orig_val)}"
-            )
-            # Use deep=True to get all nested params, compare them
-            orig_deep_params = orig_val.get_params(deep=True)
-            cloned_deep_params = cloned_val.get_params(deep=True)
-
-            # Compare only primitive values and types (not object instances)
-            for param_key in orig_deep_params:
-                orig_param = orig_deep_params.get(param_key)
-                cloned_param = cloned_deep_params.get(param_key)
-
-                # Skip comparing estimator instances themselves, just check types
-                if hasattr(orig_param, "get_params"):
-                    assert type(orig_param) is type(cloned_param), f"Parameter {key}__{param_key}: different types"
-                elif orig_param != cloned_param:
-                    assert orig_param == cloned_param, f"Parameter {key}__{param_key}: {cloned_param} != {orig_param}"
-        # For other values, direct comparison
-        else:
-            try:
-                are_equal = bool(orig_val == cloned_val)
-            except Exception:
-                are_equal = False
-            if not are_equal:
-                # Fall back to type comparison for objects that don't define __eq__
-                # (e.g., PyTorch modules, neuralforecast loss functions).
-                assert type(orig_val) is type(cloned_val), f"Parameter {key}: {cloned_val} != {orig_val}"
-
-    # Check they are different objects
     assert forecaster_clone is not forecaster, "clone() should create new instance"
 
 
@@ -949,8 +837,6 @@ def check_forecaster_methods_call_check_is_fitted(
     y: pl.DataFrame,
     X_actual: pl.DataFrame | None = None,
     forecasting_horizon: int = 3,
-    X_future: pl.DataFrame | None = None,
-    X_forecast: pl.DataFrame | None = None,
 ) -> None:
     """Check all forecaster methods (except fit) raise NotFittedError when unfitted.
 
@@ -968,12 +854,6 @@ def check_forecaster_methods_call_check_is_fitted(
         Training/test features with "time" column
     forecasting_horizon : int, default=3
         Number of steps ahead to forecast
-    X_future : pl.DataFrame, optional
-        Known-future features, accepted for signature compatibility with the
-        check harness; the not-fitted contract is exercised without them
-    X_forecast : pl.DataFrame, optional
-        External forecast features, accepted for signature compatibility with
-        the check harness; the not-fitted contract is exercised without them
 
     Raises
     ------
@@ -1104,7 +984,6 @@ def check_fit_predict_with_X_future(
     forecaster,
     y_train: pl.DataFrame,
     X_actual_train: pl.DataFrame | None,
-    y_test: pl.DataFrame,
     X_future: pl.DataFrame,
     forecasting_horizon: int = 3,
 ) -> None:
@@ -1121,8 +1000,6 @@ def check_fit_predict_with_X_future(
         Training target data.
     X_actual_train : pl.DataFrame or None
         Training features.
-    y_test : pl.DataFrame
-        Test target data.
     X_future : pl.DataFrame
         Known-future features with ``"time"`` column.
     forecasting_horizon : int, default=3
@@ -1158,7 +1035,6 @@ def check_fit_predict_with_X_forecast(
     forecaster,
     y_train: pl.DataFrame,
     X_actual_train: pl.DataFrame | None,
-    y_test: pl.DataFrame,
     X_forecast: pl.DataFrame,
     forecasting_horizon: int = 3,
 ) -> None:
@@ -1175,8 +1051,6 @@ def check_fit_predict_with_X_forecast(
         Training target data.
     X_actual_train : pl.DataFrame or None
         Training features.
-    y_test : pl.DataFrame
-        Test target data.
     X_forecast : pl.DataFrame
         External forecasts in tidy format.
     forecasting_horizon : int, default=3
@@ -1210,7 +1084,6 @@ def check_fit_predict_with_X_forecast(
 
 def check_predict_X_forecast_override(
     forecaster,
-    y_test: pl.DataFrame,
     X_forecast: pl.DataFrame,
     forecasting_horizon: int = 3,
 ) -> None:
@@ -1223,8 +1096,6 @@ def check_predict_X_forecast_override(
     ----------
     forecaster : BaseForecaster
         Fitted forecaster instance (fitted with X_forecast).
-    y_test : pl.DataFrame
-        Test target data.
     X_forecast : pl.DataFrame
         External forecasts for override.
     forecasting_horizon : int, default=3
@@ -1434,7 +1305,10 @@ def check_requires_exogenous_warns_on_X_future_X_forecast(
     """Check that a forecaster with requires_exogenous=False warns when X_future/X_forecast provided.
 
     Forecasters with ``requires_exogenous=False`` should emit a UserWarning
-    when X_future or X_forecast is passed to fit().
+    when X_future or X_forecast is passed to fit(). The check always calls
+    ``fit`` with ``X_actual=None`` (it exercises only the step-feature path),
+    and any UserWarning emitted during that call satisfies the contract; the
+    warning need not specifically mention X_future or X_forecast.
 
     Parameters
     ----------

--- a/src/yohou/testing/forecaster.py
+++ b/src/yohou/testing/forecaster.py
@@ -236,6 +236,10 @@ def check_observe_extends_observations(
         Features for training
     X_actual_observe : pl.DataFrame, optional
         Features for update
+    X_future : pl.DataFrame, optional
+        Known-future features forwarded to observe()
+    X_forecast : pl.DataFrame, optional
+        External forecast features forwarded to observe()
 
     Raises
     ------
@@ -358,6 +362,10 @@ def check_rewind_replaces_observations(
         Features for training
     X_actual_reset : pl.DataFrame, optional
         Features for reset
+    X_future : pl.DataFrame, optional
+        Known-future features forwarded to rewind()
+    X_forecast : pl.DataFrame, optional
+        External forecast features forwarded to rewind()
 
     Raises
     ------
@@ -378,13 +386,13 @@ def check_rewind_replaces_observations(
             if first_group_y is not None:
                 original_y_observed_last_time = first_group_y["time"][-1]
                 assert original_observed_time[first_group] == original_y_observed_last_time, (
-                    "observed_time_ should match last time in _y_observed before observe()"
+                    "observed_time_ should match last time in _y_observed before rewind()"
                 )
         else:
             # Non-panel data
             original_y_observed_last_time = forecaster._y_observed["time"][-1]
             assert original_observed_time == original_y_observed_last_time, (
-                "observed_time_ should match last time in _y_observed before observe()"
+                "observed_time_ should match last time in _y_observed before rewind()"
             )
 
     if forecaster._X_t_observed is not None:
@@ -394,13 +402,13 @@ def check_rewind_replaces_observations(
             if forecaster._X_t_observed[first_group] is not None:
                 original_X_t_observed_last_time = forecaster._X_t_observed[first_group]["time"][-1]
                 assert original_observed_time[first_group] == original_X_t_observed_last_time, (
-                    "observed_time_ should match last time in _X_t_observed before observe()"
+                    "observed_time_ should match last time in _X_t_observed before rewind()"
                 )
         else:
             # Non-panel data
             original_X_t_observed_last_time = forecaster._X_t_observed["time"][-1]
             assert original_observed_time == original_X_t_observed_last_time, (
-                "observed_time_ should match last time in _X_t_observed before observe()"
+                "observed_time_ should match last time in _X_t_observed before rewind()"
             )
 
     # Reset to new data
@@ -481,6 +489,10 @@ def check_rewind_propagates_to_transformers(
         Features for training
     X_actual_reset : pl.DataFrame, optional
         Features for reset
+    X_future : pl.DataFrame, optional
+        Known-future features forwarded to rewind()
+    X_forecast : pl.DataFrame, optional
+        External forecast features forwarded to rewind()
 
     Raises
     ------
@@ -560,6 +572,10 @@ def check_forecasting_horizon_validation(
         Training target data
     X_actual : pl.DataFrame, optional
         Training features
+    X_future : pl.DataFrame, optional
+        Known-future features forwarded to fit()
+    X_forecast : pl.DataFrame, optional
+        External forecast features forwarded to fit()
 
     Raises
     ------
@@ -952,6 +968,12 @@ def check_forecaster_methods_call_check_is_fitted(
         Training/test features with "time" column
     forecasting_horizon : int, default=3
         Number of steps ahead to forecast
+    X_future : pl.DataFrame, optional
+        Known-future features, accepted for signature compatibility with the
+        check harness; the not-fitted contract is exercised without them
+    X_forecast : pl.DataFrame, optional
+        External forecast features, accepted for signature compatibility with
+        the check harness; the not-fitted contract is exercised without them
 
     Raises
     ------
@@ -961,8 +983,9 @@ def check_forecaster_methods_call_check_is_fitted(
     """
     forecaster_clone = clone(forecaster)
 
-    # Determine if this is a point or interval forecaster
-    is_interval = hasattr(forecaster_clone, "predict_interval") and not hasattr(forecaster_clone, "predict")
+    # Determine if this is an interval forecaster. Only interval forecasters
+    # expose predict_interval(); point and class-proba forecasters do not.
+    is_interval = hasattr(forecaster_clone, "predict_interval")
 
     # Test that predict() or predict_interval() raises NotFittedError when unfitted
     try:

--- a/src/yohou/testing/generators.py
+++ b/src/yohou/testing/generators.py
@@ -150,6 +150,28 @@ from .weighter import (
 )
 
 
+def _interval_lower_bound(constraint_list: list) -> int | None:
+    """Return the integer lower bound of the first ``Interval`` in a constraint list.
+
+    Parameters
+    ----------
+    constraint_list : list
+        A ``_parameter_constraints`` entry (list of constraint objects).
+
+    Returns
+    -------
+    int or None
+        The interval's ``left`` bound as an int, or ``None`` if no interval
+        with an integer lower bound is present.
+
+    """
+    for constraint in constraint_list:
+        left = getattr(constraint, "left", None)
+        if left is not None:
+            return int(left)
+    return None
+
+
 def _yield_yohou_transformer_checks(
     transformer,
     X_train: pl.DataFrame,
@@ -174,7 +196,6 @@ def _yield_yohou_transformer_checks(
         Test target data
     tags : dict, optional
         Transformer metadata tags (if None, auto-detected from __sklearn_tags__):
-        - requires_y: bool
         - stateful: bool
         - observation_horizon: int | None
         - preserves_dtype: bool
@@ -195,14 +216,15 @@ def _yield_yohou_transformer_checks(
         # Get tags from __sklearn_tags__ method
         sklearn_tags = transformer.__sklearn_tags__()
         tags = {
-            "requires_y": False,  # Yohou transformers don't have a requires_y concept
             "stateful": sklearn_tags.transformer_tags.stateful if sklearn_tags.transformer_tags else False,
             "observation_horizon": (
                 transformer.observation_horizon if hasattr(transformer, "observation_horizon") else None
             ),
             "preserves_dtype": sklearn_tags.transformer_tags.preserves_dtype if sklearn_tags.transformer_tags else True,
             "invertible": sklearn_tags.transformer_tags.invertible if sklearn_tags.transformer_tags else False,
-            "supports_panel_data": True,  # All Yohou transformers support panel data (prefixed columns)
+            # The panel checks below additionally require the caller to supply
+            # panel-structured X_train; they are skipped when none is present.
+            "supports_panel_data": True,
         }
 
     # Core transformer checks (always yield)
@@ -477,8 +499,6 @@ def _yield_yohou_forecaster_checks(
             "y": y_train,
             "X_actual": X_actual_train,
             "forecasting_horizon": 3,
-            "X_future": X_future_train,
-            "X_forecast": X_forecast_train,
         },
     )
     yield (
@@ -527,9 +547,7 @@ def _yield_yohou_forecaster_checks(
             "check_observe_extends_observations",
             check_observe_extends_observations,
             {
-                "y_train": y_train,
                 "y_observe": y_update,
-                "X_actual_train": X_actual_train,
                 "X_actual_observe": X_actual_update,
                 "X_future": X_future_test,
                 "X_forecast": X_forecast_test,
@@ -539,9 +557,7 @@ def _yield_yohou_forecaster_checks(
             "check_rewind_replaces_observations",
             check_rewind_replaces_observations,
             {
-                "y_train": y_train,
                 "y_reset": y_reset,
-                "X_actual_train": X_actual_train,
                 "X_actual_reset": X_actual_reset,
                 "X_future": X_future_test,
                 "X_forecast": X_forecast_test,
@@ -556,9 +572,7 @@ def _yield_yohou_forecaster_checks(
             "check_rewind_propagates_to_transformers",
             check_rewind_propagates_to_transformers,
             {
-                "y_train": y_train,
                 "y_reset": y_reset,
-                "X_actual_train": X_actual_train,
                 "X_actual_reset": X_actual_reset,
                 "X_future": X_future_test,
                 "X_forecast": X_forecast_test,
@@ -571,7 +585,7 @@ def _yield_yohou_forecaster_checks(
         yield (
             "check_point_prediction_structure",
             check_point_prediction_structure,
-            {"y_test": y_test, "X_actual_test": X_actual_test},
+            {"y_test": y_test},
         )
         yield "check_point_prediction_types", check_point_prediction_types, {}
 
@@ -580,12 +594,12 @@ def _yield_yohou_forecaster_checks(
         yield (
             "check_interval_prediction_columns",
             check_interval_prediction_columns,
-            {"y_test": y_test, "X_actual_test": X_actual_test},
+            {"y_test": y_test},
         )
         yield (
             "check_interval_bounds",
             check_interval_bounds,
-            {"y_test": y_test, "X_actual_test": X_actual_test},
+            {"y_test": y_test},
         )
         yield "check_interval_prediction_types", check_interval_prediction_types, {}
         yield "check_coverage_rates_parameter", check_coverage_rates_parameter, {}
@@ -600,24 +614,24 @@ def _yield_yohou_forecaster_checks(
         yield (
             "check_class_proba_prediction_structure",
             check_class_proba_prediction_structure,
-            {"y_test": y_test, "X_actual_test": X_actual_test},
+            {"y_test": y_test},
         )
         yield (
             "check_class_proba_prediction_bounds",
             check_class_proba_prediction_bounds,
-            {"y_test": y_test, "X_actual_test": X_actual_test},
+            {"y_test": y_test},
         )
         yield (
             "check_class_proba_prediction_sums",
             check_class_proba_prediction_sums,
-            {"y_test": y_test, "X_actual_test": X_actual_test},
+            {"y_test": y_test},
         )
         yield "check_class_proba_prediction_types", check_class_proba_prediction_types, {}
         yield "check_class_proba_classes_attribute", check_class_proba_classes_attribute, {}
         yield (
             "check_class_proba_predict_returns_labels",
             check_class_proba_predict_returns_labels,
-            {"y_test": y_test, "X_actual_test": X_actual_test},
+            {"y_test": y_test},
         )
 
     # Reduction forecaster checks
@@ -635,17 +649,17 @@ def _yield_yohou_forecaster_checks(
             yield (
                 "check_panel_data",
                 check_panel_data,
-                {"y_panel": y_test, "X_panel": X_actual_test},
+                {"y_panel": y_test},
             )
             yield (
                 "check_panel_single_group",
                 check_panel_single_group,
-                {"y_panel": y_test, "X_panel": X_actual_test},
+                {"y_panel": y_test},
             )
             yield (
                 "check_panel_invalid_group_raises",
                 check_panel_invalid_group_raises,
-                {"y_panel": y_test, "X_panel": X_actual_test},
+                {"y_panel": y_test},
             )
 
     # X_future / X_forecast dedicated checks
@@ -660,7 +674,6 @@ def _yield_yohou_forecaster_checks(
                 {
                     "y_train": y_train,
                     "X_actual_train": X_actual_train,
-                    "y_test": y_test,
                     "X_future": X_future_train,
                     "forecasting_horizon": 3,
                 },
@@ -673,7 +686,6 @@ def _yield_yohou_forecaster_checks(
                 {
                     "y_train": y_train,
                     "X_actual_train": X_actual_train,
-                    "y_test": y_test,
                     "X_forecast": X_forecast_train,
                     "forecasting_horizon": 3,
                 },
@@ -683,7 +695,6 @@ def _yield_yohou_forecaster_checks(
                 "check_predict_X_forecast_override",
                 check_predict_X_forecast_override,
                 {
-                    "y_test": y_test,
                     "X_forecast": X_forecast_test if X_forecast_test is not None else X_forecast_train,
                     "forecasting_horizon": 3,
                 },
@@ -828,12 +839,8 @@ def _yield_yohou_splitter_checks(
     # Panel data support check (conditional)
     if tags.get("supports_panel_data", False):
         # Generate panel data for testing
-        y_panel = y.rename({col: f"{col}__group1" for col in y.columns if col != "time"})
-        X_panel = (
-            X_actual.rename({col: f"{col}__group1" for col in X_actual.columns if col != "time"})
-            if X_actual is not None
-            else None
-        )
+        y_panel = y.rename(lambda c: c if c == "time" else f"{c}__group1")
+        X_panel = X_actual.rename(lambda c: c if c == "time" else f"{c}__group1") if X_actual is not None else None
         yield (
             "check_splitter_panel_data_support",
             check_splitter_panel_data_support,
@@ -848,7 +855,11 @@ def _yield_yohou_splitter_checks(
 
         # Generate invalid values based on parameter constraints
         if "n_splits" in constraints:
-            param_test_cases.append(("n_splits", [1, 0, -1]))  # Must be >= 2
+            lower = _interval_lower_bound(constraints["n_splits"])
+            # Below the declared lower bound is invalid. Derive three values
+            # under it so the cases track the constraint instead of hardcoding.
+            invalid_n_splits = [lower - offset for offset in (1, 2, 3)] if lower is not None else [1, 0, -1]
+            param_test_cases.append(("n_splits", invalid_n_splits))
         if "test_size" in constraints:
             param_test_cases.append(("test_size", [0, -1]))  # Must be >= 1
         if "train_size" in constraints:
@@ -1117,8 +1128,6 @@ def _yield_yohou_search_checks(
             {
                 "y_train": y_train,
                 "y_test": y_test,
-                "X_actual_train": X_actual_train,
-                "X_actual_test": X_actual_test,
                 "X_future": X_future_test,
                 "X_forecast": X_forecast_test,
             },
@@ -1210,8 +1219,6 @@ def _yield_yohou_search_checks(
             {
                 "y_train": y_train,
                 "y_test": y_test,
-                "X_actual_train": X_actual_train,
-                "X_actual_test": X_actual_test,
                 "X_future": X_future_test,
                 "X_forecast": X_forecast_test,
             },
@@ -1301,8 +1308,6 @@ def _yield_yohou_search_checks(
                 {
                     "y_train": y_train,
                     "y_test": y_test,
-                    "X_actual_train": X_actual_train,
-                    "X_actual_test": X_actual_test,
                     "groups": groups,
                     "X_future": X_future_test,
                     "X_forecast": X_forecast_test,

--- a/src/yohou/testing/interval.py
+++ b/src/yohou/testing/interval.py
@@ -18,9 +18,7 @@ __all__ = [
 ]
 
 
-def check_interval_prediction_columns(
-    forecaster, y_test: pl.DataFrame, X_actual_test: pl.DataFrame | None = None
-) -> None:
+def check_interval_prediction_columns(forecaster, y_test: pl.DataFrame) -> None:
     """Check interval predictions have {col}_lower_{rate} and {col}_upper_{rate} format.
 
     Parameters
@@ -29,8 +27,6 @@ def check_interval_prediction_columns(
         Fitted interval forecaster instance
     y_test : pl.DataFrame
         Test target data
-    X_actual_test : pl.DataFrame, optional
-        Test features
 
     Raises
     ------
@@ -77,7 +73,7 @@ def check_interval_prediction_columns(
                 assert upper_col in y_pred.columns, f"Missing upper bound column: {upper_col}"
 
 
-def check_interval_bounds(forecaster, y_test: pl.DataFrame, X_actual_test: pl.DataFrame | None = None) -> None:
+def check_interval_bounds(forecaster, y_test: pl.DataFrame) -> None:
     """Check upper >= lower for all coverage rates and time steps.
 
     Parameters
@@ -86,8 +82,6 @@ def check_interval_bounds(forecaster, y_test: pl.DataFrame, X_actual_test: pl.Da
         Fitted interval forecaster instance
     y_test : pl.DataFrame
         Test target data
-    X_actual_test : pl.DataFrame, optional
-        Test features
 
     Raises
     ------
@@ -104,41 +98,21 @@ def check_interval_bounds(forecaster, y_test: pl.DataFrame, X_actual_test: pl.Da
     _, y_panel_groups = inspect_panel(y_test)
 
     if len(y_panel_groups) > 0:
-        # For panel data, interval columns use __ separator
-        for group_prefix in y_panel_groups:
-            # Get fields from the original training data (full column names)
-            expected_fields = y_panel_groups[group_prefix]
-
-            for rate in coverage_rates:
-                for field in expected_fields:
-                    lower_col = f"{field}_lower_{rate}"
-                    upper_col = f"{field}_upper_{rate}"
-
-                    lower_vals = y_pred[lower_col].to_numpy()
-                    upper_vals = y_pred[upper_col].to_numpy()
-
-                    violations = lower_vals > upper_vals
-                    if violations.any():
-                        raise AssertionError(
-                            f"Found {violations.sum()} violations where lower > upper for {field} at coverage {rate}"
-                        )
+        # For panel data, interval columns use __ separator (e.g. "stores__store_0").
+        fields = [field for group_prefix in y_panel_groups for field in y_panel_groups[group_prefix]]
     else:
-        # For global data, check individual columns
-        target_cols = list(forecaster.local_y_schema_.keys())
+        fields = list(forecaster.local_y_schema_.keys())
 
-        for rate in coverage_rates:
-            for col in target_cols:
-                lower_col = f"{col}_lower_{rate}"
-                upper_col = f"{col}_upper_{rate}"
-
-                lower_vals = y_pred[lower_col].to_numpy()
-                upper_vals = y_pred[upper_col].to_numpy()
-
-                violations = lower_vals > upper_vals
-                if violations.any():
-                    raise AssertionError(
-                        f"Found {violations.sum()} violations where lower > upper for {col} at coverage {rate}"
-                    )
+    # Build one violation flag per (field, rate) pair and evaluate in a single pass.
+    violation_exprs = [
+        (pl.col(f"{field}_lower_{rate}") > pl.col(f"{field}_upper_{rate}")).any().alias(f"{field}_lower_{rate}")
+        for rate in coverage_rates
+        for field in fields
+    ]
+    violations = y_pred.select(violation_exprs)
+    offenders = [name for name, flagged in violations.row(0, named=True).items() if flagged]
+    if offenders:
+        raise AssertionError(f"Found bounds where lower > upper: {offenders}")
 
 
 def check_interval_prediction_types(forecaster) -> None:

--- a/src/yohou/testing/interval.py
+++ b/src/yohou/testing/interval.py
@@ -205,6 +205,10 @@ def check_coverage_rates_validation(
         Training target data
     X_actual : pl.DataFrame, optional
         Training features
+    X_future : pl.DataFrame, optional
+        Known-future features forwarded to fit()
+    X_forecast : pl.DataFrame, optional
+        External forecast features forwarded to fit()
 
     Raises
     ------

--- a/src/yohou/testing/panel.py
+++ b/src/yohou/testing/panel.py
@@ -34,7 +34,7 @@ def _column_present(field: str, columns: list[str]) -> bool:
     return any(col.startswith(f"{field}_lower_") or col.startswith(f"{field}_upper_") for col in columns)
 
 
-def check_panel_data(forecaster, y_panel: pl.DataFrame, X_panel: pl.DataFrame | None = None) -> None:
+def check_panel_data(forecaster, y_panel: pl.DataFrame) -> None:
     """Check cross-learning with panel data predicts all groups by default.
 
     Validates that when panel_group=None (default), predictions are
@@ -46,8 +46,6 @@ def check_panel_data(forecaster, y_panel: pl.DataFrame, X_panel: pl.DataFrame | 
         Fitted forecaster with panel data
     y_panel : pl.DataFrame
         Panel data with panel columns for testing
-    X_panel : pl.DataFrame, optional
-        Panel features
 
     Raises
     ------
@@ -71,7 +69,7 @@ def check_panel_data(forecaster, y_panel: pl.DataFrame, X_panel: pl.DataFrame | 
                 )
 
 
-def check_panel_single_group(forecaster, y_panel: pl.DataFrame, X_panel: pl.DataFrame | None = None) -> None:
+def check_panel_single_group(forecaster, y_panel: pl.DataFrame) -> None:
     """Check cross-learning filters to specified panel group.
 
     Validates that when panel_group is specified, predictions are
@@ -83,8 +81,6 @@ def check_panel_single_group(forecaster, y_panel: pl.DataFrame, X_panel: pl.Data
         Fitted forecaster with panel data
     y_panel : pl.DataFrame
         Panel data with panel columns for testing
-    X_panel : pl.DataFrame, optional
-        Panel features
 
     Raises
     ------
@@ -111,7 +107,7 @@ def check_panel_single_group(forecaster, y_panel: pl.DataFrame, X_panel: pl.Data
             )
 
 
-def check_panel_invalid_group_raises(forecaster, y_panel: pl.DataFrame, X_panel: pl.DataFrame | None = None) -> None:
+def check_panel_invalid_group_raises(forecaster, y_panel: pl.DataFrame) -> None:
     """Check that an invalid group name raises ValueError.
 
     Validates error handling when ``groups`` specifies group names that
@@ -123,8 +119,6 @@ def check_panel_invalid_group_raises(forecaster, y_panel: pl.DataFrame, X_panel:
         Fitted forecaster with panel data
     y_panel : pl.DataFrame
         Panel data with panel columns for testing
-    X_panel : pl.DataFrame, optional
-        Panel features
 
     Raises
     ------

--- a/src/yohou/testing/panel.py
+++ b/src/yohou/testing/panel.py
@@ -6,6 +6,7 @@ handling in forecasters.
 
 import polars as pl
 
+from yohou.interval import BaseIntervalForecaster
 from yohou.utils import inspect_panel
 
 __all__ = ["check_panel_data", "check_panel_invalid_group_raises", "check_panel_single_group"]
@@ -13,21 +14,15 @@ __all__ = ["check_panel_data", "check_panel_invalid_group_raises", "check_panel_
 
 def _call_predict(forecaster, forecasting_horizon, panel_group=None, groups=None):
     """Call appropriate predict method based on forecaster type."""
-    # Interval forecasters use predict_interval, point forecasters use predict
-    if hasattr(forecaster, "predict"):
-        if panel_group is not None:
-            return forecaster.predict(forecasting_horizon=forecasting_horizon, panel_group=panel_group)
-        elif groups is not None:
-            return forecaster.predict(forecasting_horizon=forecasting_horizon, groups=groups)
-        else:
-            return forecaster.predict(forecasting_horizon=forecasting_horizon)
-    # Interval forecaster
-    elif panel_group is not None:
-        return forecaster.predict_interval(forecasting_horizon=forecasting_horizon, panel_group=panel_group)
-    elif groups is not None:
-        return forecaster.predict_interval(forecasting_horizon=forecasting_horizon, groups=groups)
-    else:
-        return forecaster.predict_interval(forecasting_horizon=forecasting_horizon)
+    if groups is None and panel_group is not None:
+        groups = [panel_group]
+    kwargs = {"forecasting_horizon": forecasting_horizon}
+    if groups is not None:
+        kwargs["groups"] = groups
+    # Interval forecasters use predict_interval, others use predict.
+    if isinstance(forecaster, BaseIntervalForecaster):
+        return forecaster.predict_interval(**kwargs)
+    return forecaster.predict(**kwargs)
 
 
 def _column_present(field: str, columns: list[str]) -> bool:
@@ -117,10 +112,10 @@ def check_panel_single_group(forecaster, y_panel: pl.DataFrame, X_panel: pl.Data
 
 
 def check_panel_invalid_group_raises(forecaster, y_panel: pl.DataFrame, X_panel: pl.DataFrame | None = None) -> None:
-    """Check that invalid panel_group raises ValueError.
+    """Check that an invalid group name raises ValueError.
 
-    Validates error handling when panel_group specifies a panel group
-    that doesn't exist in the training data.
+    Validates error handling when ``groups`` specifies group names that
+    were not seen during fit.
 
     Parameters
     ----------
@@ -143,7 +138,7 @@ def check_panel_invalid_group_raises(forecaster, y_panel: pl.DataFrame, X_panel:
         # Try to predict with invalid group name
         try:
             _call_predict(forecaster, forecasting_horizon=3, groups=["invalid_group"])
-            raise AssertionError("predict() should raise ValueError for invalid panel_group, but didn't")
+            raise AssertionError("predict() should raise ValueError for an invalid group name, but didn't")
         except ValueError as e:
             # Expected - check error message mentions the invalid group
             assert "invalid_group" in str(e) or "not found" in str(e).lower(), (

--- a/src/yohou/testing/point.py
+++ b/src/yohou/testing/point.py
@@ -12,9 +12,7 @@ except ImportError as e:
     raise ImportError("polars.testing is required for yohou.testing module. Install with: uv sync --group tests") from e
 
 
-def check_point_prediction_structure(
-    forecaster, y_test: pl.DataFrame, X_actual_test: pl.DataFrame | None = None
-) -> None:
+def check_point_prediction_structure(forecaster, y_test: pl.DataFrame) -> None:
     """Check point predictions have correct column structure.
 
     Parameters
@@ -23,8 +21,6 @@ def check_point_prediction_structure(
         Fitted point forecaster instance
     y_test : pl.DataFrame
         Test target data
-    X_actual_test : pl.DataFrame, optional
-        Test features
 
     Raises
     ------

--- a/src/yohou/testing/scorer.py
+++ b/src/yohou/testing/scorer.py
@@ -342,6 +342,9 @@ def check_scorer_panel_subselection(
     scorer_filtered = clone(scorer)
     scorer_filtered.set_params(groups=groups)
 
+    # Always fit scorer before scoring
+    scorer_filtered.fit(y_truth_panel)
+
     try:
         score = scorer_filtered.score(y_truth_panel, y_pred_panel)
         assert isinstance(score, int | float | np.number), "Panel-filtered score should be numeric"
@@ -376,6 +379,9 @@ def check_scorer_component_subselection(
     """
     scorer_filtered = clone(scorer)
     scorer_filtered.set_params(components=components)
+
+    # Always fit scorer before scoring
+    scorer_filtered.fit(y_truth)
 
     try:
         score = scorer_filtered.score(y_truth, y_pred)
@@ -457,31 +463,11 @@ def check_scorer_parameter_validation(
         If invalid value is accepted
 
     """
-    # Create scorer instance to check its type
-    scorer = scorer_class()
-    tags = scorer.__sklearn_tags__()
-
-    # Create minimal test data based on prediction type
+    # Parameter validation happens in fit(), so minimal truth data is enough
     y_truth = pl.DataFrame({
         "time": [datetime.datetime(2020, 1, i) for i in range(1, 11)],
         "value": [float(i) for i in range(10)],
     })
-
-    if tags.scorer_tags.prediction_type == "interval":
-        # Interval scorer needs _lower and _upper columns
-        pl.DataFrame({
-            "vintage_time": [datetime.datetime(2020, 1, 10) for _ in range(3)],
-            "time": [datetime.datetime(2020, 1, i) for i in range(11, 14)],
-            "value_lower_0.9": [10.0, 11.0, 12.0],
-            "value_upper_0.9": [10.5, 11.5, 12.5],
-        })
-    else:
-        # Point scorer needs regular value columns
-        pl.DataFrame({
-            "vintage_time": [datetime.datetime(2020, 1, 10) for _ in range(3)],
-            "time": [datetime.datetime(2020, 1, i) for i in range(11, 14)],
-            "value": range(10, 13),
-        })
 
     # Create scorer with invalid parameter
     params = {param_name: invalid_value}
@@ -497,8 +483,6 @@ def check_scorer_parameter_validation(
         if error_match is None or error_match in str(e):
             return  # Test passed
         raise AssertionError(f"Expected error containing '{error_match}', got: {e}") from e
-        if error_match is not None:
-            assert error_match in str(e), f"Expected error containing '{error_match}', got: {e}"
 
 
 def check_scorer_methods_call_check_is_fitted(scorer, y_train: pl.DataFrame, y_pred: pl.DataFrame) -> None:

--- a/src/yohou/testing/search.py
+++ b/src/yohou/testing/search.py
@@ -274,7 +274,7 @@ def check_search_refit_false_no_forecaster(
 
     # Temporarily set refit=False if not already
     original_refit = search_cv_clone.refit
-    search_cv_clone.refit = False
+    search_cv_clone.set_params(refit=False)
 
     search_cv_clone.fit(y, X_actual, forecasting_horizon=forecasting_horizon, X_future=X_future, X_forecast=X_forecast)
 
@@ -293,15 +293,13 @@ def check_search_refit_false_no_forecaster(
         pass
 
     # Restore original refit value
-    search_cv_clone.refit = original_refit
+    search_cv_clone.set_params(refit=original_refit)
 
 
 def check_search_predict_delegates(
     search_cv,
     y_train: pl.DataFrame,
     y_test: pl.DataFrame,
-    X_actual_train: pl.DataFrame | None = None,
-    X_actual_test: pl.DataFrame | None = None,
     X_future: pl.DataFrame | None = None,
     X_forecast: pl.DataFrame | None = None,
 ) -> None:
@@ -315,10 +313,10 @@ def check_search_predict_delegates(
         Training target data
     y_test : pl.DataFrame
         Test target data
-    X_actual_train : pl.DataFrame, optional
-        Training features
-    X_actual_test : pl.DataFrame, optional
-        Test features
+    X_future : pl.DataFrame, optional
+        Known-future features forwarded to predict()
+    X_forecast : pl.DataFrame, optional
+        External forecast features forwarded to predict()
 
     Raises
     ------
@@ -424,25 +422,35 @@ def check_search_rewind_delegates(
         If rewind() doesn't delegate correctly
 
     """
-    # Get initial observed_time
+    # Capture observed_time before the rewind so we can assert it moved in the
+    # direction the rewind actually performs.
     initial_observed_time = search_cv.best_forecaster_.observed_time_
 
-    # Rewind via search CV
+    # Rewind via search CV. rewind() sets observed state to the reset data, so
+    # the new observed_time must equal the last time in y_reset regardless of
+    # whether that is earlier or later than the pre-rewind state.
+    target_time = y_reset["time"][-1]
     search_cv.rewind(y_reset, X_actual_reset, X_future=X_future, X_forecast=X_forecast)
 
-    # Check that best_forecaster_ was rewound
+    # Check that best_forecaster_ was rewound to the reset target.
     reset_observed_time = search_cv.best_forecaster_.observed_time_
 
-    # observed_time should have changed
     if isinstance(initial_observed_time, dict):
         # Panel data case
         for group_name in initial_observed_time:
             assert reset_observed_time[group_name] != initial_observed_time[group_name], (
                 f"observed_time for group {group_name} should change after rewind"
             )
+            assert reset_observed_time[group_name] == target_time, (
+                f"observed_time for group {group_name} should be reset to the last time in y_reset "
+                f"({target_time}), got {reset_observed_time[group_name]}"
+            )
     else:
         # Non-panel case
         assert reset_observed_time != initial_observed_time, "observed_time should change after rewind"
+        assert reset_observed_time == target_time, (
+            f"observed_time should be reset to the last time in y_reset ({target_time}), got {reset_observed_time}"
+        )
 
 
 def check_search_multimetric_scoring(
@@ -541,7 +549,7 @@ def check_search_return_train_score(
 
     # Temporarily set return_train_score=True
     original_return_train_score = search_cv_clone.return_train_score
-    search_cv_clone.return_train_score = True
+    search_cv_clone.set_params(return_train_score=True)
 
     search_cv_clone.fit(y, X_actual, forecasting_horizon=forecasting_horizon, X_future=X_future, X_forecast=X_forecast)
 
@@ -558,7 +566,7 @@ def check_search_return_train_score(
             assert split_key in cv_results, f"cv_results_ must have '{split_key}' when return_train_score=True"
 
     # Restore original value
-    search_cv_clone.return_train_score = original_return_train_score
+    search_cv_clone.set_params(return_train_score=original_return_train_score)
 
 
 def check_search_error_score_handling(
@@ -591,7 +599,7 @@ def check_search_error_score_handling(
     search_cv_clone = clone(search_cv)
 
     # Set error_score to np.nan (don't raise)
-    search_cv_clone.error_score = np.nan
+    search_cv_clone.set_params(error_score=np.nan)
 
     # Note: This check assumes that invalid parameters will be tested
     # If all parameters are valid, this check may pass trivially
@@ -904,8 +912,6 @@ def check_search_panel_data(
     search_cv,
     y_train: pl.DataFrame,
     y_test: pl.DataFrame,
-    X_actual_train: pl.DataFrame | None = None,
-    X_actual_test: pl.DataFrame | None = None,
     groups: list[str] | None = None,
     X_future: pl.DataFrame | None = None,
     X_forecast: pl.DataFrame | None = None,
@@ -920,12 +926,12 @@ def check_search_panel_data(
         Training target data with panel groups
     y_test : pl.DataFrame
         Test target data with panel groups
-    X_actual_train : pl.DataFrame, optional
-        Training features with panel groups
-    X_actual_test : pl.DataFrame, optional
-        Test features with panel groups
     groups : list of str, optional
         Panel group names to test
+    X_future : pl.DataFrame, optional
+        Known-future features forwarded to predict()
+    X_forecast : pl.DataFrame, optional
+        External forecast features forwarded to predict()
 
     Raises
     ------
@@ -946,12 +952,12 @@ def check_search_panel_data(
 
         _, panel_groups = inspect_panel(y_pred)
 
-        # Check that all requested groups are present
+        # Check that all requested groups are present (exact group-key match;
+        # panel keys follow the exact group__column naming contract).
         pred_group_prefixes = set(panel_groups.keys())
         for group_name in groups:
-            # Group name might be a prefix
-            assert any(group_name in prefix for prefix in pred_group_prefixes), (
-                f"Requested panel group '{group_name}' not found in predictions"
+            assert group_name in pred_group_prefixes, (
+                f"Requested panel group '{group_name}' not found in predictions {pred_group_prefixes}"
             )
 
 
@@ -987,7 +993,7 @@ def check_search_method_availability(
     # For multimetric, preserve the original refit value (scorer name or callable)
     # For single metric, set refit=True
     if not (isinstance(search_cv.scoring, dict) and isinstance(search_cv.refit, str)):
-        search_cv_refit.refit = True
+        search_cv_refit.set_params(refit=True)
     search_cv_refit.fit(y, X_actual, forecasting_horizon=forecasting_horizon, X_future=X_future, X_forecast=X_forecast)
 
     # Methods should be available
@@ -996,7 +1002,7 @@ def check_search_method_availability(
 
     # Test with refit=False
     search_cv_no_refit = clone(search_cv)
-    search_cv_no_refit.refit = False
+    search_cv_no_refit.set_params(refit=False)
     search_cv_no_refit.fit(
         y, X_actual, forecasting_horizon=forecasting_horizon, X_future=X_future, X_forecast=X_forecast
     )
@@ -1014,8 +1020,6 @@ def check_search_interval_predict_delegates(
     search_cv,
     y_train: pl.DataFrame,
     y_test: pl.DataFrame,
-    X_actual_train: pl.DataFrame | None = None,
-    X_actual_test: pl.DataFrame | None = None,
     X_future: pl.DataFrame | None = None,
     X_forecast: pl.DataFrame | None = None,
 ) -> None:
@@ -1032,10 +1036,10 @@ def check_search_interval_predict_delegates(
         Training target data.
     y_test : pl.DataFrame
         Test target data.
-    X_actual_train : pl.DataFrame, optional
-        Training features.
-    X_actual_test : pl.DataFrame, optional
-        Test features.
+    X_future : pl.DataFrame, optional
+        Known-future features forwarded to predict_interval().
+    X_forecast : pl.DataFrame, optional
+        External forecast features forwarded to predict_interval().
 
     Raises
     ------

--- a/src/yohou/testing/transformer.py
+++ b/src/yohou/testing/transformer.py
@@ -9,6 +9,8 @@ Organized into three categories:
 3. Tag System Checks - Validate tag system correctness (3 functions)
 """
 
+import numpy as np
+
 try:
     import polars as pl
     import polars.selectors as cs
@@ -948,7 +950,6 @@ def check_transformer_preserve_dtypes(transformer, X: pl.DataFrame, y: pl.DataFr
                 X_p = None
 
             X_inv = transformer_clone.inverse_transform(X_trans, X_p)
-            X.tail(len(X_trans))
 
             for col, dtype in input_dtypes.items():
                 if col in X_inv.columns:
@@ -1001,12 +1002,18 @@ def check_fit_idempotent(transformer, X: pl.DataFrame, y: pl.DataFrame | None = 
 
     assert_frame_equal(X_trans1, X_trans2, rel_tol=1e-5, abs_tol=1e-8)
 
-    # Check fitted attributes match
+    # Check fitted attributes match. Some transformers store array-valued
+    # attributes (e.g. feature_names_in_ as a numpy array), so compare
+    # element-wise rather than relying on a scalar ``==``.
     for attr in ["feature_names_in_", "n_features_in_", "_observation_horizon"]:
         if hasattr(transformer1, attr):
             val1 = getattr(transformer1, attr)
             val2 = getattr(transformer2, attr)
-            assert val1 == val2, f"Attribute '{attr}' differs after double fit: {val1} vs {val2}"
+            if isinstance(val1, np.ndarray) or isinstance(val2, np.ndarray):
+                equal = np.array_equal(np.asarray(val1), np.asarray(val2))
+            else:
+                equal = val1 == val2
+            assert equal, f"Attribute '{attr}' differs after double fit: {val1} vs {val2}"
 
 
 def check_inverse_transform_round_trip(

--- a/src/yohou/utils/__init__.py
+++ b/src/yohou/utils/__init__.py
@@ -11,7 +11,7 @@ from .panel import (
     select_panel_columns,
 )
 from .pivot import window_futures
-from .polars import cast, get_numeric_columns
+from .polars import cast, get_categorical_columns, get_numeric_columns
 from .tabularization import tabularize
 from .tags import (
     CLASS_PROBA,
@@ -84,6 +84,7 @@ __all__ = [
     "check_sufficient_rows",
     "check_time_column",
     "dict_to_panel",
+    "get_categorical_columns",
     "get_group_df",
     "get_numeric_columns",
     "inspect_panel",

--- a/src/yohou/utils/__init__.py
+++ b/src/yohou/utils/__init__.py
@@ -4,7 +4,6 @@ from .discovery import all_displays, all_estimators, all_functions
 from .panel import (
     dict_to_panel,
     get_group_df,
-    inspect_locality,
     inspect_panel,
     panel_aware_prefix,
     panel_aware_rename,
@@ -87,7 +86,6 @@ __all__ = [
     "dict_to_panel",
     "get_group_df",
     "get_numeric_columns",
-    "inspect_locality",
     "inspect_panel",
     "interval_to_timedelta",
     "panel_aware_prefix",

--- a/src/yohou/utils/discovery.py
+++ b/src/yohou/utils/discovery.py
@@ -245,7 +245,7 @@ def _is_checked_function(item: object) -> bool:
         return False
 
     mod = item.__module__
-    return not (not mod.startswith("yohou.") or mod.endswith("estimator_checks"))
+    return mod.startswith("yohou.") and not mod.endswith("estimator_checks")
 
 
 def all_functions() -> list[tuple[str, object]]:
@@ -283,7 +283,7 @@ def all_functions() -> list[tuple[str, object]]:
             except ImportError:
                 continue
             functions = inspect.getmembers(module, _is_checked_function)
-            functions = [(func.__name__, func) for name, func in functions if not name.startswith("_")]
+            functions = [(func.__name__, func) for _, func in functions]
             all_functions.extend(functions)
 
     # drop duplicates, sort for reproducibility

--- a/src/yohou/utils/panel.py
+++ b/src/yohou/utils/panel.py
@@ -8,7 +8,6 @@ import polars as pl
 __all__ = [
     "dict_to_panel",
     "get_group_df",
-    "inspect_locality",
     "inspect_panel",
     "panel_aware_prefix",
     "panel_aware_rename",
@@ -376,15 +375,30 @@ def dict_to_panel(data: dict[str, pl.DataFrame] | pl.DataFrame | None) -> pl.Dat
     if data is None or isinstance(data, pl.DataFrame):
         return data
 
+    # Reject empty dicts before the all-None check: an empty dict satisfies
+    # all(...) vacuously, which would otherwise mask it as an all-None input.
+    if not data:
+        raise ValueError("Cannot convert empty dict to panel DataFrame")
+
     if all(v is None for v in data.values()):
         return None
 
     # Convert dict of DataFrames to single DataFrame with prefixed columns
-    if not data:
-        raise ValueError("Cannot convert empty dict to panel DataFrame")
-
     # Start with the first group to get the time column
     first_group_name = next(iter(data))
+    reference_times = data[first_group_name].get_column("time")
+    reference_set = set(reference_times.to_list())
+
+    # All groups must share an identical time axis; an inner join would
+    # otherwise silently drop timestamps not present in every group.
+    misaligned = [name for name, df in data.items() if set(df.get_column("time").to_list()) != reference_set]
+    if misaligned:
+        raise ValueError(
+            f"dict_to_panel requires every group to share an identical 'time' axis, "
+            f"but these groups differ from group '{first_group_name}': {misaligned}. "
+            f"Align the group time columns (e.g. resample or reindex) before assembling the panel."
+        )
+
     result = data[first_group_name].select("time")
 
     # Add each group's columns with prefixes
@@ -514,6 +528,3 @@ def panel_aware_suffix(col: str, suffix: str) -> str:
 
     """
     return panel_aware_rename(col, lambda member: f"{member}_{suffix}")
-
-
-inspect_locality = inspect_panel

--- a/src/yohou/utils/panel.py
+++ b/src/yohou/utils/panel.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Callable
 
 import polars as pl
+import polars.selectors as cs
 
 __all__ = [
     "dict_to_panel",
@@ -289,27 +290,17 @@ def select_panel_columns(
     if groups is None:
         return df
 
-    # Determine which columns to keep
-    cols_to_keep = ["time"]
+    # Columns belonging to a panel group start with "<group>__"; the regex stays
+    # in the polars engine and preserves the original column order on select.
+    panel_regex = "^(?:" + "|".join(re.escape(g) for g in groups) + ")__"
+    panel_selector = cs.matches(panel_regex)
 
-    for col in df.columns:
-        if col == "time":
-            continue
+    selector = cs.by_name("time") | panel_selector
+    if include_global:
+        # Global columns are the non-time columns that match no group prefix.
+        selector = selector | (cs.all() - cs.by_name("time") - panel_selector)
 
-        # Check if this column belongs to any panel group
-        is_panel = False
-        for group_prefix in groups:
-            if col.startswith(f"{group_prefix}__"):
-                is_panel = True
-                break
-
-        if is_panel:
-            cols_to_keep.append(col)
-        elif include_global:
-            # Global column (doesn't match any group prefix)
-            cols_to_keep.append(col)
-
-    return df.select(cols_to_keep)
+    return df.select(selector)
 
 
 def dict_to_panel(data: dict[str, pl.DataFrame] | pl.DataFrame | None) -> pl.DataFrame | None:

--- a/src/yohou/utils/pivot.py
+++ b/src/yohou/utils/pivot.py
@@ -6,9 +6,39 @@ from datetime import timedelta
 
 import polars as pl
 
-from yohou.utils.validation import add_interval
+from yohou.utils.validation import parse_interval
 
 __all__ = ["window_forecasts", "window_futures"]
+
+_POLARS_OFFSET_UNITS: dict[str, tuple[int, str]] = {
+    "d": (1, "d"),
+    "h": (1, "h"),
+    "m": (1, "m"),
+    "s": (1, "s"),
+    "w": (1, "w"),
+    "mo": (1, "mo"),
+    "q": (3, "mo"),
+    "y": (1, "y"),
+    "ms": (1, "ms"),
+    "us": (1, "us"),
+    "ns": (1, "ns"),
+}
+
+
+def _target_time_expr(base_col: str, step_col: str, interval: str | timedelta) -> pl.Expr:
+    """Return an expression for ``base + step * interval`` over a DataFrame.
+
+    Mirrors :func:`yohou.utils.validation.add_interval` in vectorized form,
+    including the calendar-aware semantics of ``offset_by`` for month, quarter,
+    and year units (day-of-month clamping and leap-year handling).
+    """
+    if isinstance(interval, timedelta):
+        return pl.col(base_col) + pl.duration(microseconds=int(interval.total_seconds() * 1_000_000)) * pl.col(step_col)
+
+    multiplier, unit = parse_interval(interval)
+    scale, polars_unit = _POLARS_OFFSET_UNITS[unit]
+    total = (pl.col(step_col) * (multiplier * scale)).cast(pl.String) + pl.lit(polars_unit)
+    return pl.col(base_col).dt.offset_by(total)
 
 
 def window_futures(
@@ -97,15 +127,7 @@ def window_futures(
         msg = f"No value columns found. DataFrame has only '{time_col}'. At least one value column is required."
         raise ValueError(msg)
 
-    # Build a lookup mapping from time → row values
-    # Join approach: create a tidy representation with vintage_time, then pivot.
-    rows: list[dict] = []
-    for obs_time in observation_times.to_list():
-        for step in range(1, forecasting_horizon + 1):
-            target_time = add_interval(obs_time, interval, n=step)
-            rows.append({"vintage_time": obs_time, "time": target_time, "_step": step})
-
-    if not rows:
+    if observation_times.is_empty():
         # No observation times: return empty frame with correct schema
         cols = {"time": pl.Series([], dtype=observation_times.dtype)}
         for col in value_cols:
@@ -113,7 +135,15 @@ def window_futures(
                 cols[f"{col}_step_{step}"] = pl.Series([], dtype=X_future[col].dtype)
         return pl.DataFrame(cols)
 
-    lookup = pl.DataFrame(rows)
+    # Build a lookup table as the cross product of observation times and steps,
+    # then compute each target time with a vectorized calendar-aware expression.
+    steps = pl.DataFrame({"_step": range(1, forecasting_horizon + 1)})
+    lookup = (
+        pl
+        .DataFrame({"vintage_time": observation_times})
+        .join(steps, how="cross")
+        .with_columns(_target_time_expr("vintage_time", "_step", interval).alias("time"))
+    )
 
     # Join lookup with X_future on time to get values at each target time
     joined = lookup.join(
@@ -259,28 +289,20 @@ def window_forecasts(
     )
     # matched has columns: time, _vintage (the matched vintage or null)
 
-    # Build lookup rows: for each (obs_time, matched_vintage), target times T+1..T+H
-    rows: list[dict] = []
-    for obs_time, vintage in zip(
-        matched["time"].to_list(),
-        matched["_vintage"].to_list(),
-        strict=True,
-    ):
-        if vintage is None:
-            continue
-        for step in range(1, forecasting_horizon + 1):
-            target_time = add_interval(obs_time, interval, n=step)
-            rows.append({
-                "_obs_time": obs_time,
-                vintage_col: vintage,
-                time_col: target_time,
-                "_step": step,
-            })
-
-    if not rows:
+    # Build lookup table: for each (obs_time, matched_vintage), target times
+    # T+1..T+H. Drop observation times with no matching vintage, then take the
+    # cross product with steps and compute target times in a vectorized pass.
+    matched_with_vintage = matched.filter(pl.col("_vintage").is_not_null())
+    if matched_with_vintage.is_empty():
         return _null_result()
 
-    lookup = pl.DataFrame(rows)
+    steps = pl.DataFrame({"_step": range(1, forecasting_horizon + 1)})
+    lookup = (
+        matched_with_vintage
+        .rename({"time": "_obs_time", "_vintage": vintage_col})
+        .join(steps, how="cross")
+        .with_columns(_target_time_expr("_obs_time", "_step", interval).alias(time_col))
+    )
 
     # Join lookup with X_forecast to get values at each target time from the matched vintage
     joined = lookup.join(

--- a/src/yohou/utils/polars.py
+++ b/src/yohou/utils/polars.py
@@ -62,11 +62,8 @@ def cast(
 
         if target_dtype.is_integer():
             exprs.append(pl.col(col).round().cast(target_dtype).alias(col))
-        elif not target_dtype.is_numeric():
-            # Non-numeric types (Categorical, Enum, String, Boolean, etc.)
-            # are cast directly without rounding.
-            exprs.append(pl.col(col).cast(target_dtype).alias(col))
         else:
+            # Floats and non-numeric types are cast directly without rounding.
             exprs.append(pl.col(col).cast(target_dtype).alias(col))
 
     return df.with_columns(exprs)
@@ -104,19 +101,7 @@ def get_numeric_columns(df: pl.DataFrame, exclude: list[str] | None = None) -> l
 
     """
     exclude = exclude or []
-    numeric_types = [
-        pl.Int8,
-        pl.Int16,
-        pl.Int32,
-        pl.Int64,
-        pl.UInt8,
-        pl.UInt16,
-        pl.UInt32,
-        pl.UInt64,
-        pl.Float32,
-        pl.Float64,
-    ]
-    return [col for col in df.columns if any(df[col].dtype == dtype for dtype in numeric_types) and col not in exclude]
+    return [col for col in df.columns if df.schema[col].is_numeric() and col not in exclude]
 
 
 def is_categorical_dtype(dtype: pl.DataType) -> bool:

--- a/src/yohou/utils/validate_data.py
+++ b/src/yohou/utils/validate_data.py
@@ -310,11 +310,14 @@ def _check_multi_vintage_time(y_pred: pl.DataFrame) -> None:
             "'time' column must not have missing values."
         )
 
-    # Check sorting within each vintage
-    for ot in y_pred["vintage_time"].unique().sort():
-        vintage = y_pred.filter(pl.col("vintage_time") == ot)
-        if not vintage["time"].is_sorted():
-            raise ValueError(f"'time' column within vintage_time={ot} is not sorted in ascending order.")
+    # Check sorting within each vintage with a single windowed scan: within a
+    # vintage, consecutive time diffs must never be negative.
+    unsorted = y_pred.with_columns(pl.col("time").diff().over("vintage_time").alias("_delta")).filter(
+        pl.col("_delta") < pl.duration(seconds=0)
+    )
+    if unsorted.height > 0:
+        ot = unsorted["vintage_time"].min()
+        raise ValueError(f"'time' column within vintage_time={ot} is not sorted in ascending order.")
 
 
 def _truncate_partial_vintage(
@@ -502,13 +505,12 @@ def validate_scorer_data(
 
         check_time_column(y_true)
 
-        # Validate seasonality for scorers with seasonality parameter
-        # y_true still has time column, so subtract 1 for data rows
+        # Validate that y_train has more rows than the seasonality period.
         if hasattr(scorer, "seasonality"):
             seasonality_val = scorer.seasonality
             if isinstance(seasonality_val, int) and len(y_true) <= seasonality_val:
                 raise ValueError(
-                    f"Training data length ({len(y_true) - 1}) must be greater than "
+                    f"Training data length ({len(y_true)}) must be greater than "
                     f"seasonality ({seasonality_val}). Cannot compute seasonal naive forecast errors."
                 )
 

--- a/src/yohou/utils/validation.py
+++ b/src/yohou/utils/validation.py
@@ -2,6 +2,7 @@
 
 import calendar
 import re
+import warnings
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -441,6 +442,11 @@ def check_groups_exist(
     - [`check_panel_groups_match`][yohou.utils.validation.check_panel_groups_match] : Validate y and X_actual have matching panel groups.
 
     """
+    warnings.warn(
+        "check_groups_exist is deprecated; use check_groups instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if requested_panel_groups is None:
         return
 
@@ -730,14 +736,13 @@ def check_interval_consistency(df: pl.DataFrame) -> str:
     if df is None:
         raise ValueError("DataFrame cannot be None")
 
-    time_series = df["time"].to_list()
-
-    if len(time_series) < 2:
+    if df.height < 2:
         raise ValueError("Need at least 2 time points to infer interval")
 
-    # Calculate deltas
-    deltas = [time_series[i + 1] - time_series[i] for i in range(len(time_series) - 1)]
-    unique_deltas = sorted(set(deltas))
+    # Compute consecutive deltas with polars rather than a Python loop. The
+    # full datetime list is still needed downstream for month/day arithmetic.
+    unique_deltas = sorted(df["time"].diff().drop_nulls().unique().to_list())
+    time_series = df["time"].to_list()
 
     # Check if deltas are all similar (within small tolerance for rounding)
     delta_days = [d.days for d in unique_deltas]
@@ -945,10 +950,6 @@ def validate_column_names(df: pl.DataFrame) -> None:
     # Valid: store_1__sales, my_store__my_sales
     # Invalid: store___sales (underscore adjacent to __), _store__sales, store__sales_
     # Strategy: split on __, check parts don't start/end with _ and are non-empty
-
-    # Handle None case
-    if df is None:
-        return
 
     for col_name in df.columns:
         if col_name == "time":

--- a/src/yohou/weighting/weighters.py
+++ b/src/yohou/weighting/weighters.py
@@ -267,12 +267,13 @@ class LinearDecayWeighter(BaseWeighter):
             weights = ranks / (n - 1)
         else:
             cutoff = n - self.max_steps
+            # The most-recent key (rank n - 1) maps to exactly 1.0, so no
+            # additional upper clamp is required.
             weights = np.where(
                 ranks < cutoff,
                 0.0,
                 (ranks - cutoff) / (self.max_steps - 1) if self.max_steps > 1 else 1.0,
             )
-            weights = np.minimum(1.0, weights)
 
         return pl.Series(weights, dtype=pl.Float64).alias("weight")
 
@@ -337,7 +338,11 @@ class SeasonalEmphasisWeighter(BaseWeighter):
         ranks = key.rank(method="ordinal") - 1
         in_phase = np.zeros(n, dtype=bool)
         for s in seasonalities:
-            most_recent_phase = int(ranks[-1]) % s
+            # The most-recent key has the highest ordinal rank (n - 1),
+            # regardless of the positional order of ``key``. Using ranks[-1]
+            # (the last positional element) is only correct when ``key`` is
+            # already sorted ascending.
+            most_recent_phase = (n - 1) % s
             phases = ranks.to_numpy() % s
             in_phase = in_phase | (phases == most_recent_phase)
 
@@ -397,8 +402,16 @@ class LookupWeighter(BaseWeighter):
         mapping = self.mapping or {}
         effective_default = mapping.get("*", self.default)
         lookup = {k: v for k, v in mapping.items() if k != "*"}
-        weights = np.array([lookup.get(k, effective_default) for k in key.to_list()], dtype=np.float64)
-        return pl.Series(weights, dtype=pl.Float64).alias("weight")
+        if lookup:
+            weights = key.replace_strict(
+                list(lookup.keys()),
+                list(lookup.values()),
+                default=effective_default,
+                return_dtype=pl.Float64,
+            )
+        else:
+            weights = pl.Series(np.full(len(key), effective_default, dtype=np.float64))
+        return weights.alias("weight")
 
 
 class TableWeighter(BaseWeighter):
@@ -461,8 +474,13 @@ class TableWeighter(BaseWeighter):
 
         nan_mask = np.isnan(weights_np)
         if nan_mask.any():
-            missing_keys = key.filter(pl.Series(nan_mask)).unique().to_list()
-            raise ValueError(f"Weight DataFrame has no values for {self.on}s: {missing_keys}")
+            bad_keys = key.filter(pl.Series(nan_mask)).unique()
+            present_keys = set(self.frame[self.on].to_list())
+            absent = [k for k in bad_keys.to_list() if k not in present_keys]
+            null_valued = [k for k in bad_keys.to_list() if k in present_keys]
+            if absent:
+                raise ValueError(f"Weight DataFrame has no values for {self.on}s: {absent}")
+            raise ValueError(f"Weight DataFrame has explicit null '{weight_col}' values for {self.on}s: {null_valued}")
 
         return pl.Series(weights_np, dtype=pl.Float64).alias("weight")
 
@@ -518,7 +536,7 @@ class CompositeWeighter(BaseWeighter, _BaseComposition):
 
     _parameter_constraints: dict = {
         "weighters": [list, None],
-        "combination": [str],
+        "combination": [StrOptions({"multiply", "mean"})],
         "weights": [list, None],
     }
 
@@ -571,8 +589,6 @@ class CompositeWeighter(BaseWeighter, _BaseComposition):
         for item in self.weighters:
             if not (isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], str)):
                 raise ValueError(f"Each entry in `weighters` must be a (name, weighter) tuple, got {item!r}")
-        if self.combination not in ("multiply", "mean"):
-            raise ValueError(f"combination must be 'multiply' or 'mean', got {self.combination!r}")
         if self.weights is not None and len(self.weights) != len(self.weighters):
             raise ValueError(
                 f"weights length ({len(self.weights)}) must match weighters length ({len(self.weighters)})"
@@ -586,6 +602,7 @@ class CompositeWeighter(BaseWeighter, _BaseComposition):
 
     def compute_weights(self, key: pl.Series, group_name: str | None = None) -> pl.Series:
         """Combine all component weights for ``key`` by product or mean."""
+        self._validate_params()
         self._check_weighters()
         alphas = self._resolved_weights()
         series = [weighter.compute_weights(key, group_name) for _name, weighter in self.weighters]  # ty: ignore[not-iterable]
@@ -595,12 +612,17 @@ class CompositeWeighter(BaseWeighter, _BaseComposition):
             for s, alpha in zip(series, alphas, strict=True):
                 result = result * s.pow(alpha)
         else:  # mean
+            total_alpha = sum(alphas)
+            if total_alpha == 0:
+                raise ValueError(
+                    "CompositeWeighter with combination='mean' requires the mixing "
+                    f"coefficients to sum to a nonzero value, got weights={alphas} "
+                    "(sum is zero). A zero sum would silently produce all-zero weights."
+                )
             result = pl.Series(np.zeros(len(key)), dtype=pl.Float64)
             for s, alpha in zip(series, alphas, strict=True):
                 result = result + s * alpha
-            total_alpha = sum(alphas)
-            if total_alpha != 0:
-                result = result / total_alpha
+            result = result / total_alpha
 
         return result.alias("weight")
 

--- a/tests/base/test_base_functions.py
+++ b/tests/base/test_base_functions.py
@@ -471,6 +471,33 @@ class TestRewindTransformersOne:
         assert X_t is not None
         assert len(X_t) == observation_horizon
 
+    def test_zero_observation_horizon(self, time_series_factory, SimpleTransformer):
+        """observation_horizon == 0 rewinds over all rows, not an empty slice.
+
+        With negative slicing, y[:-0] is empty and y[-0:] is the full frame,
+        which inverts the rewind/observe windows. The explicit split index keeps
+        the rewind window as the full frame and the observe window empty.
+        """
+        y = time_series_factory(length=20, n_components=2)
+        X_actual = make_exog_data(20, 3)
+
+        target_transformer = SimpleTransformer(observation_horizon=0, add_constant=10.0)
+        target_transformer.fit(y)
+
+        X_t = _rewind_transformers_one(
+            y=y,
+            X_actual=X_actual,
+            target_transformer=target_transformer,
+            feature_transformer=None,
+            observation_horizon=0,
+            target_as_feature="transformed",
+        )
+
+        # Zero horizon implies an empty observation window, not the full frame
+        # that the buggy y[-0:] slice would have produced.
+        assert X_t is not None
+        assert len(X_t) == 0
+
     def test_insufficient_data(self, time_series_factory, SimpleTransformer):
         """Test with insufficient data raises appropriate error."""
         y = time_series_factory(length=10, n_components=2)

--- a/tests/base/test_base_functions.py
+++ b/tests/base/test_base_functions.py
@@ -516,3 +516,55 @@ class TestRewindTransformersOne:
                 observation_horizon=observation_horizon,
                 target_as_feature="transformed",
             )
+
+    def test_feature_output_without_time_column_uses_tail(self, time_series_factory):
+        """A feature transformer that drops 'time' falls back to the last row."""
+        from unittest.mock import MagicMock
+
+        y = time_series_factory(length=20, n_components=1)
+        X_actual = make_exog_data(20, 2)
+
+        feature_transformer = MagicMock()
+        feature_transformer.observation_horizon = 2
+        # rewind_transform output has no 'time' column.
+        feature_transformer.rewind_transform.return_value = pl.DataFrame({"f": [1.0, 2.0, 3.0]})
+
+        X_t = _rewind_transformers_one(
+            y=y,
+            X_actual=X_actual,
+            target_transformer=None,
+            feature_transformer=feature_transformer,
+            observation_horizon=5,
+            target_as_feature=None,
+        )
+
+        # No time column to align on, so the last row is taken.
+        assert X_t.height == 1
+        assert X_t["f"][0] == 3.0
+
+    def test_feature_output_missing_last_time_uses_tail(self, time_series_factory):
+        """When the latest observation is dropped, alignment falls back to the tail."""
+        from unittest.mock import MagicMock
+
+        y = time_series_factory(length=20, n_components=1)
+        X_actual = make_exog_data(20, 2)
+        last_time = y["time"][-1]
+
+        # rewind_transform keeps 'time' but never includes last_time, so the
+        # timestamp filter is empty and the tail(1) fallback is used.
+        earlier = [last_time - timedelta(days=2), last_time - timedelta(days=1)]
+        feature_transformer = MagicMock()
+        feature_transformer.observation_horizon = 2
+        feature_transformer.rewind_transform.return_value = pl.DataFrame({"time": earlier, "f": [1.0, 2.0]})
+
+        X_t = _rewind_transformers_one(
+            y=y,
+            X_actual=X_actual,
+            target_transformer=None,
+            feature_transformer=feature_transformer,
+            observation_horizon=5,
+            target_as_feature=None,
+        )
+
+        assert X_t.height == 1
+        assert X_t["f"][0] == 2.0

--- a/tests/base/test_forecaster_contract.py
+++ b/tests/base/test_forecaster_contract.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import polars as pl
 import pytest
-from sklearn.exceptions import NotFittedError
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from conftest import SimpleTransformer
@@ -26,26 +25,9 @@ class TestBaseForecasterFit:
         result = f.fit(y, forecasting_horizon=3)
         assert result is f
 
-    def test_fit_sets_forecasting_horizon(self, y_X_factory):
-        """Fit sets fit_forecasting_horizon_ attribute."""
-        y, X = y_X_factory(length=50, n_targets=1, n_features=0)
-        f = PointReductionForecaster()
-        f.fit(y, forecasting_horizon=5)
-        assert f.fit_forecasting_horizon_ == 5
-
-    def test_fit_sets_interval(self, y_X_factory):
-        """Fit sets interval_ from time series."""
-        y, X = y_X_factory(length=50, n_targets=1, n_features=0)
-        f = PointReductionForecaster()
-        f.fit(y, forecasting_horizon=1)
-        assert hasattr(f, "interval_")
-
-    def test_fit_sets_y_observed(self, y_X_factory):
-        """Fit sets _y_observed buffer."""
-        y, X = y_X_factory(length=50, n_targets=1, n_features=0)
-        f = PointReductionForecaster()
-        f.fit(y, forecasting_horizon=1)
-        assert hasattr(f, "_y_observed")
+    # The individual fitted attributes (fit_forecasting_horizon_, interval_,
+    # _y_observed) are exhaustively covered by check_fit_sets_forecaster_attributes
+    # in the TestForecasterCommon systematic suite (tests/test_common.py).
 
 
 class TestBaseForecasterPredict:
@@ -96,12 +78,9 @@ class TestBaseForecasterObserve:
         result = f.observe(y[50:])
         assert result is f
 
-    def test_observe_not_fitted_raises(self, y_X_factory):
-        """Observe before fit raises NotFittedError."""
-        y, X = y_X_factory(length=50, n_targets=1, n_features=0)
-        f = PointReductionForecaster()
-        with pytest.raises(NotFittedError):
-            f.observe(y)
+    # observe() before fit raising NotFittedError is covered by the observe()
+    # branch of check_forecaster_methods_call_check_is_fitted in the systematic
+    # suite (tests/test_common.py).
 
 
 class TestBaseForecasterRewind:
@@ -120,11 +99,11 @@ class TestBaseForecasterObservationHorizon:
     """Tests for observation_horizon property."""
 
     def test_horizon_after_fit(self, y_X_factory):
-        """Observation horizon is accessible after fit."""
+        """A PointReductionForecaster with no stateful transformer needs no buffer."""
         y, X = y_X_factory(length=50, n_targets=1, n_features=0)
         f = PointReductionForecaster()
         f.fit(y, forecasting_horizon=1)
-        assert f.observation_horizon >= 0
+        assert f.observation_horizon == 0
 
     def test_horizon_includes_transformer(self, y_X_factory):
         """Observation horizon includes target transformer horizon."""
@@ -221,17 +200,30 @@ class TestBaseForecasterPanelObserve:
     """Tests for panel observe path."""
 
     def test_panel_observe(self, y_X_factory):
-        """Observe dispatches to panel observe when fitted on panel data."""
+        """Observe advances observed_time_ for every panel group."""
         y, X = y_X_factory(length=60, n_targets=1, n_features=0, panel=True, n_groups=2)
         f = PointReductionForecaster()
         f.fit(y[:50], forecasting_horizon=1)
+        observed_before = dict(f.observed_time_)
+
         result = f.observe(y[50:])
+
         assert result is f
+        last_time = y["time"][-1]
+        for group, before in observed_before.items():
+            assert f.observed_time_[group] > before
+            assert f.observed_time_[group] == last_time
 
     def test_panel_rewind(self, y_X_factory):
-        """Rewind dispatches to panel rewind when fitted on panel data."""
+        """Rewind rolls observed_time_ back to the rewind boundary per group."""
         y, X = y_X_factory(length=60, n_targets=1, n_features=0, panel=True, n_groups=2)
         f = PointReductionForecaster()
         f.fit(y[:50], forecasting_horizon=1)
+        f.observe(y[50:])
+
         result = f.rewind(y[:50])
+
         assert result is f
+        boundary = y[:50]["time"][-1]
+        for group_time in f.observed_time_.values():
+            assert group_time == boundary

--- a/tests/class_proba/test_reduction.py
+++ b/tests/class_proba/test_reduction.py
@@ -99,12 +99,6 @@ class TestClassProbaReductionSystematic:
         run_checks(
             forecaster,
             _yield_yohou_forecaster_checks(forecaster, y_train, X_actual_train, y_test, X_actual_test),
-            expected_failures={
-                "check_predict_time_columns",
-                "check_class_proba_predict_returns_labels",
-                "check_panel_data",
-                "check_panel_single_group",
-            },
         )
 
 

--- a/tests/compose/test_column_transformer.py
+++ b/tests/compose/test_column_transformer.py
@@ -9,9 +9,10 @@ from sklearn.base import clone
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from conftest import SimpleTransformer, StatelessTransformer
+from conftest import SimpleTransformer, StatelessTransformer, run_checks
 from yohou.compose import ColumnTransformer
 from yohou.preprocessing.window import LagTransformer
+from yohou.testing import _yield_yohou_transformer_checks
 
 
 @pytest.fixture
@@ -571,3 +572,83 @@ class TestColumnTransformerNestedParams:
         assert len(ct.transformers[0]) == 3
         assert ct.transformers[0][2] == ["a"]
         assert isinstance(ct.transformers[0][1], StatelessTransformer)
+
+
+class TestColumnTransformerSystematicChecks:
+    """Run the generic transformer contract over representative configurations.
+
+    ColumnTransformer requires constructor arguments, so it is excluded from
+    the auto-discovered ``TestTransformerCommon`` suite in ``tests/test_common.py``
+    (it sits in ``_SKIP_COMMON``). This dedicated parametrization wires it into
+    ``_yield_yohou_transformer_checks`` so the data-driven transformer contract
+    actually runs against it.
+    """
+
+    @staticmethod
+    def _data(length: int = 100):
+        from datetime import datetime, timedelta
+
+        time = pl.datetime_range(
+            start=datetime(2021, 1, 1),
+            end=datetime(2021, 1, 1) + timedelta(seconds=length - 1),
+            interval="1s",
+            eager=True,
+        )
+        return pl.DataFrame({
+            "time": time,
+            "a": [float(x) for x in range(length)],
+            "b": [float(x) * 10 for x in range(length)],
+            "c": [float(x) * 100 for x in range(length)],
+        })
+
+    @pytest.mark.parametrize(
+        "name,factory,extra_xfail",
+        [
+            (
+                "stateless-only",
+                lambda: ColumnTransformer(
+                    transformers=[("t1", StatelessTransformer(), ["a", "b"])],
+                    remainder="drop",
+                ),
+                set(),
+            ),
+            (
+                "stateful",
+                lambda: ColumnTransformer(
+                    transformers=[("t1", SimpleTransformer(observation_horizon=2, add_constant=1.0), ["a"])],
+                    remainder="drop",
+                ),
+                # The composition reassembles per-column outputs and does not
+                # drop warmup rows from the combined frame; only relevant when a
+                # component is stateful.
+                {"check_transform_drops_warmup_rows"},
+            ),
+            (
+                "passthrough-remainder",
+                lambda: ColumnTransformer(
+                    transformers=[("t1", SimpleTransformer(observation_horizon=0, add_constant=1.0), ["a"])],
+                    remainder="passthrough",
+                ),
+                set(),
+            ),
+        ],
+    )
+    def test_column_transformer_checks(self, name, factory, extra_xfail):
+        """Run the systematic transformer checks for a ColumnTransformer config."""
+        data = self._data()
+        X_train = data[:80]
+        X_test = data[80:]
+
+        transformer = clone(factory())
+        transformer.fit(X_train)
+
+        # ColumnTransformer computes observation_horizon dynamically from its
+        # components (a property) rather than storing _observation_horizon at
+        # fit, so check_fit_sets_attributes does not apply by design.
+        expected_failures = {"check_fit_sets_attributes"} | extra_xfail
+
+        run_checks(
+            transformer,
+            _yield_yohou_transformer_checks(transformer, X_train, None, X_test),
+            expected_failures=expected_failures,
+        )

--- a/tests/compose/test_decomposer.py
+++ b/tests/compose/test_decomposer.py
@@ -258,6 +258,35 @@ class TestUpdateReset:
         y_pred = forecaster.predict(forecasting_horizon=5)
         assert len(y_pred) == 5
 
+    def test_rewind_threads_residuals_through_components(self, daily_data):
+        """Rewind seeds each component with its residual stage, not full y.
+
+        Under the residual-threading contract, the second component is rewound
+        on (target - first component's prediction), so its observed buffer must
+        differ from the first component's buffer, which is rewound on the full
+        target. A regression that seeds every component with the full target
+        would make these buffers identical.
+        """
+        forecaster = DecompositionPipeline([
+            ("level", SeasonalNaive(seasonality=1)),
+            ("seasonality", SeasonalNaive(seasonality=7)),
+        ])
+        forecaster.fit(daily_data[:30], forecasting_horizon=5)
+        forecaster.observe(daily_data[30:40])
+        forecaster.rewind(daily_data[20:40])
+
+        named = dict(forecaster.forecasters_)
+        level_observed = named["level"]._y_observed
+        seasonality_observed = named["seasonality"]._y_observed
+        assert level_observed is not None
+        assert seasonality_observed is not None
+
+        level_vals = level_observed.select(pl.exclude("time")).to_numpy()
+        seasonality_vals = seasonality_observed.select(pl.exclude("time")).to_numpy()
+
+        # The seasonality component sees residuals, not the raw target.
+        assert not (level_vals == seasonality_vals).all()
+
     def test_observation_horizon(self, daily_data):
         """Test observation_horizon property."""
         forecaster = DecompositionPipeline([

--- a/tests/compose/test_decomposer.py
+++ b/tests/compose/test_decomposer.py
@@ -165,6 +165,24 @@ class TestResiduals:
         assert "value" in trend_residuals.columns
         assert len(trend_residuals) == 30
 
+    def test_store_residuals_then_observe_appends(self, daily_data):
+        """observe() appends to residuals_ without KeyError after fit."""
+        forecaster = DecompositionPipeline(
+            [
+                ("trend", PolynomialTrendForecaster(degree=1)),
+                ("seasonality", SeasonalNaive(seasonality=7)),
+            ],
+            store_residuals=True,
+        )
+        forecaster.fit(daily_data[:30], forecasting_horizon=5)
+        len_before = len(forecaster.residuals_["trend"])
+
+        forecaster.observe(daily_data[30:40])
+
+        assert "trend" in forecaster.residuals_
+        assert "seasonality" in forecaster.residuals_
+        assert len(forecaster.residuals_["trend"]) > len_before
+
 
 class TestTargetTransformer:
     """Tests for target transformer (e.g., multiplicative decomposition)."""

--- a/tests/compose/test_local_panel_forecaster.py
+++ b/tests/compose/test_local_panel_forecaster.py
@@ -537,3 +537,59 @@ class TestLocalPanelForecasterExogenous:
         # Should have lower/upper bound columns
         bound_cols = [c for c in y_pred.columns if "lower" in c or "upper" in c]
         assert len(bound_cols) > 0
+
+
+class TestReassemblePanelPredictions:
+    """Unit tests for _reassemble_panel_predictions stitching logic."""
+
+    def _forecaster(self):
+        return LocalPanelForecaster(SeasonalNaive(seasonality=1))
+
+    def test_empty_mapping_returns_empty_frame(self):
+        """No group predictions yields an empty DataFrame."""
+        result = self._forecaster()._reassemble_panel_predictions({})
+        assert result.height == 0
+        assert result.width == 0
+
+    def test_aligned_groups_join_and_sort(self):
+        """Aligned time grids join on time keys and sort by vintage/time."""
+        time = [datetime(2020, 1, 2), datetime(2020, 1, 1)]
+        vintage = [datetime(2020, 1, 1), datetime(2020, 1, 1)]
+        preds = {
+            "a": pl.DataFrame({"vintage_time": vintage, "time": time, "value": [2.0, 1.0]}),
+            "b": pl.DataFrame({"vintage_time": vintage, "time": time, "value": [20.0, 10.0]}),
+        }
+        result = self._forecaster()._reassemble_panel_predictions(preds)
+
+        assert result["time"].to_list() == [datetime(2020, 1, 1), datetime(2020, 1, 2)]
+        assert result["a__value"].to_list() == [1.0, 2.0]
+        assert result["b__value"].to_list() == [10.0, 20.0]
+
+    def test_mismatched_row_counts_raise(self):
+        """Groups producing different numbers of rows raise a clear error."""
+        preds = {
+            "a": pl.DataFrame({"time": [datetime(2020, 1, 1), datetime(2020, 1, 2)], "value": [1.0, 2.0]}),
+            "b": pl.DataFrame({"time": [datetime(2020, 1, 1)], "value": [10.0]}),
+        }
+        with pytest.raises(ValueError, match="must align to form a panel"):
+            self._forecaster()._reassemble_panel_predictions(preds)
+
+    def test_misaligned_time_grids_raise(self):
+        """Same row count but disjoint timestamps cannot form a panel."""
+        preds = {
+            "a": pl.DataFrame({"time": [datetime(2020, 1, 1), datetime(2020, 1, 2)], "value": [1.0, 2.0]}),
+            "b": pl.DataFrame({"time": [datetime(2020, 1, 3), datetime(2020, 1, 4)], "value": [10.0, 20.0]}),
+        }
+        with pytest.raises(ValueError, match="does not align"):
+            self._forecaster()._reassemble_panel_predictions(preds)
+
+    def test_groups_without_time_columns_concat_horizontally(self):
+        """Frames without time keys are concatenated by position."""
+        preds = {
+            "a": pl.DataFrame({"value": [1.0, 2.0]}),
+            "b": pl.DataFrame({"value": [10.0, 20.0]}),
+        }
+        result = self._forecaster()._reassemble_panel_predictions(preds)
+
+        assert result["a__value"].to_list() == [1.0, 2.0]
+        assert result["b__value"].to_list() == [10.0, 20.0]

--- a/tests/compose/test_utils.py
+++ b/tests/compose/test_utils.py
@@ -7,6 +7,8 @@ import polars as pl
 import polars.testing as plt
 import pytest
 
+from yohou.base import BaseTransformer
+
 
 class TestHstack:
     """Tests for _hstack horizontal stacking with observation horizon alignment."""
@@ -204,3 +206,48 @@ class TestRewindTransformOne:
 
         expected = pl.DataFrame({"a": [5.0, 10.0]})
         plt.assert_frame_equal(result, expected)
+
+
+class _StatefulWithoutMethods(BaseTransformer):
+    """A BaseTransformer that has lost its stateful observe/rewind methods.
+
+    Used to verify the guards reject a broken stateful transformer rather
+    than silently falling back to a stateless ``transform``.
+    """
+
+    @property
+    def observe_transform(self):
+        raise AttributeError("observe_transform removed")
+
+    @property
+    def rewind_transform(self):
+        raise AttributeError("rewind_transform removed")
+
+    def _fit(self, X, y=None):
+        return None
+
+    def _transform(self, X):
+        return X
+
+    def get_feature_names_out(self, input_features=None):
+        return ["a"]
+
+
+class TestStatefulFallbackGuards:
+    """Stateful BaseTransformers missing their methods must error, not fall back."""
+
+    def test_observe_transform_one_rejects_broken_stateful(self):
+        """A BaseTransformer without observe_transform raises AttributeError."""
+        from yohou.compose.utils import _observe_transform_one
+
+        X = pl.DataFrame({"time": [1], "a": [1.0]})
+        with pytest.raises(AttributeError, match="no 'observe_transform' method"):
+            _observe_transform_one(_StatefulWithoutMethods(), X, y=None, weight=None, params={})
+
+    def test_rewind_transform_one_rejects_broken_stateful(self):
+        """A BaseTransformer without rewind_transform raises AttributeError."""
+        from yohou.compose.utils import _rewind_transform_one
+
+        X = pl.DataFrame({"time": [1], "a": [1.0]})
+        with pytest.raises(AttributeError, match="no 'rewind_transform' method"):
+            _rewind_transform_one(_StatefulWithoutMethods(), X, y=None, weight=None, params={})

--- a/tests/datasets/test_fetchers.py
+++ b/tests/datasets/test_fetchers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import zipfile
+from datetime import datetime
 
 import polars as pl
 import pytest
@@ -434,3 +435,33 @@ class TestFetchDemandClassification:
         """DESCR is a non-empty string."""
         assert isinstance(demand_data.DESCR, str)
         assert len(demand_data.DESCR) > 0
+
+
+class TestClassificationMissingColumns:
+    """The classification fetchers raise clear errors when expected columns are absent."""
+
+    def test_air_quality_missing_pm25_raises(self, monkeypatch):
+        """A KDD Cup frame without the pm2.5 target column raises ValueError."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 3), interval="1h", eager=True)
+        frame = pl.DataFrame({"time": time, "beijing__pm10": [1.0] * len(time)})
+
+        monkeypatch.setattr(
+            "yohou.datasets._fetchers.fetch_kdd_cup",
+            lambda **kwargs: Bunch(frame=frame),
+        )
+
+        with pytest.raises(ValueError, match="pm2.5"):
+            fetch_air_quality_classification()
+
+    def test_demand_missing_columns_raises(self, monkeypatch):
+        """An electricity demand frame missing required columns raises ValueError."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 3), interval="1h", eager=True)
+        frame = pl.DataFrame({"time": time, "nsw__demand": [1.0] * len(time)})
+
+        monkeypatch.setattr(
+            "yohou.datasets._fetchers.fetch_electricity_demand",
+            lambda **kwargs: Bunch(frame=frame),
+        )
+
+        with pytest.raises(ValueError, match="electricity demand"):
+            fetch_demand_classification()

--- a/tests/datasets/test_wasm_fetchers.py
+++ b/tests/datasets/test_wasm_fetchers.py
@@ -44,7 +44,7 @@ class TestFetchDatasetWasmRouting:
             from yohou.datasets._registry import SUNSPOT
 
             _fetch_dataset(SUNSPOT, "sunspot", value_column_name="sunspot_number")
-            mock_wasm.assert_called_once_with("sunspot", SUNSPOT)
+            mock_wasm.assert_called_once_with("sunspot", SUNSPOT, n_series=None)
 
     def test_wasm_url_is_correct(self):
         expected_url = f"{_CDN_BASE_URL}/sunspot.bin"
@@ -114,6 +114,24 @@ class TestFetchDatasetWasmBunch:
 
         assert SUNSPOT.descr == result.DESCR
         assert result.frequency == SUNSPOT.frequency
+
+    def test_n_series_slices_value_columns(self):
+        df = pl.DataFrame({
+            "time": [datetime(2020, 1, 1), datetime(2020, 2, 1)],
+            "a": [1.0, 2.0],
+            "b": [3.0, 4.0],
+            "c": [5.0, 6.0],
+        })
+        payload = df.serialize(format="binary")
+        mock_response = io.BytesIO(payload)
+        mock_response.read = lambda: payload
+
+        with patch("yohou.datasets._fetchers.urlopen", return_value=mock_response):
+            result = _fetch_dataset_wasm("sunspot", SUNSPOT, n_series=2)
+
+        assert result.frame.columns == ["time", "a", "b"]
+        assert result.feature_names == ["a", "b"]
+        assert result.n_series == 2
 
 
 class TestFetchClassificationWasm:

--- a/tests/ensemble/test_voting_point.py
+++ b/tests/ensemble/test_voting_point.py
@@ -518,3 +518,41 @@ class TestVotingPointForecasterSklearn:
 
         with pytest.raises(NotFittedError):
             forecaster.predict(forecasting_horizon=3)
+
+
+class TestVotingSchemaValidation:
+    """Tests for _validate_schemas_match across base forecasters."""
+
+    def _ensemble_with(self, schemas):
+        """Build an (unfitted) ensemble and inject fake fitted children."""
+        from types import SimpleNamespace
+
+        ensemble = VotingPointForecaster(forecasters=[("a", SeasonalNaive()), ("b", SeasonalNaive())])
+        ensemble.forecasters_ = [(name, SimpleNamespace(local_y_schema_=schema)) for name, schema in schemas]
+        return ensemble
+
+    def test_mismatched_target_columns_raises(self):
+        """Different predicted column names raise a clear error."""
+        ensemble = self._ensemble_with([
+            ("a", {"sales": pl.Float64}),
+            ("b", {"revenue": pl.Float64}),
+        ])
+        with pytest.raises(ValueError, match="must predict the same target columns"):
+            ensemble._validate_schemas_match()
+
+    def test_mismatched_target_dtypes_raises(self):
+        """Same columns but differing dtypes raise a dtype-mismatch error."""
+        ensemble = self._ensemble_with([
+            ("a", {"sales": pl.Float64}),
+            ("b", {"sales": pl.Float32}),
+        ])
+        with pytest.raises(ValueError, match="differ from"):
+            ensemble._validate_schemas_match()
+
+    def test_matching_schemas_pass(self):
+        """Identical schemas validate without error."""
+        ensemble = self._ensemble_with([
+            ("a", {"sales": pl.Float64}),
+            ("b", {"sales": pl.Float64}),
+        ])
+        ensemble._validate_schemas_match()

--- a/tests/integration/test_coverage_gaps.py
+++ b/tests/integration/test_coverage_gaps.py
@@ -4,7 +4,6 @@ Covers uncovered branches in:
 - base/forecaster.py: _tags merging into input_tags/target_tags/top-level
 - base/forecaster.py: observation_horizon pre-fit and with dict transformers
 - model_selection/split.py: _tags merging into input_tags/top-level
-- interval/base.py: BaseSimilarity.discarded_time_stamps
 - interval/base.py: BaseIntervalForecaster concrete fit()
 - class_proba/base.py: BaseClassProbaForecaster concrete fit()
 """
@@ -17,7 +16,6 @@ import numpy as np
 import polars as pl
 
 from yohou.interval.base import BaseIntervalForecaster
-from yohou.interval.similarity import DistanceSimilarity
 from yohou.point.base import BasePointForecaster
 from yohou.utils.tags import Tags
 
@@ -187,14 +185,6 @@ class TestSplitterTagMerging:
         assert tags.input_tags is not None
         assert tags.input_tags.allow_nan is True
         assert tags.non_deterministic is True
-
-
-class TestSimilarityDiscardedTimestamps:
-    """BaseSimilarity.discarded_time_stamps returns None."""
-
-    def test_returns_none(self):
-        sim = DistanceSimilarity()
-        assert sim.discarded_time_stamps is None
 
 
 class _MinimalIntervalForecaster(BaseIntervalForecaster):

--- a/tests/interval/test_utils.py
+++ b/tests/interval/test_utils.py
@@ -44,12 +44,12 @@ class TestWeightedQuantile:
         result = weighted_quantile(x, q=0.5, weights=weights)
         assert isinstance(result, float)
 
-    def test_zero_weights_returns_inf(self):
-        """Test that all-zero weights returns infinity."""
+    def test_zero_weights_raises(self):
+        """Test that all-zero weights raise a descriptive ValueError."""
         x = np.array([1.0, 2.0, 3.0])
         weights = np.array([0.0, 0.0, 0.0])
-        result = weighted_quantile(x, q=0.1, weights=weights)
-        assert result == float("inf")
+        with pytest.raises(ValueError, match="sum to zero"):
+            weighted_quantile(x, q=0.1, weights=weights)
 
     def test_small_weights_normalizes(self):
         """Test that small (but non-zero) weights are normalized and produce a finite result."""

--- a/tests/model_selection/test_split.py
+++ b/tests/model_selection/test_split.py
@@ -87,24 +87,25 @@ class TestExpandingWindowBasic:
         splitter = ExpandingWindowSplitter(n_splits=3, test_size=15)
         assert splitter.get_n_splits(y) == 3
 
-    def test_expanding_window_insufficient_data(self, y_X_factory):
-        """Test behavior when splits don't fit - skips invalid splits."""
+    def test_expanding_window_insufficient_data_raises(self, y_X_factory):
+        """split() raises rather than silently yielding fewer folds than advertised."""
         y, _ = y_X_factory(length=20, n_targets=1, n_features=0, seed=42)
 
         splitter = ExpandingWindowSplitter(n_splits=5, test_size=10)
-        splits = list(splitter.split(y))
+        with pytest.raises(ValueError, match="non-overlapping test windows"):
+            list(splitter.split(y))
 
-        assert len(splits) == 2
+    def test_expanding_window_split_count_matches_get_n_splits(self, y_X_factory):
+        """split() yields exactly get_n_splits() folds, or raises (never silently fewer)."""
+        y, _ = y_X_factory(length=20, n_targets=1, n_features=0, seed=42)
 
-        train_idx, test_idx = splits[0]
-        assert len(test_idx) == 10
-        assert test_idx[0] == 0
-        assert len(train_idx) == 0
-
-        train_idx, test_idx = splits[1]
-        assert len(test_idx) == 10
-        assert test_idx[0] == 10
-        assert len(train_idx) == 10
+        splitter = ExpandingWindowSplitter(n_splits=5, test_size=10)
+        try:
+            n_yielded = len(list(splitter.split(y)))
+        except ValueError:
+            pass
+        else:
+            assert n_yielded == splitter.get_n_splits(y)
 
     def test_expanding_window_train_index_expansion(self, y_X_factory):
         """Test training set expands correctly without max_train_size."""

--- a/tests/preprocessing/test_imputation.py
+++ b/tests/preprocessing/test_imputation.py
@@ -339,6 +339,22 @@ class TestTimeSeriesInterpolatorMethods:
         result = imputer.transform(df_with_nulls)
         assert result["val"].null_count() == 0
 
+    def test_nearest_selects_by_temporal_distance(self):
+        """method='nearest' splits an interior gap toward the closer anchor."""
+        from datetime import datetime
+
+        from yohou.preprocessing.imputation import SimpleTimeImputer
+
+        X = pl.DataFrame({
+            "time": [datetime(2020, 1, i) for i in range(1, 6)],
+            "val": [1.0, None, None, None, 5.0],
+        })
+        result = SimpleTimeImputer(method="nearest").fit(X).transform(X)
+        # Must not collapse to an unconditional forward-fill.
+        assert result["val"].to_list() != [1.0, 1.0, 1.0, 1.0, 5.0]
+        # Points nearer the leading anchor take 1.0; nearer the trailing take 5.0.
+        assert result["val"].to_list() == [1.0, 1.0, 1.0, 5.0, 5.0]
+
     def test_fill_both(self, df_with_nulls):
         """method='fill_both' fills forward then backward."""
         from yohou.preprocessing.imputation import SimpleTimeImputer

--- a/tests/preprocessing/test_imputation.py
+++ b/tests/preprocessing/test_imputation.py
@@ -4,6 +4,9 @@ Tests SimpleImputer, TransformedSpaceKNNImputer, SimpleTimeImputer,
 and SeasonalImputer basic functionality.
 """
 
+from datetime import datetime
+
+import numpy as np
 import polars as pl
 import pytest
 
@@ -375,3 +378,35 @@ class TestSeasonalImputerMedian:
         imputer.fit(X)
         X_imputed = imputer.transform(X)
         assert X_imputed.null_count().sum_horizontal().item() == 0
+
+
+class TestSeasonalImputerIrregularInterval:
+    """SeasonalImputer on calendar (month/year) intervals with no fixed step."""
+
+    def test_monthly_interval_uses_row_position_fallback(self):
+        """Calendar intervals have no fixed second-step; season index falls back to row position."""
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2021, 12, 1), interval="1mo", eager=True)
+        values = [float(i) for i in range(len(time))]
+        values[3] = None  # introduce a gap
+        X = pl.DataFrame({"time": time, "val": values})
+
+        imputer = SeasonalImputer(period=12, fill_method="seasonal_mean")
+        imputer.fit(X)
+        assert imputer._step_seconds_ is None
+
+        result = imputer.transform(X)
+        # The gap aligns with a season that has another observed value, so it is filled.
+        assert result["val"].null_count() == 0
+
+    def test_empty_seasons_remain_nan(self):
+        """A season with no observed data stays NaN (covers the missing-bucket branch)."""
+        # Only 3 monthly points but period=12, so seasons 3..11 have no rows at all.
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 3, 1), interval="1mo", eager=True)
+        X = pl.DataFrame({"time": time, "val": [1.0, None, 3.0]})
+
+        imputer = SeasonalImputer(period=12, fill_method="seasonal_mean")
+        imputer.fit(X)
+
+        # Season index 1 (row 1) has only a null, so its seasonal value is NaN.
+        seasonal = imputer.seasonal_values_["val"]
+        assert np.isnan(seasonal[1])

--- a/tests/preprocessing/test_resampling.py
+++ b/tests/preprocessing/test_resampling.py
@@ -307,3 +307,27 @@ class TestUpsampler:
 
         with pytest.raises(ValueError, match="larger than input interval"):
             upsampler.fit(X)
+
+    def test_upsample_empty_series_raises(self) -> None:
+        """Transforming an empty series raises a clear error."""
+        X = create_hourly_data(length=48)
+        upsampler = Upsampler(interval="30m", interpolation="linear")
+        upsampler.fit(X)
+
+        with pytest.raises(ValueError, match="empty time series"):
+            upsampler.transform(X.head(0))
+
+
+class TestDownsamplerBoundaries:
+    """Tests for Downsampler include_boundaries handling."""
+
+    def test_include_boundaries_dropped_from_output(self) -> None:
+        """include_boundaries=True must not leak boundary columns into output."""
+        X = create_hourly_data(length=48)
+        downsampler = Downsampler(interval="1d", aggregation="mean", include_boundaries=True)
+        downsampler.fit(X)
+        result = downsampler.transform(X)
+
+        assert "_lower_boundary" not in result.columns
+        assert "_upper_boundary" not in result.columns
+        assert result.columns == ["time", "value_a", "value_b"]

--- a/tests/preprocessing/test_resampling.py
+++ b/tests/preprocessing/test_resampling.py
@@ -271,6 +271,18 @@ class TestUpsampler:
         assert X_daily["value"][1] in [10.0, 20.0]
         assert X_daily["value"][2] == 20.0
 
+    def test_upsample_interpolation_nearest_by_distance(self) -> None:
+        """'nearest' assigns each gap point the temporally closest anchor."""
+        X = pl.DataFrame({
+            "time": [datetime(2021, 1, 1), datetime(2021, 1, 5)],
+            "value": [10.0, 50.0],
+        })
+        X_daily = Upsampler(interval="1d", interpolation="nearest").fit(X).transform(X)
+
+        # Jan 1..5; Jan 2 nearer to Jan 1, Jan 4 nearer to Jan 5, Jan 3 ties -> trailing anchor's prev.
+        assert X_daily["value"].to_list() != [10.0, 10.0, 10.0, 10.0, 50.0]
+        assert X_daily["value"].to_list() == [10.0, 10.0, 10.0, 50.0, 50.0]
+
     def test_upsample_fit_transform(self) -> None:
         """Test fit_transform convenience method."""
         X = create_daily_data(length=3)

--- a/tests/preprocessing/test_signal.py
+++ b/tests/preprocessing/test_signal.py
@@ -74,7 +74,6 @@ class TestIntegrateTransformer:
                     "check_inverse_transform_identity",
                     "check_inverse_transform_round_trip",
                     "check_inverse_observe_transform_identity",
-                    "check_observe_transform_sequential_consistency",
                 ],
             ),
         ],

--- a/tests/preprocessing/test_sklearn.py
+++ b/tests/preprocessing/test_sklearn.py
@@ -6,6 +6,8 @@ SplineTransformer, SklearnTransformer) using both the check generator pattern an
 component-specific tests.
 """
 
+from datetime import datetime
+
 import numpy as np
 import polars as pl
 import pytest
@@ -1089,3 +1091,22 @@ class TestTransformerCloneAndParams:
         poly.set_params(degree=2, interaction_only=False)
         assert poly.get_params()["degree"] == 2
         assert poly.get_params()["interaction_only"] is False
+
+    def test_transform_empty_frame_returns_empty(self):
+        """An empty (0-row) input transforms to an empty output.
+
+        sklearn's check_array rejects zero-sample arrays, so the wrapper
+        short-circuits. This happens during rewind when observation_horizon
+        is 0 and the observe window is empty.
+        """
+        time = pl.datetime_range(start=datetime(2020, 1, 1), end=datetime(2020, 1, 10), interval="1d", eager=True)
+        X = pl.DataFrame({"time": time, "value": np.arange(len(time), dtype=float)})
+
+        scaler = StandardScaler()
+        scaler.fit(X)
+
+        X_empty = X.head(0)
+        result = scaler.transform(X_empty)
+
+        assert result.height == 0
+        assert result.columns == X.columns

--- a/tests/preprocessing/test_time_features.py
+++ b/tests/preprocessing/test_time_features.py
@@ -242,6 +242,22 @@ class TestFourierFeatureTransformerEdgeCases:
         with pytest.raises(ValueError, match="conflict"):
             transformer.fit(X)
 
+    def test_yearly_interval_uses_calendar_offsets(self):
+        """Yearly data anchors Fourier phases via calendar year offsets."""
+        time = pl.datetime_range(start=datetime(2000, 1, 1), end=datetime(2012, 1, 1), interval="1y", eager=True)
+        X = pl.DataFrame({"time": time, "value": range(len(time))})
+
+        transformer = FourierFeatureTransformer(seasonality=4.0, harmonics=[1])
+        transformer.fit(X)
+        assert transformer.interval_.endswith("y")
+
+        X_t = transformer.transform(X)
+        assert "fourier_4.0_sin_1" in X_t.columns
+        assert X_t.height == X.height
+        # Phase repeats every 4 years: year 0 and year 4 share the same angle.
+        sin_col = X_t["fourier_4.0_sin_1"].to_list()
+        assert sin_col[0] == pytest.approx(sin_col[4], abs=1e-9)
+
 
 class TestTimeIndexTransformerSystematic:
     """Systematic check generator tests for TimeIndexTransformer."""

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -67,7 +67,6 @@ _XFAIL_CHECKS: dict[str, set[str]] = {
         "check_inverse_transform_identity",
         "check_inverse_transform_round_trip",
         "check_inverse_observe_transform_identity",
-        "check_observe_transform_sequential_consistency",
     },
     "NumericalIntegrator": {
         "check_inverse_transform_identity",

--- a/tests/testing/test_forecaster.py
+++ b/tests/testing/test_forecaster.py
@@ -112,7 +112,7 @@ class TestForecasterObserveRewindChecks:
         forecaster.fit(y[:30], X[:30], forecasting_horizon=3)
 
         # Should not raise
-        check_observe_extends_observations(forecaster, y[:30], y[30:40], X[:30], X[30:40])
+        check_observe_extends_observations(forecaster, y[30:40], X[30:40])
 
     def test_rewind_replaces_observations(self, y_X_factory):
         """Test check_rewind_replaces_observations passes for valid forecaster."""
@@ -121,7 +121,7 @@ class TestForecasterObserveRewindChecks:
         forecaster.fit(y[:30], X[:30], forecasting_horizon=3)
 
         # Should not raise
-        check_rewind_replaces_observations(forecaster, y[:30], y[20:40], X[:30], X[20:40])
+        check_rewind_replaces_observations(forecaster, y[20:40], X[20:40])
 
     def test_rewind_propagates_to_transformers(self, y_X_factory):
         """Test check_rewind_propagates_to_transformers passes for valid forecaster."""
@@ -132,7 +132,7 @@ class TestForecasterObserveRewindChecks:
         forecaster.fit(y[:30], X[:30], forecasting_horizon=3)
 
         # Should not raise
-        check_rewind_propagates_to_transformers(forecaster, y[:30], y[20:40], X[:30], X[20:40])
+        check_rewind_propagates_to_transformers(forecaster, y[20:40], X[20:40])
 
 
 class TestForecasterCloneAndTagChecks:
@@ -208,9 +208,7 @@ class TestForecasterPanelObserveRewind:
         forecaster.fit(y.head(40), forecasting_horizon=3)
         check_observe_extends_observations(
             forecaster,
-            y.head(40),
             y.slice(40, 10),
-            None,
             None,
         )
 
@@ -221,9 +219,7 @@ class TestForecasterPanelObserveRewind:
         forecaster.fit(y.head(40), forecasting_horizon=3)
         check_rewind_replaces_observations(
             forecaster,
-            y.head(40),
             y.slice(20, 20),
-            None,
             None,
         )
 
@@ -316,7 +312,6 @@ class TestStepColumnChecks:
             forecaster,
             y[:50],
             X[:50],
-            y[50:60],
             X_future=X_future,
             forecasting_horizon=3,
         )
@@ -337,7 +332,6 @@ class TestStepColumnChecks:
             forecaster,
             y[:50],
             X[:50],
-            y[50:60],
             X_forecast=X_forecast,
             forecasting_horizon=3,
         )
@@ -357,7 +351,6 @@ class TestStepColumnChecks:
         forecaster.fit(y[:50], X[:50], forecasting_horizon=3, X_forecast=X_forecast)
         check_predict_X_forecast_override(
             forecaster,
-            y[50:60],
             X_forecast=X_forecast,
             forecasting_horizon=3,
         )

--- a/tests/testing/test_generators.py
+++ b/tests/testing/test_generators.py
@@ -1,14 +1,31 @@
 """Tests for yohou.testing.generators check generation functions."""
 
 from sklearn.tree import DecisionTreeRegressor
+from sklearn.utils._param_validation import Interval
 
 from yohou.point.naive import SeasonalNaive
 from yohou.point.reduction import PointReductionForecaster
 from yohou.preprocessing.window import LagTransformer
 from yohou.testing.generators import (
+    _interval_lower_bound,
     _yield_yohou_forecaster_checks,
     _yield_yohou_transformer_checks,
 )
+
+
+class TestIntervalLowerBound:
+    """Tests for the _interval_lower_bound constraint helper."""
+
+    def test_returns_int_lower_bound(self):
+        """The integer lower bound of the first Interval constraint is returned."""
+        import numbers
+
+        constraints = [Interval(numbers.Integral, 1, None, closed="left")]
+        assert _interval_lower_bound(constraints) == 1
+
+    def test_returns_none_without_interval(self):
+        """A constraint list with no bound returns None."""
+        assert _interval_lower_bound([list, None]) is None
 
 
 class TestGeneratorChecks:

--- a/tests/testing/test_interval.py
+++ b/tests/testing/test_interval.py
@@ -22,7 +22,7 @@ class TestIntervalChecks:
         forecaster.fit(y[:80], X[:80], forecasting_horizon=3)
 
         # Should not raise
-        check_interval_prediction_columns(forecaster, y[:80], X[:80])
+        check_interval_prediction_columns(forecaster, y[:80])
 
     def test_check_interval_prediction_columns_single_coverage(self, y_X_factory):
         """Test check validates single coverage rate."""
@@ -31,7 +31,7 @@ class TestIntervalChecks:
         forecaster.fit(y[:80], X[:80], forecasting_horizon=3, coverage_rates=[0.95])
 
         # Should not raise
-        check_interval_prediction_columns(forecaster, y[:80], X[:80])
+        check_interval_prediction_columns(forecaster, y[:80])
 
     def test_check_interval_bounds(self, y_X_factory):
         """Test check_interval_bounds passes for valid interval forecaster."""
@@ -40,7 +40,7 @@ class TestIntervalChecks:
         forecaster.fit(y[:80], X[:80], forecasting_horizon=3)
 
         # Should not raise
-        check_interval_bounds(forecaster, y[:80], X[:80])
+        check_interval_bounds(forecaster, y[:80])
 
     def test_check_interval_bounds_single_target(self, y_X_factory):
         """Test check validates single target intervals."""
@@ -49,7 +49,7 @@ class TestIntervalChecks:
         forecaster.fit(y[:80], X[:80], forecasting_horizon=3, coverage_rates=[0.9])
 
         # Should not raise
-        check_interval_bounds(forecaster, y[:80], X[:80])
+        check_interval_bounds(forecaster, y[:80])
 
     def test_check_interval_prediction_types(self):
         """Test check_interval_prediction_types passes for valid interval forecaster."""

--- a/tests/testing/test_panel.py
+++ b/tests/testing/test_panel.py
@@ -20,7 +20,7 @@ class TestPanelChecks:
         forecaster.fit(y[:40], X[:40], forecasting_horizon=3)
 
         # Should not raise
-        check_panel_data(forecaster, y[:40], X[:40])
+        check_panel_data(forecaster, y[:40])
 
     def test_check_panel_data_non_panel(self, y_X_factory):
         """Test check handles non-panel data correctly."""
@@ -31,7 +31,7 @@ class TestPanelChecks:
         forecaster.fit(y[:40], X[:40], forecasting_horizon=3)
 
         # Should not raise - check handles non-panel case
-        check_panel_data(forecaster, y[:40], X[:40])
+        check_panel_data(forecaster, y[:40])
 
     def test_check_panel_single_group(self, y_X_factory):
         """Test check_panel_single_group passes for valid panel forecaster."""
@@ -42,7 +42,7 @@ class TestPanelChecks:
         forecaster.fit(y[:40], X[:40], forecasting_horizon=3)
 
         # Should not raise
-        check_panel_single_group(forecaster, y[:40], X[:40])
+        check_panel_single_group(forecaster, y[:40])
 
     def test_check_panel_invalid_group_raises(self, y_X_factory):
         """Test check_panel_invalid_group_raises passes for valid panel forecaster."""
@@ -53,4 +53,4 @@ class TestPanelChecks:
         forecaster.fit(y[:40], X[:40], forecasting_horizon=3)
 
         # Should not raise
-        check_panel_invalid_group_raises(forecaster, y[:40], X[:40])
+        check_panel_invalid_group_raises(forecaster, y[:40])

--- a/tests/testing/test_point.py
+++ b/tests/testing/test_point.py
@@ -19,7 +19,7 @@ class TestPointChecks:
         forecaster.fit(y[:40], X[:40], forecasting_horizon=3)
 
         # Should not raise
-        check_point_prediction_structure(forecaster, y[:40], X[:40])
+        check_point_prediction_structure(forecaster, y[:40])
 
     def test_check_point_prediction_structure_different_horizon(self, y_X_factory):
         """Test check validates prediction with different horizon."""
@@ -28,7 +28,7 @@ class TestPointChecks:
         forecaster.fit(y[:40], X[:40], forecasting_horizon=3)
 
         # Should not raise - check uses its own horizon internally
-        check_point_prediction_structure(forecaster, y[:40], X[:40])
+        check_point_prediction_structure(forecaster, y[:40])
 
     def test_check_point_prediction_types(self):
         """Test check_point_prediction_types passes for valid point forecaster."""

--- a/tests/testing/test_scorer_checks.py
+++ b/tests/testing/test_scorer_checks.py
@@ -109,20 +109,16 @@ class TestScorerCheckFunctions:
         )
 
     def test_check_panel_subselection(self, scorer_panel_data):
-        """check_scorer_panel_subselection clones internally (exposes unfitted clone bug)."""
+        """check_scorer_panel_subselection fits the clone before scoring."""
         scorer, y_truth, y_pred = scorer_panel_data
         scorer_copy = MeanAbsoluteError()
-        scorer_copy.fit(y_truth)
-        with pytest.raises(AssertionError, match="filtering failed"):
-            check_scorer_panel_subselection(scorer_copy, y_truth, y_pred, groups=["g1"])
+        check_scorer_panel_subselection(scorer_copy, y_truth, y_pred, groups=["g1"])
 
     def test_check_component_subselection(self, scorer_panel_data):
-        """check_scorer_component_subselection clones internally (exposes unfitted clone bug)."""
+        """check_scorer_component_subselection fits the clone before scoring."""
         scorer, y_truth, y_pred = scorer_panel_data
         scorer_copy = MeanAbsoluteError()
-        scorer_copy.fit(y_truth)
-        with pytest.raises(AssertionError, match="filtering failed"):
-            check_scorer_component_subselection(scorer_copy, y_truth, y_pred, components=["val"])
+        check_scorer_component_subselection(scorer_copy, y_truth, y_pred, components=["val"])
 
     def test_check_coverage_rate_subselection(self, interval_scorer_data):
         """check_scorer_coverage_rate_subselection filters interval predictions."""

--- a/tests/utils/test_panel.py
+++ b/tests/utils/test_panel.py
@@ -397,6 +397,16 @@ class TestDictToPanel:
         assert result["sales__store_1"].to_list() == [100, 110, 120]
         assert result["inventory__warehouse_1"].to_list() == [50, 55, 60]
 
+    def test_dict_to_panel_raises_on_misaligned_times(self):
+        """Non-overlapping group timestamps raise rather than being silently dropped."""
+        data_dict = {
+            "sales": pl.DataFrame({"time": [1, 2, 3], "store_1": [100, 110, 120]}),
+            "inventory": pl.DataFrame({"time": [2, 3, 4], "warehouse_1": [50, 55, 60]}),
+        }
+
+        with pytest.raises(ValueError, match="identical 'time' axis"):
+            dict_to_panel(data_dict)
+
     def test_dict_to_panel_dataframe_passthrough(self):
         """Test dict_to_panel returns DataFrame unchanged when given a DataFrame."""
         df = pl.DataFrame({"time": [1, 2, 3], "sales__store_1": [100, 110, 120], "sales__store_2": [150, 160, 170]})
@@ -445,10 +455,10 @@ class TestDictToPanel:
         assert result["time"].dtype == pl.Datetime
         assert result["time"].to_list() == time.to_list()
 
-    def test_dict_to_panel_empty_dict_returns_none(self):
-        """Test dict_to_panel returns None for empty dict (vacuous truth in all())."""
-        result = dict_to_panel({})
-        assert result is None
+    def test_dict_to_panel_empty_dict_raises(self):
+        """Test dict_to_panel raises on an empty dict rather than silently returning None."""
+        with pytest.raises(ValueError, match="empty dict"):
+            dict_to_panel({})
 
     def test_dict_to_panel_none_input_returns_none(self):
         """Test dict_to_panel returns None when input is None."""

--- a/tests/utils/test_validate_data.py
+++ b/tests/utils/test_validate_data.py
@@ -1327,3 +1327,32 @@ class TestValidateStepSourceSchema:
         df = pl.DataFrame({"time": time, "value": [1.0] * len(time)})
         expected = {"value": pl.Float64}
         _validate_step_source_schema(df, expected, "X_future", exclude_cols={"time"})
+
+
+class TestCheckMultiVintageTime:
+    """Tests for _check_multi_vintage_time time-ordering validation."""
+
+    def test_unsorted_time_within_vintage_raises(self):
+        """Descending time within a single vintage raises a ValueError naming the vintage."""
+        from yohou.utils.validate_data import _check_multi_vintage_time
+
+        vintage = datetime(2020, 1, 1)
+        y_pred = pl.DataFrame({
+            "vintage_time": [vintage, vintage, vintage],
+            "time": [datetime(2020, 1, 4), datetime(2020, 1, 3), datetime(2020, 1, 5)],
+            "value": [1.0, 2.0, 3.0],
+        })
+        with pytest.raises(ValueError, match="not sorted in ascending order"):
+            _check_multi_vintage_time(y_pred)
+
+    def test_sorted_time_within_vintage_passes(self):
+        """Ascending time within each vintage passes."""
+        from yohou.utils.validate_data import _check_multi_vintage_time
+
+        vintage = datetime(2020, 1, 1)
+        y_pred = pl.DataFrame({
+            "vintage_time": [vintage, vintage, vintage],
+            "time": [datetime(2020, 1, 2), datetime(2020, 1, 3), datetime(2020, 1, 4)],
+            "value": [1.0, 2.0, 3.0],
+        })
+        _check_multi_vintage_time(y_pred)

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -1605,10 +1605,6 @@ class TestCheckPanelGroupNamesExist:
 class TestValidateColumnNames:
     """Tests for validate_column_names."""
 
-    def test_none_df_returns_early(self):
-        """None df returns without error."""
-        validate_column_names(None)
-
     def test_multiple_separators_raises(self):
         """Column with multiple __ separators raises ValueError."""
         df = pl.DataFrame({

--- a/tests/weighting/test_weighting.py
+++ b/tests/weighting/test_weighting.py
@@ -68,6 +68,19 @@ def test_seasonal_emphasis_matches_legacy_values() -> None:
     assert weights == pytest.approx([1.0, 1.0, 1.0, 2.0])
 
 
+def test_seasonal_emphasis_anchors_to_most_recent_unsorted() -> None:
+    """The emphasized phase is the most-recent timestamp's, regardless of order."""
+    # Most-recent timestamp (2024-01-09) is in the first position, not the last.
+    t = pl.Series(
+        "time",
+        [datetime(2024, 1, 9), datetime(2024, 1, 1), datetime(2024, 1, 2), datetime(2024, 1, 8)],
+    )
+    weights = SeasonalEmphasisWeighter(seasonality=7, emphasis=2.0).compute_weights(t).to_list()
+    # Phase is rank-based; with 4 distinct timestamps only the most-recent (rank 3,
+    # here in the first position) matches its own phase and is emphasized.
+    assert weights == pytest.approx([2.0, 1.0, 1.0, 1.0])
+
+
 def test_exponential_scale_inferred_elapsed_for_datetime(times: pl.Series) -> None:
     """Datetime keys default to elapsed scale."""
     w = ExponentialDecayWeighter(half_life=1)
@@ -275,6 +288,15 @@ def test_composite_mean_weighted_coefficients(times: pl.Series) -> None:
         .to_list()
     )
     assert got == pytest.approx(expected)
+
+
+def test_composite_mean_zero_coefficient_sum_raises(times: pl.Series) -> None:
+    """combination='mean' with zero-sum coefficients raises rather than returning zeros."""
+    a = ExponentialDecayWeighter(half_life=2)
+    b = SeasonalEmphasisWeighter(seasonality=2, emphasis=1.5)
+    weighter = CompositeWeighter([("a", a), ("b", b)], combination="mean", weights=[0.0, 0.0])
+    with pytest.raises(ValueError, match="sum to a nonzero value"):
+        weighter.compute_weights(times)
 
 
 def test_composite_multiply_exponents(times: pl.Series) -> None:

--- a/tests/weighting/test_weighting.py
+++ b/tests/weighting/test_weighting.py
@@ -147,6 +147,13 @@ def test_table_weighter_unmatched_key_raises(times: pl.Series) -> None:
         TableWeighter(frame=frame, on="time").compute_weights(times)
 
 
+def test_table_weighter_explicit_null_weight_raises(times: pl.Series) -> None:
+    """A key present in the frame but with an explicit null weight raises ValueError."""
+    frame = pl.DataFrame({"time": times, "weight": [0.5, None, 0.5]})
+    with pytest.raises(ValueError, match="explicit null"):
+        TableWeighter(frame=frame, on="time").compute_weights(times)
+
+
 def test_table_weighter_panel_group_column(times: pl.Series) -> None:
     """Group-specific weight columns are used for panel data."""
     frame = pl.DataFrame({"time": times, "A_weight": [1.0, 2.0, 3.0], "weight": [9.0, 9.0, 9.0]})


### PR DESCRIPTION
## Description

Remediates issues across source, docstrings, tests, surface, and assets.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)

## Motivation and Context

The QA sweep surfaced genuine correctness bugs plus docstrings/comments that contradict the code. This PR fixes the confirmed behavioral defects (each behind a failing-first test) and corrects the documentation/cleanup clusters.

**Correctness bugs (behavior-changing, tested):**
- `ExpandingWindowSplitter` raises instead of silently yielding fewer folds than `get_n_splits()`
- `dict_to_panel` raises on misaligned group time axes instead of dropping rows
- `SimpleTimeImputer`/`Upsampler` `"nearest"` now selects by true temporal distance (honors `limit`)
- `_rewind_transformers_one` handles `observation_horizon == 0` via an explicit split index
- `DecompositionPipeline.observe` appends to `residuals_` defensively
- `SeasonalEmphasisWeighter` anchors phase to the most-recent rank; `CompositeWeighter` mean raises on zero-sum coefficients
- `VotingClassProbaForecaster._predict_class_proba_one` delegates to the soft/hard helpers (removes the dead duplicate + hard-vote double-predict)
- `weighted_quantile` raises on zero weights instead of returning `inf`

Source contradictions, docstring/signature accuracy, dead code, polars idioms, error handling, public-surface export/doc reconciliation, and stale `.claude`/`CLAUDE.md` asset references.

`ColumnTransformer` wired into the systematic transformer checks; duplicate/vacuous forecaster-contract tests resolved.

Metrics findings are owned by the sibling change `fix/calibration-error-and-metric-docs` and are intentionally excluded here.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
