### PR TITLE
feat(plotting): add plot_nested_splits for nested CV visualization

### DIFF
--- a/docs/pages/api/plotting.md
+++ b/docs/pages/api/plotting.md
@@ -43,6 +43,7 @@ Interactive time series visualization functions using Plotly. All plotting funct
 | Name | Description |
 | --- | --- |
 | [`plot_splits`](generated/yohou.plotting.model_selection.plot_splits.md) | Plot cross-validation splits as a timeline visualization. |
+| [`plot_nested_splits`](generated/yohou.plotting.model_selection.plot_nested_splits.md) | Plot a nested cross-validation: inner folds within an outer training fold, outer test held out. |
 | [`plot_cv_results_scatter`](generated/yohou.plotting.model_selection.plot_cv_results_scatter.md) | Plot hyperparameter search results as a scatter plot. |
 | [`plot_forecast`](generated/yohou.plotting.forecasting.plot_forecast.md) | Plot forecasts with historical data and optional prediction intervals. |
 | [`plot_score_time_series`](generated/yohou.plotting.evaluation.plot_score_time_series.md) | Plot scorer values over time for one or more forecasts. |

--- a/docs/pages/api/plotting.md
+++ b/docs/pages/api/plotting.md
@@ -43,7 +43,7 @@ Interactive time series visualization functions using Plotly. All plotting funct
 | Name | Description |
 | --- | --- |
 | [`plot_splits`](generated/yohou.plotting.model_selection.plot_splits.md) | Plot cross-validation splits as a timeline visualization. |
-| [`plot_nested_splits`](generated/yohou.plotting.model_selection.plot_nested_splits.md) | Plot a nested cross-validation: inner folds within an outer training fold, outer test held out. |
+| [`plot_nested_splits`](generated/yohou.plotting.model_selection.plot_nested_splits.md) | Plot a nested cross-validation: inner tuning folds within an outer training fold, plus the outer refit window and its held-out scored test. |
 | [`plot_cv_results_scatter`](generated/yohou.plotting.model_selection.plot_cv_results_scatter.md) | Plot hyperparameter search results as a scatter plot. |
 | [`plot_forecast`](generated/yohou.plotting.forecasting.plot_forecast.md) | Plot forecasts with historical data and optional prediction intervals. |
 | [`plot_score_time_series`](generated/yohou.plotting.evaluation.plot_score_time_series.md) | Plot scorer values over time for one or more forecasts. |

--- a/src/yohou/metrics/base.py
+++ b/src/yohou/metrics/base.py
@@ -744,17 +744,20 @@ class BaseScorer(BaseEstimator, metaclass=abc.ABCMeta):
             value_cols: list[str],
         ) -> pl.DataFrame:
             """Apply a single normalized weight (array or dict) to scores."""
-            if isinstance(w_resolved, dict):
-                for group_name, group_arr in w_resolved.items():
-                    normed = _normalize_weights(group_arr)  # ty: ignore[invalid-argument-type]
-                    tiled = np.tile(normed, n_rates) if n_rates > 1 else normed
-                    group_cols = [c for c in panel_groups.get(group_name, []) if c in value_cols]  # ty: ignore[no-matching-overload]
-                    if group_cols:
-                        df = _apply_array(df, tiled, group_cols)
-            else:
+            if isinstance(w_resolved, np.ndarray):
                 normed = _normalize_weights(w_resolved)
                 tiled = np.tile(normed, n_rates) if n_rates > 1 else normed
                 df = _apply_array(df, tiled, value_cols)
+            else:
+                # ``w_resolved`` narrows to ``dict[str, np.ndarray]`` here (the union
+                # minus ``np.ndarray``), which preserves the key/value types so no
+                # type suppressions are needed for ``group_name`` / ``group_arr``.
+                for group_name, group_arr in w_resolved.items():
+                    normed = _normalize_weights(group_arr)
+                    tiled = np.tile(normed, n_rates) if n_rates > 1 else normed
+                    group_cols = [c for c in panel_groups.get(group_name, []) if c in value_cols]
+                    if group_cols:
+                        df = _apply_array(df, tiled, group_cols)
             return df
 
         value_cols = [c for c in scores.columns if c != "coverage_rate"]

--- a/src/yohou/plotting/__init__.py
+++ b/src/yohou/plotting/__init__.py
@@ -50,7 +50,7 @@ from yohou.plotting.forecasting import (
     plot_forecast,
     plot_time_weight,
 )
-from yohou.plotting.model_selection import plot_cv_results_scatter, plot_splits
+from yohou.plotting.model_selection import plot_cv_results_scatter, plot_nested_splits, plot_splits
 from yohou.plotting.signal import plot_phase, plot_spectrum
 
 __all__ = [
@@ -77,6 +77,7 @@ __all__ = [
     "plot_group_scores",
     "plot_lag_scatter",
     "plot_missing_data",
+    "plot_nested_splits",
     "plot_outliers",
     "plot_partial_autocorrelation",
     "plot_phase",

--- a/src/yohou/plotting/model_selection.py
+++ b/src/yohou/plotting/model_selection.py
@@ -77,13 +77,17 @@ def _add_split_row(
     line_width: float,
     show_train_legend: bool,
     show_test_legend: bool,
+    train_group: str = "train",
+    test_group: str = "test",
     row: int | None = None,
     col: int | None = None,
 ) -> None:
     """Draw a train segment and a test segment on a single ``row_label`` row.
 
     Reused by :func:`plot_splits` (one row per outer fold) and
-    :func:`plot_nested_splits` (one row per inner fold).
+    :func:`plot_nested_splits` (one row per inner fold, plus the outer evaluation
+    row). ``train_group`` / ``test_group`` set the ``legendgroup`` so that, for
+    example, the inner and outer rows toggle independently in the legend.
     """
     _add_segment(
         fig,
@@ -92,7 +96,7 @@ def _add_split_row(
         row_label,
         color=train_color,
         name=train_name,
-        legendgroup="train",
+        legendgroup=train_group,
         show_legend=show_train_legend,
         line_width=line_width,
         row=row,
@@ -105,7 +109,7 @@ def _add_split_row(
         row_label,
         color=test_color,
         name=test_name,
-        legendgroup="test",
+        legendgroup=test_group,
         show_legend=show_test_legend,
         line_width=line_width,
         row=row,
@@ -279,10 +283,12 @@ def _plot_nested_all(
     *,
     train_color: str,
     test_color: str,
-    holdout_color: str,
+    outer_train_color: str,
+    outer_test_color: str,
     train_name: str,
     test_name: str,
-    holdout_name: str,
+    outer_train_name: str,
+    outer_test_name: str,
     show_legend: bool,
     title: str,
     x_label: str,
@@ -333,7 +339,7 @@ def _plot_nested_all(
                 inner_times,
                 inner_train_idx,
                 inner_test_idx,
-                f"Fold {j + 1}",
+                f"Inner fold {j + 1}",
                 train_color=train_color,
                 test_color=test_color,
                 train_name=train_name,
@@ -341,19 +347,27 @@ def _plot_nested_all(
                 line_width=line_width,
                 show_train_legend=tracker.should_show(train_name),
                 show_test_legend=tracker.should_show(test_name),
+                train_group="inner_train",
+                test_group="inner_val",
                 row=row,
                 col=col,
             )
-        _add_segment(
+        # Outer evaluation row: refit window + held-out scored test window.
+        _add_split_row(
             fig,
             times,
+            outer_train_idx,
             outer_test_idx,
-            holdout_name,
-            color=holdout_color,
-            name=holdout_name,
-            legendgroup="holdout",
-            show_legend=tracker.should_show(holdout_name),
+            "Outer fold",
+            train_color=outer_train_color,
+            test_color=outer_test_color,
+            train_name=outer_train_name,
+            test_name=outer_test_name,
             line_width=line_width,
+            show_train_legend=tracker.should_show(outer_train_name),
+            show_test_legend=tracker.should_show(outer_test_name),
+            train_group="outer_train",
+            test_group="outer_test",
             row=row,
             col=col,
         )
@@ -375,10 +389,12 @@ def plot_nested_splits(
     X_actual: pl.DataFrame | None = None,
     train_color: str | None = None,
     test_color: str | None = None,
-    holdout_color: str | None = None,
+    outer_train_color: str | None = None,
+    outer_test_color: str | None = None,
     train_name: str = "Inner train",
     test_name: str = "Inner validation",
-    holdout_name: str = "Outer test (held out)",
+    outer_train_name: str = "Outer train (refit, best params)",
+    outer_test_name: str = "Outer test (scored)",
     show_legend: bool = True,
     title: str | None = None,
     x_label: str | None = None,
@@ -392,10 +408,13 @@ def plot_nested_splits(
     """
     Plot a nested cross-validation as a timeline visualization.
 
-    Shows the inner cross-validation carved from one outer fold's training window,
-    together with that outer fold's test window drawn as a held-out segment the inner
-    splitter never sees. The figure is generated from the splitters themselves, so it
-    is faithful to actual splitting behavior rather than hand-drawn.
+    Shows both levels of a nested cross-validation. The **inner** rows are the
+    cross-validation carved from one outer fold's training window, which selects the
+    hyperparameters. The **outer** row above them shows the full outer training
+    window the model is then refit on with those hyperparameters, plus the outer test
+    window it is scored on (held out from the inner tuning). The figure is generated
+    from the splitters themselves, so it is faithful to actual splitting behavior
+    rather than hand-drawn.
 
     Parameters
     ----------
@@ -412,15 +431,18 @@ def plot_nested_splits(
     X_actual : pl.DataFrame or None, default=None
         Actual features passed to ``split()``. Sliced to the outer training window for
         the inner split.
-    train_color, test_color, holdout_color : str or None, default=None
-        Colors for the inner-train, inner-validation, and held-out outer-test segments.
-        If None, the first three colors from the yohou palette are used.
+    train_color, test_color, outer_train_color, outer_test_color : str or None, default=None
+        Colors for the inner-train, inner-validation, outer-refit-train, and
+        outer-test segments. If None, the first four colors from the yohou palette
+        are used.
     train_name : str, default="Inner train"
         Legend label for the inner training segments.
     test_name : str, default="Inner validation"
         Legend label for the inner validation segments.
-    holdout_name : str, default="Outer test (held out)"
-        Legend label for the held-out outer-test segment.
+    outer_train_name : str, default="Outer train (refit, best params)"
+        Legend label for the outer training window the model is refit on.
+    outer_test_name : str, default="Outer test (scored)"
+        Legend label for the outer test window the refit model is scored on.
     show_legend : bool, default=True
         Whether to show the legend.
     title : str or None, default=None
@@ -484,10 +506,11 @@ def plot_nested_splits(
             msg = f"Expected BaseSplitter for {label}, got {type(splitter).__name__}"
             raise TypeError(msg)
 
-    colors = resolve_color_palette(None, 3)
+    colors = resolve_color_palette(None, 4)
     train_color = train_color or colors[0]
     test_color = test_color or colors[1]
-    holdout_color = holdout_color or colors[2]
+    outer_train_color = outer_train_color or colors[2]
+    outer_test_color = outer_test_color or colors[3]
 
     times = y["time"]
     outer_splits = list(outer_splitter.split(y, X_actual))
@@ -506,10 +529,12 @@ def plot_nested_splits(
             X_actual,
             train_color=train_color,
             test_color=test_color,
-            holdout_color=holdout_color,
+            outer_train_color=outer_train_color,
+            outer_test_color=outer_test_color,
             train_name=train_name,
             test_name=test_name,
-            holdout_name=holdout_name,
+            outer_train_name=outer_train_name,
+            outer_test_name=outer_test_name,
             show_legend=show_legend,
             title=title_default,
             x_label=x_label_default,
@@ -541,7 +566,7 @@ def plot_nested_splits(
             inner_times,
             inner_train_idx,
             inner_test_idx,
-            f"Fold {j + 1}",
+            f"Inner fold {j + 1}",
             train_color=train_color,
             test_color=test_color,
             train_name=train_name,
@@ -549,18 +574,26 @@ def plot_nested_splits(
             line_width=line_width,
             show_train_legend=(j == 0),
             show_test_legend=(j == 0),
+            train_group="inner_train",
+            test_group="inner_val",
         )
-    # Held-out outer test row (single segment, placed on the full-series time axis).
-    _add_segment(
+    # Outer evaluation row: the full outer training window the model is refit on with
+    # the best hyperparameters, plus the held-out outer test window it is scored on.
+    _add_split_row(
         fig,
         times,
+        outer_train_idx,
         outer_test_idx,
-        holdout_name,
-        color=holdout_color,
-        name=holdout_name,
-        legendgroup="holdout",
-        show_legend=show_legend,
+        "Outer fold",
+        train_color=outer_train_color,
+        test_color=outer_test_color,
+        train_name=outer_train_name,
+        test_name=outer_test_name,
         line_width=line_width,
+        show_train_legend=show_legend,
+        show_test_legend=show_legend,
+        train_group="outer_train",
+        test_group="outer_test",
     )
 
     n_plot_rows = len(inner_splits) + 1

--- a/src/yohou/plotting/model_selection.py
+++ b/src/yohou/plotting/model_selection.py
@@ -1,7 +1,9 @@
 """Cross-validation and hyperparameter search visualization functions."""
 
+import math
 from typing import Literal
 
+import numpy as np
 import polars as pl
 
 try:
@@ -11,10 +13,104 @@ except ImportError as e:
     raise ImportError(msg) from e
 
 from yohou.model_selection import BaseSplitter
-from yohou.plotting._utils import _create_figure, apply_default_layout, resolve_color_palette
+from yohou.plotting._utils import (
+    LegendTracker,
+    _create_figure,
+    _create_subplots,
+    _subplot_spacing,
+    apply_default_layout,
+    resolve_color_palette,
+)
 from yohou.utils import validate_plotting_data, validate_plotting_params
 
-__all__ = ["plot_cv_results_scatter", "plot_splits"]
+__all__ = ["plot_cv_results_scatter", "plot_nested_splits", "plot_splits"]
+
+
+def _add_segment(
+    fig: go.Figure,
+    times: pl.Series,
+    idx: np.ndarray,
+    row_label: str,
+    *,
+    color: str,
+    name: str,
+    legendgroup: str,
+    show_legend: bool,
+    line_width: float,
+    row: int | None = None,
+    col: int | None = None,
+) -> None:
+    """Draw one horizontal segment (``idx[0]``..``idx[-1]``) on the ``row_label`` row.
+
+    Shared primitive for :func:`plot_splits` and :func:`plot_nested_splits`. When
+    ``show_legend`` is ``False`` the trace name is dropped (matching the historical
+    ``plot_splits`` behavior for non-first folds) while the ``legendgroup`` is kept so
+    grouped traces still toggle together.
+    """
+    add_kwargs = {} if row is None else {"row": row, "col": col}
+    fig.add_trace(
+        go.Scatter(
+            x=[times[int(idx[0])], times[int(idx[-1])]],
+            y=[row_label, row_label],
+            mode="lines",
+            line={"color": color, "width": line_width},
+            name=name if show_legend else None,
+            showlegend=show_legend,
+            legendgroup=legendgroup,
+            hovertemplate=f"{name}<br>Start: %{{x}}<br>Fold: {row_label}<extra></extra>",
+        ),
+        **add_kwargs,
+    )
+
+
+def _add_split_row(
+    fig: go.Figure,
+    times: pl.Series,
+    train_idx: np.ndarray,
+    test_idx: np.ndarray,
+    row_label: str,
+    *,
+    train_color: str,
+    test_color: str,
+    train_name: str,
+    test_name: str,
+    line_width: float,
+    show_train_legend: bool,
+    show_test_legend: bool,
+    row: int | None = None,
+    col: int | None = None,
+) -> None:
+    """Draw a train segment and a test segment on a single ``row_label`` row.
+
+    Reused by :func:`plot_splits` (one row per outer fold) and
+    :func:`plot_nested_splits` (one row per inner fold).
+    """
+    _add_segment(
+        fig,
+        times,
+        train_idx,
+        row_label,
+        color=train_color,
+        name=train_name,
+        legendgroup="train",
+        show_legend=show_train_legend,
+        line_width=line_width,
+        row=row,
+        col=col,
+    )
+    _add_segment(
+        fig,
+        times,
+        test_idx,
+        row_label,
+        color=test_color,
+        name=test_name,
+        legendgroup="test",
+        show_legend=show_test_legend,
+        line_width=line_width,
+        row=row,
+        col=col,
+    )
 
 
 def plot_splits(
@@ -24,6 +120,8 @@ def plot_splits(
     X_actual: pl.DataFrame | None = None,
     train_color: str | None = None,
     test_color: str | None = None,
+    train_name: str = "Train",
+    test_name: str = "Test",
     show_legend: bool = True,
     title: str | None = None,
     x_label: str | None = None,
@@ -52,6 +150,10 @@ def plot_splits(
         Color for train segments. If None, uses first color from yohou palette.
     test_color : str | None, default=None
         Color for test segments. If None, uses second color from yohou palette.
+    train_name : str, default="Train"
+        Legend label for the train segments.
+    test_name : str, default="Test"
+        Legend label for the test segments.
     show_legend : bool, default=True
         Whether to show the legend.
     title : str | None, default=None
@@ -130,44 +232,21 @@ def plot_splits(
     # Get time column
     times = y["time"]
 
-    # Plot each split
+    # Plot each split (one row per fold: train segment + test segment).
     for i, (train_idx, test_idx) in enumerate(splits):
-        fold_label = f"Fold {i + 1}"
-
-        # Get train time range
-        t_train_start = times[int(train_idx[0])]
-        t_train_end = times[int(train_idx[-1])]
-
-        # Get test time range
-        t_test_start = times[int(test_idx[0])]
-        t_test_end = times[int(test_idx[-1])]
-
-        # Plot train segment
-        fig.add_trace(
-            go.Scatter(
-                x=[t_train_start, t_train_end],
-                y=[fold_label, fold_label],
-                mode="lines",
-                line={"color": train_color, "width": line_width},
-                name="Train" if i == 0 else None,
-                showlegend=(i == 0),
-                legendgroup="train",
-                hovertemplate=f"Train<br>Start: %{{x}}<br>Fold: {fold_label}<extra></extra>",
-            )
-        )
-
-        # Plot test segment
-        fig.add_trace(
-            go.Scatter(
-                x=[t_test_start, t_test_end],
-                y=[fold_label, fold_label],
-                mode="lines",
-                line={"color": test_color, "width": line_width},
-                name="Test" if i == 0 else None,
-                showlegend=(i == 0),
-                legendgroup="test",
-                hovertemplate=f"Test<br>Start: %{{x}}<br>Fold: {fold_label}<extra></extra>",
-            )
+        _add_split_row(
+            fig,
+            times,
+            train_idx,
+            test_idx,
+            f"Fold {i + 1}",
+            train_color=train_color,
+            test_color=test_color,
+            train_name=train_name,
+            test_name=test_name,
+            line_width=line_width,
+            show_train_legend=(i == 0),
+            show_test_legend=(i == 0),
         )
 
     # Set default labels
@@ -188,6 +267,313 @@ def plot_splits(
     )
     fig.update_layout(showlegend=show_legend)
 
+    return fig
+
+
+def _plot_nested_all(
+    y: pl.DataFrame,
+    times: pl.Series,
+    outer_splits: list,
+    inner_splitter: BaseSplitter,
+    X_actual: pl.DataFrame | None,
+    *,
+    train_color: str,
+    test_color: str,
+    holdout_color: str,
+    train_name: str,
+    test_name: str,
+    holdout_name: str,
+    show_legend: bool,
+    title: str,
+    x_label: str,
+    y_label: str,
+    width: int | None,
+    height: int | None,
+    resampler: bool | Literal["widget"] | None,
+    line_width: float,
+    facet_n_cols: int,
+) -> go.Figure:
+    """Render one subplot per outer fold (faceted nested-CV view).
+
+    Used by :func:`plot_nested_splits` when ``outer_fold="all"``. A
+    :class:`~yohou.plotting._utils.LegendTracker` ensures each legend entry appears
+    once across all subplots.
+    """
+    n_outer = len(outer_splits)
+    n_cols = min(n_outer, max(1, facet_n_cols))
+    n_rows = math.ceil(n_outer / n_cols)
+    n_cells = n_rows * n_cols
+    subplot_titles = [f"Outer fold {k + 1}" if k < n_outer else "" for k in range(n_cells)]
+
+    fig = _create_subplots(
+        resampler,
+        rows=n_rows,
+        cols=n_cols,
+        shared_xaxes=True,
+        subplot_titles=subplot_titles,
+        vertical_spacing=_subplot_spacing(n_rows),
+    )
+    tracker = LegendTracker(show_legend)
+
+    for k, (outer_train_idx, outer_test_idx) in enumerate(outer_splits):
+        row = k // n_cols + 1
+        col = k % n_cols + 1
+        y_inner = y[outer_train_idx]
+        x_inner = X_actual[outer_train_idx] if X_actual is not None else None
+        inner_times = y_inner["time"]
+        try:
+            inner_splits = list(inner_splitter.split(y_inner, x_inner))
+        except Exception as exc:
+            msg = f"inner split failed for outer fold {k + 1} (training slice of {len(outer_train_idx)} rows): {exc}"
+            raise ValueError(msg) from exc
+
+        for j, (inner_train_idx, inner_test_idx) in enumerate(inner_splits):
+            _add_split_row(
+                fig,
+                inner_times,
+                inner_train_idx,
+                inner_test_idx,
+                f"Fold {j + 1}",
+                train_color=train_color,
+                test_color=test_color,
+                train_name=train_name,
+                test_name=test_name,
+                line_width=line_width,
+                show_train_legend=tracker.should_show(train_name),
+                show_test_legend=tracker.should_show(test_name),
+                row=row,
+                col=col,
+            )
+        _add_segment(
+            fig,
+            times,
+            outer_test_idx,
+            holdout_name,
+            color=holdout_color,
+            name=holdout_name,
+            legendgroup="holdout",
+            show_legend=tracker.should_show(holdout_name),
+            line_width=line_width,
+            row=row,
+            col=col,
+        )
+
+    height_default = height or max(400, n_rows * 320)
+    fig = apply_default_layout(fig, title=title, width=width, height=height_default)
+    fig.update_xaxes(title_text=x_label)
+    fig.update_yaxes(title_text=y_label)
+    fig.update_layout(showlegend=show_legend)
+    return fig
+
+
+def plot_nested_splits(
+    y: pl.DataFrame,
+    outer_splitter: BaseSplitter,
+    inner_splitter: BaseSplitter,
+    *,
+    outer_fold: int | Literal["all"] = -1,
+    X_actual: pl.DataFrame | None = None,
+    train_color: str | None = None,
+    test_color: str | None = None,
+    holdout_color: str | None = None,
+    train_name: str = "Inner train",
+    test_name: str = "Inner validation",
+    holdout_name: str = "Outer test (held out)",
+    show_legend: bool = True,
+    title: str | None = None,
+    x_label: str | None = None,
+    y_label: str | None = None,
+    width: int | None = None,
+    height: int | None = None,
+    resampler: bool | Literal["widget"] | None = None,
+    line_width: float = 10.0,
+    facet_n_cols: int = 2,
+) -> go.Figure:
+    """
+    Plot a nested cross-validation as a timeline visualization.
+
+    Shows the inner cross-validation carved from one outer fold's training window,
+    together with that outer fold's test window drawn as a held-out segment the inner
+    splitter never sees. The figure is generated from the splitters themselves, so it
+    is faithful to actual splitting behavior rather than hand-drawn.
+
+    Parameters
+    ----------
+    y : pl.DataFrame
+        Target time series with mandatory "time" column.
+    outer_splitter : BaseSplitter
+        Splitter for the outer (evaluation) loop.
+    inner_splitter : BaseSplitter
+        Splitter for the inner (tuning) loop, applied to an outer fold's training slice.
+    outer_fold : int or "all", default=-1
+        Which outer fold to render. An integer selects a single outer fold (default
+        ``-1``, the last fold, whose training window is largest). ``"all"`` renders one
+        subplot per outer fold.
+    X_actual : pl.DataFrame or None, default=None
+        Actual features passed to ``split()``. Sliced to the outer training window for
+        the inner split.
+    train_color, test_color, holdout_color : str or None, default=None
+        Colors for the inner-train, inner-validation, and held-out outer-test segments.
+        If None, the first three colors from the yohou palette are used.
+    train_name : str, default="Inner train"
+        Legend label for the inner training segments.
+    test_name : str, default="Inner validation"
+        Legend label for the inner validation segments.
+    holdout_name : str, default="Outer test (held out)"
+        Legend label for the held-out outer-test segment.
+    show_legend : bool, default=True
+        Whether to show the legend.
+    title : str or None, default=None
+        Plot title. Defaults to "Nested Cross-Validation Splits".
+    x_label : str or None, default=None
+        X-axis label. Defaults to "Time".
+    y_label : str or None, default=None
+        Y-axis label. Defaults to "Fold".
+    width : int or None, default=None
+        Plot width in pixels.
+    height : int or None, default=None
+        Plot height in pixels.
+    resampler : bool or "widget" or None, default=None
+        Enable plotly-resampler for large datasets.
+    line_width : float, default=10.0
+        Width of the segment bars.
+    facet_n_cols : int, default=2
+        Number of subplot columns when ``outer_fold="all"``.
+
+    Returns
+    -------
+    go.Figure
+        Plotly figure object.
+
+    Raises
+    ------
+    TypeError
+        If a splitter is not a ``BaseSplitter``.
+    ValueError
+        If ``y`` is empty or missing 'time', ``outer_fold`` is out of range, or an
+        outer fold's training slice is too small for the inner splitter.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from yohou.plotting import plot_nested_splits
+    >>> from yohou.model_selection import ExpandingWindowSplitter
+
+    >>> y = pl.DataFrame({
+    ...     "time": pl.date_range(pl.date(2020, 1, 1), pl.date(2020, 12, 31), "1d", eager=True),
+    ...     "value": list(range(366)),
+    ... })
+
+    >>> fig = plot_nested_splits(
+    ...     y,
+    ...     ExpandingWindowSplitter(n_splits=3, test_size=30),
+    ...     ExpandingWindowSplitter(n_splits=3, test_size=20),
+    ... )
+    >>> len(fig.data) > 0
+    True
+
+    See Also
+    --------
+    [`plot_splits`][yohou.plotting.plot_splits] : Plot a flat (single-level) CV.
+    `ExpandingWindowSplitter` : Expanding window cross-validation.
+    """
+    validate_plotting_data(y)
+    validate_plotting_params(width=width, height=height)
+    for label, splitter in (("outer_splitter", outer_splitter), ("inner_splitter", inner_splitter)):
+        if not isinstance(splitter, BaseSplitter):
+            msg = f"Expected BaseSplitter for {label}, got {type(splitter).__name__}"
+            raise TypeError(msg)
+
+    colors = resolve_color_palette(None, 3)
+    train_color = train_color or colors[0]
+    test_color = test_color or colors[1]
+    holdout_color = holdout_color or colors[2]
+
+    times = y["time"]
+    outer_splits = list(outer_splitter.split(y, X_actual))
+    n_outer = len(outer_splits)
+
+    title_default = title or "Nested Cross-Validation Splits"
+    x_label_default = x_label or "Time"
+    y_label_default = y_label or "Fold"
+
+    if outer_fold == "all":
+        return _plot_nested_all(
+            y,
+            times,
+            outer_splits,
+            inner_splitter,
+            X_actual,
+            train_color=train_color,
+            test_color=test_color,
+            holdout_color=holdout_color,
+            train_name=train_name,
+            test_name=test_name,
+            holdout_name=holdout_name,
+            show_legend=show_legend,
+            title=title_default,
+            x_label=x_label_default,
+            y_label=y_label_default,
+            width=width,
+            height=height,
+            resampler=resampler,
+            line_width=line_width,
+            facet_n_cols=facet_n_cols,
+        )
+
+    if not isinstance(outer_fold, int):
+        msg = f"outer_fold must be an int or 'all', got {outer_fold!r}"
+        raise ValueError(msg)
+    if not -n_outer <= outer_fold < n_outer:
+        msg = f"outer_fold={outer_fold} is out of range for {n_outer} outer folds"
+        raise ValueError(msg)
+
+    outer_train_idx, outer_test_idx = outer_splits[outer_fold]
+    y_inner = y[outer_train_idx]
+    x_inner = X_actual[outer_train_idx] if X_actual is not None else None
+    inner_times = y_inner["time"]
+    inner_splits = list(inner_splitter.split(y_inner, x_inner))
+
+    fig = _create_figure(resampler)
+    for j, (inner_train_idx, inner_test_idx) in enumerate(inner_splits):
+        _add_split_row(
+            fig,
+            inner_times,
+            inner_train_idx,
+            inner_test_idx,
+            f"Fold {j + 1}",
+            train_color=train_color,
+            test_color=test_color,
+            train_name=train_name,
+            test_name=test_name,
+            line_width=line_width,
+            show_train_legend=(j == 0),
+            show_test_legend=(j == 0),
+        )
+    # Held-out outer test row (single segment, placed on the full-series time axis).
+    _add_segment(
+        fig,
+        times,
+        outer_test_idx,
+        holdout_name,
+        color=holdout_color,
+        name=holdout_name,
+        legendgroup="holdout",
+        show_legend=show_legend,
+        line_width=line_width,
+    )
+
+    n_plot_rows = len(inner_splits) + 1
+    height_default = height or (300 + n_plot_rows * 30)
+    fig = apply_default_layout(
+        fig,
+        title=title_default,
+        x_label=x_label_default,
+        y_label=y_label_default,
+        width=width,
+        height=height_default,
+    )
+    fig.update_layout(showlegend=show_legend)
     return fig
 
 

--- a/tests/plotting/test_model_selection.py
+++ b/tests/plotting/test_model_selection.py
@@ -139,26 +139,38 @@ class TestPlotNestedSplits:
     """Tests for plot_nested_splits function."""
 
     def test_basic_single_fold(self, sample_y):
-        """Single outer fold renders inner folds plus a held-out outer-test row."""
+        """Single outer fold renders inner folds plus the outer evaluation row."""
         fig = plot_nested_splits(
             sample_y,
             ExpandingWindowSplitter(n_splits=3, test_size=30),
             ExpandingWindowSplitter(n_splits=2, test_size=20),
         )
-        # 2 inner folds × (train + test) + 1 held-out row
-        assert_figure_valid(fig, min_traces=5)
+        # 2 inner folds × (train + test) + outer row (train + test) = 6 traces
+        assert_figure_valid(fig, min_traces=6)
 
-    def test_holdout_row_present(self, sample_y):
-        """The held-out outer-test segment appears as its own legend entry and row."""
+    def test_outer_row_present(self, sample_y):
+        """The outer evaluation row shows the refit-train and the scored outer test."""
         fig = plot_nested_splits(
             sample_y,
             ExpandingWindowSplitter(n_splits=3, test_size=30),
             ExpandingWindowSplitter(n_splits=2, test_size=20),
         )
         legend_names = [t.name for t in fig.data if t.showlegend]
-        assert "Outer test (held out)" in legend_names
+        assert "Outer train (refit, best params)" in legend_names
+        assert "Outer test (scored)" in legend_names
         rows = {label for t in fig.data for label in t.y}
-        assert "Outer test (held out)" in rows
+        assert "Outer fold" in rows
+
+    def test_outer_train_spans_full_training_window(self, sample_y):
+        """The outer refit-train segment covers the whole outer training window."""
+        outer = ExpandingWindowSplitter(n_splits=3, test_size=30)
+        train_idx, _ = list(outer.split(sample_y))[-1]
+        expected_start = sample_y["time"][int(train_idx[0])]
+        expected_end = sample_y["time"][int(train_idx[-1])]
+        fig = plot_nested_splits(sample_y, outer, ExpandingWindowSplitter(n_splits=2, test_size=20))
+        outer_train = next(t for t in fig.data if t.name == "Outer train (refit, best params)")
+        assert outer_train.x[0] == expected_start
+        assert outer_train.x[-1] == expected_end
 
     def test_faceted_all_folds(self, sample_y):
         """outer_fold='all' renders one subplot per outer fold, legend shown once."""
@@ -173,9 +185,14 @@ class TestPlotNestedSplits:
         # One subplot per outer fold (3) -> at least 3 x-axes in the layout.
         x_axes = [k for k in fig.layout if k.startswith("xaxis")]
         assert len(x_axes) >= 3
-        # Each legend entry (inner train / inner validation / held-out) appears once.
+        # Each of the four legend entries appears once across the subplots.
         legend_names = [t.name for t in fig.data if t.showlegend]
-        assert sorted(legend_names) == ["Inner train", "Inner validation", "Outer test (held out)"]
+        assert sorted(legend_names) == [
+            "Inner train",
+            "Inner validation",
+            "Outer test (scored)",
+            "Outer train (refit, best params)",
+        ]
 
     def test_custom_colors_and_names(self, sample_y):
         """Colors and segment names are configurable."""
@@ -185,13 +202,15 @@ class TestPlotNestedSplits:
             ExpandingWindowSplitter(n_splits=2, test_size=20),
             train_color="#111111",
             test_color="#222222",
-            holdout_color="#333333",
+            outer_train_color="#333333",
+            outer_test_color="#444444",
             train_name="itr",
             test_name="ival",
-            holdout_name="held",
+            outer_train_name="otr",
+            outer_test_name="otest",
         )
         legend_names = [t.name for t in fig.data if t.showlegend]
-        assert legend_names == ["itr", "ival", "held"]
+        assert legend_names == ["itr", "ival", "otr", "otest"]
 
     def test_sliding_window_outer(self, sample_y):
         """A non-prefix outer training set (sliding window) renders without error."""

--- a/tests/plotting/test_model_selection.py
+++ b/tests/plotting/test_model_selection.py
@@ -241,6 +241,45 @@ class TestPlotNestedSplits:
                 "not_a_splitter",
             )
 
+    def test_invalid_outer_fold_value(self, sample_y):
+        """A non-integer outer_fold other than 'all' raises ValueError."""
+        with pytest.raises(ValueError, match="must be an int or 'all'"):
+            plot_nested_splits(
+                sample_y,
+                ExpandingWindowSplitter(n_splits=3, test_size=30),
+                ExpandingWindowSplitter(n_splits=2, test_size=20),
+                outer_fold="last",
+            )
+
+    def test_faceted_inner_split_too_small_raises(self, sample_y):
+        """An outer fold whose training slice is too small for the inner splitter raises a fold-indexed error."""
+        with pytest.raises(ValueError, match="inner split failed for outer fold"):
+            plot_nested_splits(
+                sample_y,
+                ExpandingWindowSplitter(n_splits=3, test_size=30),
+                ExpandingWindowSplitter(n_splits=2, test_size=200),  # needs 400 rows, first fold has ~276
+                outer_fold="all",
+            )
+
+    def test_with_x_actual(self, sample_y):
+        """X_actual is sliced to the outer training window in both single-fold and faceted modes."""
+        x_actual = pl.DataFrame({"time": sample_y["time"], "feature": list(range(len(sample_y)))})
+        single = plot_nested_splits(
+            sample_y,
+            ExpandingWindowSplitter(n_splits=3, test_size=30),
+            ExpandingWindowSplitter(n_splits=2, test_size=20),
+            X_actual=x_actual,
+        )
+        assert_figure_valid(single)
+        faceted = plot_nested_splits(
+            sample_y,
+            ExpandingWindowSplitter(n_splits=3, test_size=30),
+            ExpandingWindowSplitter(n_splits=2, test_size=20),
+            X_actual=x_actual,
+            outer_fold="all",
+        )
+        assert_figure_valid(faceted)
+
 
 class TestPlotCvResultsScatter:
     """Tests for plot_cv_results_scatter function."""

--- a/tests/plotting/test_model_selection.py
+++ b/tests/plotting/test_model_selection.py
@@ -9,7 +9,7 @@ import polars as pl
 import pytest
 
 from yohou.model_selection import ExpandingWindowSplitter, SlidingWindowSplitter
-from yohou.plotting import plot_cv_results_scatter, plot_splits
+from yohou.plotting import plot_cv_results_scatter, plot_nested_splits, plot_splits
 
 from .conftest import assert_figure_valid, assert_layout
 
@@ -119,6 +119,108 @@ class TestPlotSplits:
         splitter = ExpandingWindowSplitter(n_splits=2, test_size=30)
         fig = plot_splits(sample_y, splitter)
         assert len(fig.data) >= 4  # At least 2 × (train + test)
+
+    def test_default_legend_names_unchanged(self, sample_y):
+        """The default legend labels remain 'Train' / 'Test'."""
+        splitter = ExpandingWindowSplitter(n_splits=2, test_size=30)
+        fig = plot_splits(sample_y, splitter)
+        legend_names = [t.name for t in fig.data if t.showlegend]
+        assert legend_names == ["Train", "Test"]
+
+    def test_custom_train_test_names(self, sample_y):
+        """train_name / test_name override the legend labels without renaming traces."""
+        splitter = ExpandingWindowSplitter(n_splits=2, test_size=30)
+        fig = plot_splits(sample_y, splitter, train_name="Fit", test_name="Scored")
+        legend_names = [t.name for t in fig.data if t.showlegend]
+        assert legend_names == ["Fit", "Scored"]
+
+
+class TestPlotNestedSplits:
+    """Tests for plot_nested_splits function."""
+
+    def test_basic_single_fold(self, sample_y):
+        """Single outer fold renders inner folds plus a held-out outer-test row."""
+        fig = plot_nested_splits(
+            sample_y,
+            ExpandingWindowSplitter(n_splits=3, test_size=30),
+            ExpandingWindowSplitter(n_splits=2, test_size=20),
+        )
+        # 2 inner folds × (train + test) + 1 held-out row
+        assert_figure_valid(fig, min_traces=5)
+
+    def test_holdout_row_present(self, sample_y):
+        """The held-out outer-test segment appears as its own legend entry and row."""
+        fig = plot_nested_splits(
+            sample_y,
+            ExpandingWindowSplitter(n_splits=3, test_size=30),
+            ExpandingWindowSplitter(n_splits=2, test_size=20),
+        )
+        legend_names = [t.name for t in fig.data if t.showlegend]
+        assert "Outer test (held out)" in legend_names
+        rows = {label for t in fig.data for label in t.y}
+        assert "Outer test (held out)" in rows
+
+    def test_faceted_all_folds(self, sample_y):
+        """outer_fold='all' renders one subplot per outer fold, legend shown once."""
+        outer = ExpandingWindowSplitter(n_splits=3, test_size=30)
+        fig = plot_nested_splits(
+            sample_y,
+            outer,
+            ExpandingWindowSplitter(n_splits=2, test_size=20),
+            outer_fold="all",
+        )
+        assert_figure_valid(fig)
+        # One subplot per outer fold (3) -> at least 3 x-axes in the layout.
+        x_axes = [k for k in fig.layout if k.startswith("xaxis")]
+        assert len(x_axes) >= 3
+        # Each legend entry (inner train / inner validation / held-out) appears once.
+        legend_names = [t.name for t in fig.data if t.showlegend]
+        assert sorted(legend_names) == ["Inner train", "Inner validation", "Outer test (held out)"]
+
+    def test_custom_colors_and_names(self, sample_y):
+        """Colors and segment names are configurable."""
+        fig = plot_nested_splits(
+            sample_y,
+            ExpandingWindowSplitter(n_splits=3, test_size=30),
+            ExpandingWindowSplitter(n_splits=2, test_size=20),
+            train_color="#111111",
+            test_color="#222222",
+            holdout_color="#333333",
+            train_name="itr",
+            test_name="ival",
+            holdout_name="held",
+        )
+        legend_names = [t.name for t in fig.data if t.showlegend]
+        assert legend_names == ["itr", "ival", "held"]
+
+    def test_sliding_window_outer(self, sample_y):
+        """A non-prefix outer training set (sliding window) renders without error."""
+        fig = plot_nested_splits(
+            sample_y,
+            SlidingWindowSplitter(n_splits=3, test_size=30),
+            ExpandingWindowSplitter(n_splits=2, test_size=20),
+            outer_fold=-1,
+        )
+        assert_figure_valid(fig)
+
+    def test_invalid_outer_fold_index(self, sample_y):
+        """An out-of-range integer outer_fold raises ValueError."""
+        with pytest.raises(ValueError, match="out of range"):
+            plot_nested_splits(
+                sample_y,
+                ExpandingWindowSplitter(n_splits=3, test_size=30),
+                ExpandingWindowSplitter(n_splits=2, test_size=20),
+                outer_fold=99,
+            )
+
+    def test_invalid_splitter_type(self, sample_y):
+        """A non-BaseSplitter argument raises TypeError naming the argument."""
+        with pytest.raises(TypeError, match="inner_splitter"):
+            plot_nested_splits(
+                sample_y,
+                ExpandingWindowSplitter(n_splits=3, test_size=30),
+                "not_a_splitter",
+            )
 
 
 class TestPlotCvResultsScatter:


### PR DESCRIPTION
## Description

Adds `plot_nested_splits`, a sibling of `plot_splits`, that visualizes a **nested cross-validation**: the inner CV folds carved from one outer fold's training window, plus that outer fold's test window drawn as a held-out segment the inner splitter never sees. It supports a single-fold zoom (`outer_fold=int`, default the last fold) and a faceted view across all outer folds (`outer_fold="all"`). The figure is generated from the real splitters, so it is faithful to actual splitting behavior rather than hand-drawn.

The per-fold train/test drawing is refactored out of `plot_splits` into shared `_add_segment` / `_add_split_row` helpers (`plot_splits`'s public behavior is unchanged), and `train_name` / `test_name` parameters are added so callers no longer need to rename traces after building the figure.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Downstream projects (e.g. EvoltaForecast docs) hand-roll the nested-CV figure by slicing an outer fold, calling `plot_splits` on it, and patching in a held-out row. This belongs in yohou as a first-class, tested, correct visualization. The faceted mode also makes the full nested procedure (one inner CV per outer fold) clear in a single figure.

Fixes #

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

- `plot_splits` is refactored internally only; its parameters, trace count, legend groups, and default "Train"/"Test" labels are unchanged (verified by the existing tests passing without modification).
- Correct for non-prefix outer training sets (e.g. `SlidingWindowSplitter` as the outer splitter); the faceted path de-duplicates legend entries via `LegendTracker`.
- New tests: `TestPlotNestedSplits` (single-fold, faceted, custom colors/names, held-out row, sliding-window outer, invalid index, invalid splitter) plus `plot_splits` naming tests. 40 passed (incl. doctests); ruff, ty, interrogate, and rumdl all clean.
