### PR TITLE
fix: remediate correctness findings

### DIFF
--- a/src/yohou/class_proba/base.py
+++ b/src/yohou/class_proba/base.py
@@ -393,7 +393,10 @@ class BaseClassProbaForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         for col in y_obs.columns:
             if col in ("vintage_time", "time"):
                 continue
-            mapping = self.label_to_code_[col]
+            # For panel columns like "group_0__weather", extract "weather":
+            # label_to_code_ is keyed by base (unprefixed) target names.
+            base_col = col.split("__", 1)[1] if "__" in col else col
+            mapping = self.label_to_code_[base_col]
             exprs.append(pl.col(col).cast(pl.String).replace_strict(mapping, return_dtype=pl.Float64).alias(col))
         return y_obs.with_columns(exprs)
 

--- a/src/yohou/compose/column_transformer.py
+++ b/src/yohou/compose/column_transformer.py
@@ -1261,6 +1261,18 @@ class ColumnTransformer(BaseTransformer, _BaseComposition):
                     .add(caller="fit_transform", callee="transform")
                 )
             method_mapping.add(caller="transform", callee="transform")
+            # Stateful callers: observe_transform/rewind_transform dispatch via
+            # process_routing too, so they must be registered or routing raises
+            # at runtime. Map to the stateful callee when present, else fall
+            # back to transform (mirroring the per-step transform fallback).
+            if hasattr(step, "observe_transform"):
+                method_mapping.add(caller="observe_transform", callee="observe_transform")
+            else:
+                method_mapping.add(caller="observe_transform", callee="transform")
+            if hasattr(step, "rewind_transform"):
+                method_mapping.add(caller="rewind_transform", callee="rewind_transform")
+            else:
+                method_mapping.add(caller="rewind_transform", callee="transform")
             router.add(method_mapping=method_mapping, **{name: step})
 
         return router

--- a/src/yohou/compose/decomposition_pipeline.py
+++ b/src/yohou/compose/decomposition_pipeline.py
@@ -652,6 +652,41 @@ class DecompositionPipeline(BasePointForecaster, _BaseComposition):
 
         return y_pred
 
+    def _transform_panel(
+        self,
+        transformer_dict: dict,
+        df: pl.DataFrame,
+        schema: dict,
+        method: str,
+    ) -> dict[str, pl.DataFrame]:
+        """Apply a per-group stateful transform dict to a panel DataFrame.
+
+        Slices each group's columns, calls ``method`` (e.g.
+        ``"observe_transform"`` or ``"rewind_transform"``) on the group's
+        transformer with the group prefix stripped, and returns the per-group
+        transformed frames as a dict keyed by group. Mirrors the per-group
+        inverse-transform branch in ``predict`` so that panel-mode
+        ``observe``/``rewind`` do not assume a scalar transformer. Callers reuse
+        the dict both as the per-group observation buffer (``_y_observed``,
+        ``_X_observed``) and, via ``dict_to_panel``, as the panel frame fed to
+        the component forecasters.
+        """
+        assert self.groups_ is not None
+        transformed = {}
+        for group_name in self.groups_:
+            transformer = transformer_dict[group_name]
+            group_local = get_group_df(df=df, group_name=group_name, schema=schema)
+            transformed[group_name] = group_local if transformer is None else getattr(transformer, method)(group_local)
+        return transformed
+
+    def _panel_X_actual_schema(self) -> dict:
+        """Build the per-group X_actual schema (local plus shared columns)."""
+        assert self.local_X_actual_schema_ is not None
+        X_schema = dict(self.local_X_actual_schema_)
+        if self.shared_X_actual_schema_:
+            X_schema.update(self.shared_X_actual_schema_)
+        return X_schema
+
     def observe_predict(
         self,
         y: pl.DataFrame,
@@ -794,15 +829,29 @@ class DecompositionPipeline(BasePointForecaster, _BaseComposition):
         # pre-observe state to transform, then updates the buffer.  A separate
         # observe() then transform() would transform against post-observe state
         # and yield empty output for stateful transformers (e.g. differencing).
+        y_t_dict: dict[str, pl.DataFrame] | None = None
+        X_t_dict: dict[str, pl.DataFrame] | None = None
         if self.target_transformer_ is not None:
-            assert isinstance(self.target_transformer_, BaseTransformer)
-            y_t = self.target_transformer_.observe_transform(y)
+            if self.groups_ is None:
+                assert isinstance(self.target_transformer_, BaseTransformer)
+                y_t = self.target_transformer_.observe_transform(y)
+            else:
+                assert isinstance(self.target_transformer_, dict)
+                y_t_dict = self._transform_panel(self.target_transformer_, y, self.local_y_schema_, "observe_transform")
+                y_t = dict_to_panel(y_t_dict)
         else:
             y_t = y
 
         if X_actual is not None and self.feature_transformer_ is not None:
-            assert isinstance(self.feature_transformer_, BaseTransformer)
-            X_t = self.feature_transformer_.observe_transform(X_actual)
+            if self.groups_ is None:
+                assert isinstance(self.feature_transformer_, BaseTransformer)
+                X_t = self.feature_transformer_.observe_transform(X_actual)
+            else:
+                assert isinstance(self.feature_transformer_, dict)
+                X_t_dict = self._transform_panel(
+                    self.feature_transformer_, X_actual, self._panel_X_actual_schema(), "observe_transform"
+                )
+                X_t = dict_to_panel(X_t_dict)
         else:
             X_t = X_actual
 
@@ -843,10 +892,11 @@ class DecompositionPipeline(BasePointForecaster, _BaseComposition):
                 prior = self.residuals_.get(name)
                 self.residuals_[name] = pl.concat([prior, residuals]) if prior is not None else residuals
 
-        # Observe base class observation buffers
-        self._y_observed = y_t
+        # Observe base class observation buffers. In panel mode predict() reads
+        # these as per-group dicts, so store the dict form there.
+        self._y_observed = y_t_dict if self.groups_ is not None and y_t_dict is not None else y_t
         if X_t is not None:
-            self._X_observed = X_t
+            self._X_observed = X_t_dict if self.groups_ is not None and X_t_dict is not None else X_t
 
         return self
 
@@ -907,15 +957,29 @@ class DecompositionPipeline(BasePointForecaster, _BaseComposition):
         )
 
         # Rewind transformers first
+        y_t_dict: dict[str, pl.DataFrame] | None = None
+        X_t_dict: dict[str, pl.DataFrame] | None = None
         if self.target_transformer_ is not None:
-            assert isinstance(self.target_transformer_, BaseTransformer)
-            y_t = self.target_transformer_.rewind_transform(y)
+            if self.groups_ is None:
+                assert isinstance(self.target_transformer_, BaseTransformer)
+                y_t = self.target_transformer_.rewind_transform(y)
+            else:
+                assert isinstance(self.target_transformer_, dict)
+                y_t_dict = self._transform_panel(self.target_transformer_, y, self.local_y_schema_, "rewind_transform")
+                y_t = dict_to_panel(y_t_dict)
         else:
             y_t = y
 
         if X_actual is not None and self.feature_transformer_ is not None:
-            assert isinstance(self.feature_transformer_, BaseTransformer)
-            X_t = self.feature_transformer_.rewind_transform(X_actual)
+            if self.groups_ is None:
+                assert isinstance(self.feature_transformer_, BaseTransformer)
+                X_t = self.feature_transformer_.rewind_transform(X_actual)
+            else:
+                assert isinstance(self.feature_transformer_, dict)
+                X_t_dict = self._transform_panel(
+                    self.feature_transformer_, X_actual, self._panel_X_actual_schema(), "rewind_transform"
+                )
+                X_t = dict_to_panel(X_t_dict)
         else:
             X_t = X_actual
 
@@ -978,10 +1042,11 @@ class DecompositionPipeline(BasePointForecaster, _BaseComposition):
                 [pl.col("time")] + [(pl.col(col) - pl.col(f"{col}_pred")).alias(col) for col in target_cols]
             )
 
-        # Rewind base class observation buffers
-        self._y_observed = y_t
+        # Rewind base class observation buffers. In panel mode predict() reads
+        # these as per-group dicts, so store the dict form there.
+        self._y_observed = y_t_dict if self.groups_ is not None and y_t_dict is not None else y_t
         if X_t is not None:
-            self._X_observed = X_t
+            self._X_observed = X_t_dict if self.groups_ is not None and X_t_dict is not None else X_t
 
         return self
 

--- a/src/yohou/compose/local_panel_forecaster.py
+++ b/src/yohou/compose/local_panel_forecaster.py
@@ -469,7 +469,6 @@ class LocalPanelForecaster(BaseForecaster):
         groups: list[str] | None = None,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
-        **params,
     ) -> LocalPanelForecaster:
         """Observe new data per group without refitting.
 
@@ -487,8 +486,6 @@ class LocalPanelForecaster(BaseForecaster):
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"``
             columns.
-        **params : dict
-            Metadata routing parameters.
 
         Returns
         -------
@@ -508,7 +505,7 @@ class LocalPanelForecaster(BaseForecaster):
             )
             X_future_group, X_forecast_group = self._split_exogenous_for_group(group_name, X_future, X_forecast)
             self.forecasters_[group_name].observe(
-                y=y_group, X_actual=X_group, X_future=X_future_group, X_forecast=X_forecast_group, **params
+                y=y_group, X_actual=X_group, X_future=X_future_group, X_forecast=X_forecast_group
             )
 
         return self
@@ -520,7 +517,6 @@ class LocalPanelForecaster(BaseForecaster):
         groups: list[str] | None = None,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
-        **params,
     ) -> LocalPanelForecaster:
         """Rewind each per-group forecaster's observation window.
 
@@ -538,8 +534,6 @@ class LocalPanelForecaster(BaseForecaster):
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"``
             columns.
-        **params : dict
-            Metadata routing parameters.
 
         Returns
         -------
@@ -559,7 +553,7 @@ class LocalPanelForecaster(BaseForecaster):
             )
             X_future_group, X_forecast_group = self._split_exogenous_for_group(group_name, X_future, X_forecast)
             self.forecasters_[group_name].rewind(
-                y=y_group, X_actual=X_group, X_future=X_future_group, X_forecast=X_forecast_group, **params
+                y=y_group, X_actual=X_group, X_future=X_future_group, X_forecast=X_forecast_group
             )
 
         return self

--- a/src/yohou/compose/utils.py
+++ b/src/yohou/compose/utils.py
@@ -98,7 +98,9 @@ def _observe_transform_one(
 
     if weight is None:
         return X_transformed
-    return X_transformed * weight
+    # Scale only feature columns: multiplying the whole DataFrame would cast the
+    # mandatory datetime "time" column to f64, violating the data contract.
+    return X_transformed.with_columns(cs.exclude("time") * weight)
 
 
 def _rewind_transform_one(
@@ -145,4 +147,6 @@ def _rewind_transform_one(
 
     if weight is None:
         return X_transformed
-    return X_transformed * weight
+    # Scale only feature columns: multiplying the whole DataFrame would cast the
+    # mandatory datetime "time" column to f64, violating the data contract.
+    return X_transformed.with_columns(cs.exclude("time") * weight)

--- a/src/yohou/ensemble/voting_class_proba.py
+++ b/src/yohou/ensemble/voting_class_proba.py
@@ -8,6 +8,7 @@ from typing import Literal
 import numpy as np
 import polars as pl
 from pydantic import StrictInt
+from sklearn.utils import Bunch
 from sklearn.utils.metadata_routing import (
     MetadataRouter,
     MethodMapping,
@@ -310,6 +311,13 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
 
         return self
 
+    @staticmethod
+    def _routed_for(routed_params: Bunch | None, name: str, callee: str) -> dict:
+        """Per-forecaster routed metadata for one callee, or empty if none."""
+        if routed_params is None:
+            return {}
+        return getattr(routed_params.get(name, Bunch(**{callee: {}})), callee, {})
+
     def _predict_class_proba_one(
         self,
         groups: list[str],
@@ -336,9 +344,11 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
             Aggregated probability predictions.
 
         """
+        _raise_for_params(params, self, "predict_class_proba")
+        routed_params = process_routing(self, "predict_class_proba", **params)
         if self.method == "soft":
-            return self._soft_vote_predict_class_proba(groups=groups, **params)
-        return self._hard_vote_predict_class_proba(groups=groups, **params)
+            return self._soft_vote_predict_class_proba(groups=groups, routed_params=routed_params)
+        return self._hard_vote_predict_class_proba(groups=groups, routed_params=routed_params)
 
     def predict_class_proba(  # ty: ignore[invalid-method-override]
         self,
@@ -374,6 +384,8 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
 
         """
         check_is_fitted(self, ["forecasters_", "classes_"])
+        _raise_for_params(params, self, "predict_class_proba")
+        routed_params = process_routing(self, "predict_class_proba", **params)
 
         if self.method == "soft":
             return self._soft_vote_predict_class_proba(
@@ -381,14 +393,14 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
                 groups=groups,
                 X_future=X_future,
                 X_forecast=X_forecast,
-                **params,
+                routed_params=routed_params,
             )
         return self._hard_vote_predict_class_proba(
             forecasting_horizon=forecasting_horizon,
             groups=groups,
             X_future=X_future,
             X_forecast=X_forecast,
-            **params,
+            routed_params=routed_params,
         )
 
     def _soft_vote_predict_class_proba(
@@ -397,7 +409,7 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
         groups: list[str] | None = None,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
-        **params,
+        routed_params: Bunch | None = None,
     ) -> pl.DataFrame:
         """Soft vote: weighted average of class probabilities.
 
@@ -421,13 +433,13 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
 
         """
         predictions = []
-        for _name, forecaster in self.forecasters_:
+        for name, forecaster in self.forecasters_:
             y_proba = forecaster.predict_class_proba(  # ty: ignore[unresolved-attribute]
                 forecasting_horizon=forecasting_horizon,
                 groups=groups,
                 X_future=X_future,
                 X_forecast=X_forecast,
-                **params,
+                **self._routed_for(routed_params, name, "predict_class_proba"),
             )
             predictions.append(y_proba)
 
@@ -453,7 +465,7 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
         groups: list[str] | None = None,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
-        **params,
+        routed_params: Bunch | None = None,
     ) -> pl.DataFrame:
         """Hard vote: majority vote converted to one-hot probabilities.
 
@@ -477,13 +489,13 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
 
         """
         predictions = []
-        for _name, forecaster in self.forecasters_:
+        for name, forecaster in self.forecasters_:
             y_pred = forecaster.predict(  # ty: ignore[unresolved-attribute]
                 forecasting_horizon=forecasting_horizon,
                 groups=groups,
                 X_future=X_future,
                 X_forecast=X_forecast,
-                **params,
+                **self._routed_for(routed_params, name, "predict"),
             )
             predictions.append(y_pred)
 
@@ -537,6 +549,8 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
 
         """
         check_is_fitted(self, ["forecasters_", "classes_"])
+        _raise_for_params(params, self, "predict")
+        routed_params = process_routing(self, "predict", **params)
 
         if self.method == "hard":
             return self._hard_vote_predict(
@@ -544,15 +558,15 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
                 groups=groups,
                 X_future=X_future,
                 X_forecast=X_forecast,
-                **params,
+                routed_params=routed_params,
             )
 
-        y_proba = self.predict_class_proba(
+        y_proba = self._soft_vote_predict_class_proba(
             forecasting_horizon=forecasting_horizon,
             groups=groups,
             X_future=X_future,
             X_forecast=X_forecast,
-            **params,
+            routed_params=routed_params,
         )
         return self._ensemble_argmax_from_proba(y_proba)
 
@@ -604,7 +618,7 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
         groups: list[str] | None = None,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
-        **params,
+        routed_params: Bunch | None = None,
     ) -> pl.DataFrame:
         """Hard vote: majority vote of argmax predictions.
 
@@ -628,13 +642,13 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
 
         """
         predictions = []
-        for _name, forecaster in self.forecasters_:
+        for name, forecaster in self.forecasters_:
             y_pred = forecaster.predict(  # ty: ignore[unresolved-attribute]
                 forecasting_horizon=forecasting_horizon,
                 groups=groups,
                 X_future=X_future,
                 X_forecast=X_forecast,
-                **params,
+                **self._routed_for(routed_params, name, "predict"),
             )
             predictions.append(y_pred)
 
@@ -665,7 +679,9 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
                 method_mapping=MethodMapping()
                 .add(caller="fit", callee="fit")
                 .add(caller="predict", callee="predict")
-                .add(caller="predict_class_proba", callee="predict_class_proba"),
+                .add(caller="predict", callee="predict_class_proba")
+                .add(caller="predict_class_proba", callee="predict_class_proba")
+                .add(caller="predict_class_proba", callee="predict"),
             )
 
         return router

--- a/src/yohou/ensemble/voting_class_proba.py
+++ b/src/yohou/ensemble/voting_class_proba.py
@@ -312,10 +312,8 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
         return self
 
     @staticmethod
-    def _routed_for(routed_params: Bunch | None, name: str, callee: str) -> dict:
+    def _routed_for(routed_params: Bunch, name: str, callee: str) -> dict:
         """Per-forecaster routed metadata for one callee, or empty if none."""
-        if routed_params is None:
-            return {}
         return getattr(routed_params.get(name, Bunch(**{callee: {}})), callee, {})
 
     def _predict_class_proba_one(
@@ -409,7 +407,8 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
         groups: list[str] | None = None,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
-        routed_params: Bunch | None = None,
+        *,
+        routed_params: Bunch,
     ) -> pl.DataFrame:
         """Soft vote: weighted average of class probabilities.
 
@@ -465,7 +464,8 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
         groups: list[str] | None = None,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
-        routed_params: Bunch | None = None,
+        *,
+        routed_params: Bunch,
     ) -> pl.DataFrame:
         """Hard vote: majority vote converted to one-hot probabilities.
 
@@ -618,7 +618,8 @@ class VotingClassProbaForecaster(_BaseEnsembleForecaster, BaseClassProbaForecast
         groups: list[str] | None = None,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
-        routed_params: Bunch | None = None,
+        *,
+        routed_params: Bunch,
     ) -> pl.DataFrame:
         """Hard vote: majority vote of argmax predictions.
 

--- a/src/yohou/interval/reduction.py
+++ b/src/yohou/interval/reduction.py
@@ -314,6 +314,24 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
         multiquantile_param = self._detect_multiquantile_loss()
 
         if multiquantile_param is not None:
+            # A MultiQuantile estimator is single-output and single-step: it
+            # predicts the quantile vector for one target at one horizon. The
+            # predict path would otherwise reuse the first target's quantiles
+            # for every target and return a single row regardless of horizon,
+            # so reject the unsupported shapes up front. Count targets per group
+            # (local_y_t_schema_) so single-target-per-group panels stay valid.
+            n_targets = len(self.local_y_t_schema_)
+            if n_targets > 1:
+                raise ValueError(
+                    f"MultiQuantile estimators support only a single target column; got {n_targets}. "
+                    "Fit one IntervalReductionForecaster per target, or use a single-quantile estimator."
+                )
+            if forecasting_horizon > 1:
+                raise ValueError(
+                    "The MultiQuantile reduction path requires forecasting_horizon=1; "
+                    f"got {forecasting_horizon}. Use a single-quantile estimator for multi-step horizons."
+                )
+
             all_quantiles = sorted({q for cr in self.fit_coverage_rates_ for q in ((1.0 - cr) / 2.0, (1.0 + cr) / 2.0)})
             q_to_idx = {q: i for i, q in enumerate(all_quantiles)}
             self._multiquantile_map_ = {

--- a/src/yohou/model_selection/split.py
+++ b/src/yohou/model_selection/split.py
@@ -338,11 +338,12 @@ class ExpandingWindowSplitter(BaseSplitter):
             raise ValueError(f"test_size={test_size} should be less than the number of samples={n_samples}.")
 
         first_test_start = n_samples - n_splits * test_size
-        if first_test_start < 0:
+        if first_test_start < 1:
             raise ValueError(
                 f"Cannot create n_splits={n_splits} non-overlapping test windows of "
                 f"test_size={test_size} from n_samples={n_samples}: this needs at least "
-                f"{n_splits * test_size} samples for the test windows alone. "
+                f"{n_splits * test_size + 1} samples (the test windows alone need "
+                f"{n_splits * test_size}, leaving none for the first fold's training set). "
                 f"Reduce n_splits or test_size, or provide more data."
             )
 
@@ -851,6 +852,12 @@ def train_test_split(
             msg = f"test_size as a float must be in (0.0, 1.0), got {test_size}."
             raise ValueError(msg)
         n_test = max(1, round(n_samples * test_size))
+        if n_test >= n_samples:
+            msg = (
+                f"test_size={test_size} rounds to {n_test} test samples, which leaves no "
+                f"training samples ({n_samples} total). Use a smaller test_size."
+            )
+            raise ValueError(msg)
     elif isinstance(test_size, int):
         if test_size < 1 or test_size >= n_samples:
             msg = f"test_size as an int must be in [1, {n_samples - 1}], got {test_size}."

--- a/src/yohou/preprocessing/imputation.py
+++ b/src/yohou/preprocessing/imputation.py
@@ -682,7 +682,10 @@ class SeasonalImputer(BaseTransformer):
                 for i in np.where(null_mask)[0]:
                     values[i] = seasonal_vals[season_idx_arr[i]]
 
-            result_cols[col_name] = pl.Series(values)
+            # A position whose season bucket was empty at fit time stays NaN;
+            # convert back to a proper polars null rather than emitting a float
+            # NaN, which would violate the data contract.
+            result_cols[col_name] = pl.Series(values).fill_nan(None)
 
         return pl.DataFrame(result_cols)
 

--- a/src/yohou/stationarity/base.py
+++ b/src/yohou/stationarity/base.py
@@ -164,25 +164,12 @@ class _BaseTrendForecaster(BasePointForecaster):
         if groups is None:
             groups = self.groups_
 
-        target_observation_horizon = 0
-        if self.target_transformer_ is not None:
-            if isinstance(self.target_transformer_, dict):
-                first_target_transformer = next(iter(self.target_transformer_.values()))
-                if first_target_transformer is not None:
-                    target_observation_horizon = typing_cast(
-                        BaseTransformer,
-                        first_target_transformer,
-                    ).observation_horizon
-                else:
-                    target_observation_horizon = 0
-            else:
-                target_observation_horizon = self.target_transformer_.observation_horizon
-
-        # Panel data
+        # Panel data: each group uses its own transformer's observation
+        # horizon, not the first group's (groups may differ).
         if groups is not None:
             first_observed_time = {
                 group: get_group_df(df=y, group_name=group, schema=self.local_y_schema_)["time"][
-                    target_observation_horizon
+                    self._group_target_observation_horizon(group)
                 ]
                 for group in groups
             }
@@ -190,9 +177,28 @@ class _BaseTrendForecaster(BasePointForecaster):
 
         # Non-panel data
         else:
-            self._first_observed_time = y["time"][target_observation_horizon]
+            self._first_observed_time = y["time"][self._group_target_observation_horizon(None)]
 
         return self
+
+    def _group_target_observation_horizon(self, group: str | None) -> int:
+        """Observation horizon of the target transformer for one group.
+
+        Returns the group's own transformer horizon in panel mode (where
+        ``target_transformer_`` is a dict), the scalar transformer's horizon in
+        non-panel mode, or 0 when there is no target transformer.
+        """
+        if self.target_transformer_ is None:
+            return 0
+        if isinstance(self.target_transformer_, dict):
+            # The dict form only exists in panel mode, where group is a real name.
+            assert group is not None
+            transformer_dict = typing_cast("dict[str, BaseTransformer | None]", self.target_transformer_)
+            transformer = transformer_dict[group]
+            if transformer is None:
+                return 0
+            return transformer.observation_horizon
+        return self.target_transformer_.observation_horizon
 
     def _get_time_indices(
         self, forecasting_horizon: int | None = None, panel_group_name: str | None = None

--- a/tests/class_proba/test_reduction.py
+++ b/tests/class_proba/test_reduction.py
@@ -261,6 +261,32 @@ class TestRecursivePredict:
         proba_cols = [c for c in y_pred.columns if "_proba_" in c]
         assert len(proba_cols) == 3
 
+    def test_recursive_predict_panel(self, class_proba_y_X_factory):
+        """Recursive prediction on panel data re-encodes prefixed columns.
+
+        Regression for the 2026-06-15 QA finding: ``_encode_observation``
+        looked up ``label_to_code_`` by the raw column name, so panel columns
+        like ``group_0__weather`` raised ``KeyError`` (the dict is keyed by the
+        base target name ``weather``). Recursive prediction (horizon > fit
+        horizon, no X_actual) is the path that exercises it.
+        """
+        y, _ = class_proba_y_X_factory(
+            length=120,
+            n_targets=1,
+            n_features=0,
+            n_classes=3,
+            seed=42,
+            panel=True,
+            n_groups=2,
+        )
+        forecaster = ClassProbaReductionForecaster(
+            estimator=DecisionTreeClassifier(random_state=42),
+        )
+        forecaster.fit(y, forecasting_horizon=3)
+
+        y_pred = forecaster.predict_class_proba(forecasting_horizon=6)
+        assert len(y_pred) == 6
+
     def test_predict_longer_horizon_without_X(self, class_proba_data):
         """Recursive prediction works without exogenous features."""
         y_train, _, X_actual_train, _ = class_proba_data

--- a/tests/compose/test_decomposer.py
+++ b/tests/compose/test_decomposer.py
@@ -61,6 +61,51 @@ class TestSystematicChecks:
         )
 
 
+class TestPanelObserveRewind:
+    """Panel-mode observe/rewind must not crash on the scalar-transformer assumption.
+
+    Regression for the 2026-06-15 QA findings: in panel mode the base class
+    stores ``target_transformer_``/``feature_transformer_`` as dicts keyed by
+    group, so ``observe``/``rewind`` must branch on ``groups_`` instead of
+    asserting a single ``BaseTransformer`` (which raised ``AssertionError``).
+    """
+
+    @pytest.fixture
+    def panel_data(self):
+        """Two-group strictly-positive linear panel (LogTransformer-safe)."""
+        n = 60
+        time = pl.datetime_range(
+            start=datetime(2020, 1, 1),
+            end=datetime(2020, 1, 1) + timedelta(days=n - 1),
+            interval="1d",
+            eager=True,
+        )
+        data = {"time": time}
+        for g in range(2):
+            slope = g + 1
+            data[f"g{g}__value"] = [slope * t + 10.0 * (g + 1) for t in range(n)]
+        return pl.DataFrame(data)
+
+    def test_panel_observe_then_rewind_with_target_transformer(self, panel_data):
+        y = panel_data
+        y_train, y_new = y[:50], y[50:]
+        forecaster = DecompositionPipeline(
+            [("trend", PolynomialTrendForecaster(degree=1))],
+            target_transformer=LogTransformer(),
+        )
+        forecaster.fit(y_train, forecasting_horizon=3)
+
+        forecaster.observe(y_new)
+        y_pred = forecaster.predict()
+        assert "g0__value" in y_pred.columns
+        assert "g1__value" in y_pred.columns
+
+        forecaster.rewind(y_train)
+        y_pred_rewound = forecaster.predict()
+        assert "g0__value" in y_pred_rewound.columns
+        assert "g1__value" in y_pred_rewound.columns
+
+
 class TestBasicFitPredict:
     """Tests for basic fit/predict workflow."""
 

--- a/tests/compose/test_decomposer.py
+++ b/tests/compose/test_decomposer.py
@@ -105,6 +105,43 @@ class TestPanelObserveRewind:
         assert "g0__value" in y_pred_rewound.columns
         assert "g1__value" in y_pred_rewound.columns
 
+    @pytest.mark.parametrize("with_shared", [False, True])
+    def test_panel_observe_then_rewind_with_feature_transformer(self, panel_data, with_shared):
+        """Panel observe/rewind must apply the per-group feature transformer.
+
+        Covers the ``feature_transformer_`` panel branch (and the shared
+        ``_panel_X_actual_schema`` helper): with X_actual present in panel
+        mode, ``observe``/``rewind`` build the per-group transform dict instead
+        of asserting a single ``BaseTransformer``. The ``with_shared`` parameter
+        exercises both the local-only and local-plus-shared X_actual schemas.
+        """
+        from yohou.preprocessing import FunctionTransformer
+
+        y = panel_data
+        X_actual = panel_data.rename({c: c.replace("__value", "__feat") if c != "time" else c for c in y.columns})
+        if with_shared:
+            # A shared (global, no ``__``) column makes _panel_X_actual_schema
+            # merge both the local and shared schemas.
+            X_actual = X_actual.with_columns(shared_feat=pl.col("g0__feat") + pl.col("g1__feat"))
+        y_train, y_new = y[:50], y[50:]
+        X_train, X_new = X_actual[:50], X_actual[50:]
+
+        forecaster = DecompositionPipeline(
+            [("trend", PolynomialTrendForecaster(degree=1))],
+            feature_transformer=FunctionTransformer(),
+        )
+        forecaster.fit(y_train, X_actual=X_train, forecasting_horizon=3)
+
+        forecaster.observe(y_new, X_actual=X_new)
+        y_pred = forecaster.predict()
+        assert "g0__value" in y_pred.columns
+        assert "g1__value" in y_pred.columns
+
+        forecaster.rewind(y_train, X_actual=X_train)
+        y_pred_rewound = forecaster.predict()
+        assert "g0__value" in y_pred_rewound.columns
+        assert "g1__value" in y_pred_rewound.columns
+
 
 class TestBasicFitPredict:
     """Tests for basic fit/predict workflow."""

--- a/tests/compose/test_feature_union.py
+++ b/tests/compose/test_feature_union.py
@@ -43,6 +43,26 @@ class TestFeatureUnionFitTransform:
         X_t = union.transform(X)
         assert "time" in X_t.columns
 
+    def test_weighted_observe_rewind_preserve_time_dtype(self, time_series_factory):
+        """Weighted observe/rewind keep the datetime "time" column.
+
+        Regression for the 2026-06-15 QA finding: the weighting path returned
+        ``X_transformed * weight``, which multiplied the whole DataFrame and
+        silently cast the datetime "time" column to f64.
+        """
+        X = time_series_factory(length=50)
+        union = FeatureUnion(
+            [("s1", SimpleTransformer(observation_horizon=0))],
+            transformer_weights={"s1": 2.0},
+        )
+        union.fit(X)
+
+        X_obs = union.observe_transform(X)
+        assert X_obs["time"].dtype == pl.Datetime
+
+        X_rew = union.rewind_transform(X)
+        assert X_rew["time"].dtype == pl.Datetime
+
     def test_horizontal_concat_two_transformers(self, time_series_factory):
         """Two transformers produce horizontally concatenated output."""
         X = time_series_factory(length=50, n_components=1)

--- a/tests/compose/test_local_panel_forecaster.py
+++ b/tests/compose/test_local_panel_forecaster.py
@@ -188,6 +188,24 @@ class TestObserveRewind:
         y_pred = f.predict(forecasting_horizon=5)
         assert len(y_pred) == 5
 
+    def test_observe_rewind_reject_unexpected_params(self, panel_y):
+        """observe/rewind reject stray kwargs at the LocalPanelForecaster boundary.
+
+        Regression for the 2026-06-15 QA finding: observe/rewind accepted and
+        forwarded ``**params`` raw to child forecasters, so a stray keyword was
+        passed through and surfaced as a confusing error deep in the base class.
+        Like the base ``observe``/``rewind``, these methods take no routable
+        metadata, so an unexpected keyword is rejected up front.
+        """
+        y = panel_y
+        f = LocalPanelForecaster(forecaster=SeasonalNaive(seasonality=7))
+        f.fit(y[:80], forecasting_horizon=5)
+
+        with pytest.raises(TypeError, match="observe"):
+            f.observe(y=y[80:85], sample_weight=[1.0] * 5)
+        with pytest.raises(TypeError, match="rewind"):
+            f.rewind(y=y[70:80], sample_weight=[1.0] * 10)
+
 
 class TestLocalVsGlobal:
     """Verify that LocalPanelForecaster handles heterogeneous groups better than pooled."""

--- a/tests/compose/test_metadata_routing.py
+++ b/tests/compose/test_metadata_routing.py
@@ -343,6 +343,34 @@ class TestColumnTransformerRouting:
         assert len(y_t) > 0
         assert "time" in y_t.columns
 
+    def test_stateful_methods_routable_when_routing_enabled(self, y_X_factory):
+        """observe_transform/rewind_transform must not raise when routing is enabled.
+
+        Regression for the 2026-06-15 QA finding: get_metadata_routing did not
+        register observe_transform/rewind_transform as callers, so
+        process_routing raised an unregistered-caller error at runtime once
+        metadata routing was enabled.
+        """
+        import sklearn
+
+        y, _ = y_X_factory(length=50, n_targets=2)
+        y_train, y_test = y[:-10], y[-10:]
+
+        ct = ColumnTransformer(
+            [
+                ("diff1", SeasonalDifferencing(seasonality=3), ["y_0"]),
+                ("diff2", SeasonalDifferencing(seasonality=2), ["y_1"]),
+            ],
+            remainder="passthrough",
+        )
+        ct.fit(y_train)
+
+        with sklearn.config_context(enable_metadata_routing=True):
+            y_obs = ct.observe_transform(y_test[:3])
+            assert "time" in y_obs.columns
+            y_rew = ct.rewind_transform(y_test[:3])
+            assert "time" in y_rew.columns
+
 
 class TestSearchCVRouting:
     """Tests for GridSearchCV metadata routing."""

--- a/tests/ensemble/test_voting_class_proba.py
+++ b/tests/ensemble/test_voting_class_proba.py
@@ -421,6 +421,31 @@ class TestVotingClassProbaPanelData:
         assert len(proba_cols) > 0
 
 
+class TestVotingClassProbaRouting:
+    """Metadata-routing guards on predict and predict_class_proba."""
+
+    @pytest.mark.parametrize("method", ["soft", "hard"])
+    def test_predict_rejects_unrouted_metadata(self, class_proba_y_X_factory, method):
+        """predict/predict_class_proba reject metadata no child requested.
+
+        Regression for the 2026-06-15 QA finding: these methods accepted
+        ``**params`` labelled as routing metadata but never called
+        ``_raise_for_params``/``process_routing``, so a stray param was passed
+        through to children unchecked instead of being validated.
+        """
+        y, X_actual = class_proba_y_X_factory(length=100, n_targets=1, n_features=2, n_classes=3, seed=42)
+        forecaster = VotingClassProbaForecaster(
+            forecasters=[("dt_1", _make_class_proba_forecaster()), ("dt_2", _make_class_proba_forecaster())],
+            method=method,
+        )
+        forecaster.fit(y[:80], X_actual[:80], forecasting_horizon=3)
+
+        with pytest.raises(TypeError, match="not routed"):
+            forecaster.predict(forecasting_horizon=3, sample_weight=[1.0] * 3)
+        with pytest.raises(TypeError, match="not routed"):
+            forecaster.predict_class_proba(forecasting_horizon=3, sample_weight=[1.0] * 3)
+
+
 class TestVotingClassProbaErrorHandling:
     """Tests for error handling behavior."""
 

--- a/tests/interval/test_reduction.py
+++ b/tests/interval/test_reduction.py
@@ -453,8 +453,14 @@ class TestMultiQuantile:
 
     @pytest.mark.slow
     def test_fit_predict_global(self, standard_splits):
-        """Multi-quantile path produces correct interval columns (global)."""
+        """Multi-quantile path produces correct interval columns (global, single target).
+
+        A MultiQuantile estimator is single-output and single-step, so the
+        path is only valid for one target column at ``forecasting_horizon=1``;
+        it returns exactly one row (the 2026-06-15 QA fix).
+        """
         y_train, y_test, X_actual_train, X_actual_test = standard_splits
+        y_train = y_train.select(["time", "a"])
         coverage_rates = [0.5, 0.9]
         est = _MockMultiQuantileRegressor()
         forecaster = IntervalReductionForecaster(estimator=est)
@@ -462,7 +468,7 @@ class TestMultiQuantile:
         forecaster.fit(
             y=y_train,
             X_actual=X_actual_train,
-            forecasting_horizon=2,
+            forecasting_horizon=1,
             coverage_rates=coverage_rates,
         )
 
@@ -471,23 +477,23 @@ class TestMultiQuantile:
         assert len(forecaster.estimator_) == 1
 
         y_pred = forecaster.predict_interval(
-            forecasting_horizon=2,
+            forecasting_horizon=1,
             X_actual=X_actual_test,
             coverage_rates=coverage_rates,
         )
 
-        # Should have lower/upper for each coverage rate + time columns
-        y_cols = [c for c in y_train.columns if c != "time"]
-        for col in y_cols:
-            for cr in coverage_rates:
-                assert f"{col}_lower_{cr}" in y_pred.columns
-                assert f"{col}_upper_{cr}" in y_pred.columns
-                assert all(y_pred[f"{col}_upper_{cr}"] + 1e-14 >= y_pred[f"{col}_lower_{cr}"])
+        assert len(y_pred) == 1
+        for cr in coverage_rates:
+            assert f"a_lower_{cr}" in y_pred.columns
+            assert f"a_upper_{cr}" in y_pred.columns
+            assert all(y_pred[f"a_upper_{cr}"] + 1e-14 >= y_pred[f"a_lower_{cr}"])
 
     @pytest.mark.slow
-    def test_fit_predict_panel(self, panel_splits):
-        """Multi-quantile path produces correct interval columns (panel)."""
+    def test_fit_predict_panel_single_target(self, panel_splits):
+        """Multi-quantile path is valid for one target per group, horizon=1."""
         y_train_panel, y_test_panel, X_train_panel, X_test_panel = panel_splits
+        # One target ("a") per group keeps the per-group target count at 1.
+        y_train_panel = y_train_panel.select(["time", "x__a", "y__a"])
         coverage_rates = [0.9]
         est = _MockMultiQuantileRegressor()
         forecaster = IntervalReductionForecaster(estimator=est)
@@ -505,19 +511,42 @@ class TestMultiQuantile:
             coverage_rates=coverage_rates,
         )
 
-        # Check panel column naming
         for group in ["x", "y"]:
-            for target in ["a", "b"]:
-                for cr in coverage_rates:
-                    lower_col = f"{group}__{target}_lower_{cr}"
-                    upper_col = f"{group}__{target}_upper_{cr}"
-                    assert lower_col in y_pred.columns, f"Missing {lower_col}"
-                    assert upper_col in y_pred.columns, f"Missing {upper_col}"
+            for cr in coverage_rates:
+                assert f"{group}__a_lower_{cr}" in y_pred.columns
+                assert f"{group}__a_upper_{cr}" in y_pred.columns
+
+    @pytest.mark.slow
+    def test_multiquantile_rejects_multi_target(self, standard_splits):
+        """Multi-target input is rejected at fit (single-output estimator).
+
+        Regression for the 2026-06-15 QA finding: the predict path reused the
+        first target's quantiles for every target. The fit now rejects it.
+        """
+        y_train, _, X_actual_train, _ = standard_splits
+        forecaster = IntervalReductionForecaster(estimator=_MockMultiQuantileRegressor())
+        with pytest.raises(ValueError, match="single target column"):
+            forecaster.fit(y=y_train, X_actual=X_actual_train, forecasting_horizon=1, coverage_rates=[0.9])
+
+    @pytest.mark.slow
+    def test_multiquantile_rejects_multi_step(self, standard_splits):
+        """Horizon > 1 is rejected at fit (single-step estimator).
+
+        Regression for the 2026-06-15 QA finding: the predict path returned a
+        single row regardless of the fitted horizon.
+        """
+        y_train, _, X_actual_train, _ = standard_splits
+        y_train = y_train.select(["time", "a"])
+        forecaster = IntervalReductionForecaster(estimator=_MockMultiQuantileRegressor())
+        with pytest.raises(ValueError, match="forecasting_horizon=1"):
+            forecaster.fit(y=y_train, X_actual=X_actual_train, forecasting_horizon=2, coverage_rates=[0.9])
 
     @pytest.mark.slow
     def test_observe_predict_multiquantile(self, standard_splits):
-        """Multi-quantile path works with observe_predict_interval."""
+        """Multi-quantile path works with observe_predict_interval (single target)."""
         y_train, y_test, X_actual_train, X_actual_test = standard_splits
+        y_train = y_train.select(["time", "a"])
+        y_test = y_test.select(["time", "a"])
         coverage_rates = [0.5, 0.9]
         est = _MockMultiQuantileRegressor()
         forecaster = IntervalReductionForecaster(estimator=est)
@@ -538,11 +567,9 @@ class TestMultiQuantile:
             coverage_rates=coverage_rates,
         )
 
-        y_cols = [c for c in y_train.columns if c != "time"]
-        for col in y_cols:
-            for cr in coverage_rates:
-                assert f"{col}_lower_{cr}" in y_pred.columns
-                assert f"{col}_upper_{cr}" in y_pred.columns
+        for cr in coverage_rates:
+            assert f"a_lower_{cr}" in y_pred.columns
+            assert f"a_upper_{cr}" in y_pred.columns
 
 
 class _MockLGBMQuantileRegressor(BaseEstimator, RegressorMixin):

--- a/tests/model_selection/test_split.py
+++ b/tests/model_selection/test_split.py
@@ -95,6 +95,20 @@ class TestExpandingWindowBasic:
         with pytest.raises(ValueError, match="non-overlapping test windows"):
             list(splitter.split(y))
 
+    def test_expanding_window_all_test_no_train_raises(self, y_X_factory):
+        """The boundary n_samples == n_splits * test_size must not yield an empty train.
+
+        Regression for the 2026-06-15 QA finding: the guard was
+        ``first_test_start < 0``, so n_samples == n_splits * test_size (which
+        makes the first fold's training set empty) slipped through and yielded
+        a fold whose train index starts at 0.
+        """
+        y, _ = y_X_factory(length=20, n_targets=1, n_features=0, seed=42)
+
+        splitter = ExpandingWindowSplitter(n_splits=2, test_size=10)
+        with pytest.raises(ValueError, match="non-overlapping test windows"):
+            list(splitter.split(y))
+
     def test_expanding_window_split_count_matches_get_n_splits(self, y_X_factory):
         """split() yields exactly get_n_splits() folds, or raises (never silently fewer)."""
         y, _ = y_X_factory(length=20, n_targets=1, n_features=0, seed=42)

--- a/tests/model_selection/test_train_test_split.py
+++ b/tests/model_selection/test_train_test_split.py
@@ -114,6 +114,20 @@ class TestTrainTestSplitValidation:
         with pytest.raises(ValueError, match="At least one array"):
             train_test_split(test_size=2)
 
+    def test_float_rounding_to_full_sample_raises(self):
+        """A float test_size rounding to n_samples must raise, not empty the train set.
+
+        Regression for the 2026-06-15 QA finding: ``round(n * 0.99)`` could equal
+        n_samples, leaving ``split_idx == 0`` and an empty training set returned
+        silently.
+        """
+        y = pl.DataFrame({
+            "time": pl.date_range(date(2020, 1, 1), date(2020, 1, 10), eager=True),
+            "v": list(range(10)),
+        })
+        with pytest.raises(ValueError, match="leaves no training samples"):
+            train_test_split(y, test_size=0.99)
+
     def test_mismatched_lengths_raises(self, y_daily):
         short = pl.DataFrame({"a": [1, 2, 3]})
         with pytest.raises(ValueError, match="same number of rows"):

--- a/tests/preprocessing/test_imputation.py
+++ b/tests/preprocessing/test_imputation.py
@@ -105,6 +105,32 @@ class TestSeasonalImputer:
         # Check no nulls remain
         assert X_imputed.null_count().sum_horizontal().item() == 0
 
+    def test_empty_season_bucket_yields_null_not_nan(self):
+        """An empty season bucket leaves a polars null, never a float NaN.
+
+        Regression for the 2026-06-15 QA finding: when a season bucket had no
+        observations at fit time, ``_transform`` wrote ``np.nan`` over the
+        polars null, silently violating the data contract.
+        """
+        time = pl.datetime_range(
+            start=datetime(2020, 1, 1),
+            end=datetime(2020, 1, 10),
+            interval="1d",
+            eager=True,
+        )
+        # period=2: even rows are season 0, odd rows season 1. Season 0 has no
+        # observations at fit, so its positions cannot be imputed.
+        values = [None, 1.0, None, 2.0, None, 3.0, None, 4.0, None, 5.0]
+        X = pl.DataFrame({"time": time, "value": values})
+
+        imputer = SeasonalImputer(period=2, fill_method="seasonal_mean")
+        imputer.fit(X)
+        X_imputed = imputer.transform(X)
+
+        # The empty-bucket positions remain null, and no float NaN is emitted.
+        assert X_imputed["value"].is_nan().sum() == 0
+        assert X_imputed["value"].null_count() == 5
+
     def test_preserves_time_column(self, time_series_with_nulls_factory):
         """Test SeasonalImputer preserves time column."""
         X = time_series_with_nulls_factory(length=70, n_components=1)

--- a/tests/stationarity/test_trend.py
+++ b/tests/stationarity/test_trend.py
@@ -233,3 +233,24 @@ class TestPolynomialTrendWithoutExogenous:
         forecaster = PolynomialTrendForecaster(degree=1)
         tags = forecaster.__sklearn_tags__()
         assert tags.forecaster_tags.requires_exogenous is False
+
+    def test_panel_rewind_uses_per_group_observation_horizon(self):
+        """Each panel group's rewind uses its own transformer horizon.
+
+        Regression for the 2026-06-15 QA finding: panel rewind read the
+        observation horizon from the first group's transformer
+        (``next(iter(...))``) and applied it to every group. With groups whose
+        transformers have different horizons, each group must use its own.
+        """
+        from yohou.stationarity import SeasonalDifferencing
+
+        forecaster = PolynomialTrendForecaster(degree=1, target_transformer=SeasonalDifferencing(seasonality=2))
+        # Simulate a fitted panel state with per-group transformers whose
+        # observation horizons (== seasonality) differ across groups.
+        forecaster.target_transformer_ = {
+            "g0": SeasonalDifferencing(seasonality=2),
+            "g1": SeasonalDifferencing(seasonality=5),
+        }
+
+        assert forecaster._group_target_observation_horizon("g0") == 2
+        assert forecaster._group_target_observation_horizon("g1") == 5


### PR DESCRIPTION
## Description

Fixes confirmed, behavior-changing defects. Each fix ships with a failing-first regression test. This is the first of several PRs; the remaining workstreams (W2-W7: remaining correctness, docstrings, dead code, polars idioms, duplication, surface/assets) land separately.

Behavioral fixes:

- **compose/decomposition_pipeline**: panel `observe`/`rewind` branch on `groups_` and apply the per-group transformer dict (mirroring `predict`) instead of asserting a scalar `BaseTransformer`; `_y_observed`/`_X_observed` stored as per-group dicts so `predict()` works after a panel observe.
- **class_proba/base**: `_encode_observation` strips the `group__` prefix before the `label_to_code_` lookup (panel `KeyError`).
- **stationarity/base**: panel rewind uses each group's own `observation_horizon`, not the first group's.
- **compose/utils**: weighted `FeatureUnion` scales only non-`time` columns so the datetime `time` column is preserved.
- **preprocessing/imputation**: `SeasonalImputer` leaves empty-bucket positions as polars null, not float NaN.
- **model_selection/split**: `ExpandingWindowSplitter` and `train_test_split` raise on configs that would leave an empty training set.
- **compose/column_transformer**: `get_metadata_routing` registers `observe_transform`/`rewind_transform` callers so routing resolves.
- **compose/local_panel_forecaster**: `observe`/`rewind` drop `**params` (take no routable metadata; reject stray kwargs at the boundary).
- **ensemble/voting_class_proba**: add `_raise_for_params` + `process_routing` and thread per-forecaster routed params through the soft/hard vote helpers.
- **interval/reduction**: multiquantile path rejects multi-target and horizon>1 at fit (single-output, single-step estimator).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Two implementation notes vs. the original plan: (1) `LocalPanelForecaster.observe`/`rewind` drop `**params` rather than relying on `_raise_for_params`, which is a no-op since importing yohou enables metadata routing globally; (2) the multiquantile fix rejects unsupported shapes at fit, counting targets per group via `local_y_t_schema_` so single-target-per-group panels stay valid. Fast + slow + integration suites for the touched subpackages are green.