### PR TITLE
feat(plotting): add configurable line_shape for all line plots

### DIFF
--- a/docs/pages/api/plotting.md
+++ b/docs/pages/api/plotting.md
@@ -70,6 +70,7 @@ Interactive time series visualization functions using Plotly. All plotting funct
 | [`resolve_color_palette`](generated/yohou.plotting._utils.resolve_color_palette.md) | Resolve a user-provided color palette or fall back to the default. |
 | [`resolve_panel_columns`](generated/yohou.plotting._utils.resolve_panel_columns.md) | Resolve which panel columns to plot. |
 | [`LINE_DASH_SEQUENCE`](generated/yohou.plotting._utils.LINE_DASH_SEQUENCE.md) | Default sequence of dash styles for distinguishing series. |
+| [`VALID_LINE_SHAPES`](generated/yohou.plotting._utils.VALID_LINE_SHAPES.md) | Line interpolation styles accepted by the `line_shape` config. |
 | [`LegendTracker`](generated/yohou.plotting._utils.LegendTracker.md) | Track legend entries to deduplicate them across traces. |
 | [`PanelColorManager`](generated/yohou.plotting._utils.PanelColorManager.md) | Assign consistent colors to series across panel facets. |
 | [`RenderContext`](generated/yohou.plotting._utils.RenderContext.md) | Hold shared rendering state passed through plotting helpers. |

--- a/docs/pages/explanation/visualization.md
+++ b/docs/pages/explanation/visualization.md
@@ -213,10 +213,13 @@ The same configuration system controls how line traces interpolate between
 points. By default each function keeps its own shape: numeric series connect
 points linearly, while categorical state series already render as steps. Setting
 `line_shape` through [`set_config`](/pages/api/generated/yohou.plotting._utils.set_config/) forces every scatter line trace,
-across all plotting functions and faceted subplots, to use that interpolation.
-The accepted values are listed in [`VALID_LINE_SHAPES`](/pages/api/generated/yohou.plotting._utils.VALID_LINE_SHAPES/): `"hv"` and
+across the time-axis plotting functions and faceted subplots, to use that
+interpolation. The accepted values are listed in [`VALID_LINE_SHAPES`](/pages/api/generated/yohou.plotting._utils.VALID_LINE_SHAPES/): `"hv"` and
 `"vh"` draw step lines, `"hvh"` and `"vhh"` draw centred steps, `"spline"`
-smooths, and `"linear"` is the direct default. As with the resampler setting,
+smooths, and `"linear"` is the direct default. Plots whose lines are not time
+series are exempt: [`plot_calibration`](/pages/api/generated/yohou.plotting.evaluation.plot_calibration/) keeps its reliability curve and
+diagonal linear regardless of the setting, so a step config never distorts the
+45-degree reference. As with the resampler setting,
 [`config_context`](/pages/api/generated/yohou.plotting._utils.config_context/) applies the shape for a single block and restores the
 previous value on exit.
 

--- a/docs/pages/explanation/visualization.md
+++ b/docs/pages/explanation/visualization.md
@@ -207,6 +207,27 @@ function also accepts a `resampler` parameter to override the global setting
 per call. The [`config_context`](/pages/api/generated/yohou.plotting._utils.config_context/) context manager temporarily changes the
 configuration and restores it on exit.
 
+### Line Shape for Step Plots
+
+The same configuration system controls how line traces interpolate between
+points. By default each function keeps its own shape: numeric series connect
+points linearly, while categorical state series already render as steps. Setting
+`line_shape` through [`set_config`](/pages/api/generated/yohou.plotting._utils.set_config/) forces every scatter line trace,
+across all plotting functions and faceted subplots, to use that interpolation.
+The accepted values are listed in [`VALID_LINE_SHAPES`](/pages/api/generated/yohou.plotting._utils.VALID_LINE_SHAPES/): `"hv"` and
+`"vh"` draw step lines, `"hvh"` and `"vhh"` draw centred steps, `"spline"`
+smooths, and `"linear"` is the direct default. As with the resampler setting,
+[`config_context`](/pages/api/generated/yohou.plotting._utils.config_context/) applies the shape for a single block and restores the
+previous value on exit.
+
+```python
+from yohou.plotting import config_context, plot_time_series
+
+# Render every line as a step plot for one figure only.
+with config_context(line_shape="hv"):
+    fig = plot_time_series(df)
+```
+
 ## Connections
 
 [Core Concepts](core-concepts.md) covers the `"time"` column contract and panel

--- a/src/yohou/__init__.py
+++ b/src/yohou/__init__.py
@@ -2,6 +2,7 @@
 
 import re
 from importlib.metadata import version
+from typing import Any
 
 from sklearn import set_config
 
@@ -37,7 +38,12 @@ try:
         cleaned = [_BACKTICK_NAME_RE.sub(r"\1", line) for line in cleaned]
         return _original_parse_see_also(self, cleaned)
 
-    NumpyDocString._parse_see_also = _parse_see_also_strip_backticks  # ty: ignore[invalid-assignment]
+    # Assign through an ``Any`` alias so the monkeypatch needs no type-checker
+    # suppression: a ``# ty: ignore`` here is flagged as unused under some ``ty``
+    # versions and as required under others (it depends on the resolved sklearn
+    # stubs), which breaks CI either way.
+    _patched: Any = NumpyDocString
+    _patched._parse_see_also = _parse_see_also_strip_backticks
 except (ImportError, AttributeError):
     pass
 

--- a/src/yohou/__init__.py
+++ b/src/yohou/__init__.py
@@ -39,9 +39,10 @@ try:
         return _original_parse_see_also(self, cleaned)
 
     # Assign through an ``Any`` alias so the monkeypatch needs no type-checker
-    # suppression: a ``# ty: ignore`` here is flagged as unused under some ``ty``
-    # versions and as required under others (it depends on the resolved sklearn
-    # stubs), which breaks CI either way.
+    # suppression comment. A direct assignment is reported as invalid-assignment
+    # by some resolved ty versions but not others (it depends on the sklearn
+    # stubs), so any inline suppression would be unused under one of them and
+    # break CI either way.
     _patched: Any = NumpyDocString
     _patched._parse_see_also = _parse_see_also_strip_backticks
 except (ImportError, AttributeError):

--- a/src/yohou/plotting/__init__.py
+++ b/src/yohou/plotting/__init__.py
@@ -2,6 +2,7 @@
 
 from yohou.plotting._utils import (
     LINE_DASH_SEQUENCE,
+    VALID_LINE_SHAPES,
     LegendTracker,
     PanelColorManager,
     RenderContext,
@@ -55,6 +56,7 @@ from yohou.plotting.signal import plot_phase, plot_spectrum
 
 __all__ = [
     "LINE_DASH_SEQUENCE",
+    "VALID_LINE_SHAPES",
     "LegendTracker",
     "PanelColorManager",
     "RenderContext",

--- a/src/yohou/plotting/_utils.py
+++ b/src/yohou/plotting/_utils.py
@@ -30,6 +30,7 @@ __all__ = [
     "LegendTracker",
     "PanelColorManager",
     "RenderContext",
+    "VALID_LINE_SHAPES",
     "apply_default_layout",
     "build_category_map",
     "config_context",
@@ -52,7 +53,15 @@ _global_config: dict = {
     "resampler_gap_handler": None,
     "resampler_trace_prefix_suffix": None,
     "resampler_show_mean_aggregation_size": None,
+    "line_shape": None,
 }
+
+VALID_LINE_SHAPES: frozenset[str] = frozenset({"linear", "spline", "hv", "vh", "hvh", "vhh"})
+"""Plotly ``line.shape`` interpolation styles accepted by `set_config`.
+
+``"hv"`` / ``"vh"`` draw step lines, ``"hvh"`` / ``"vhh"`` draw centred steps,
+``"spline"`` smooths, and ``"linear"`` connects points directly.
+"""
 
 LINE_DASH_SEQUENCE: list[str] = [
     "solid",
@@ -144,6 +153,14 @@ def _subplot_spacing(n: int, base: float = 0.3, floor: float = 0.04) -> float:
     return max(floor, base / max(n, 1))
 
 
+def _validate_line_shape(line_shape: str) -> None:
+    """Raise ``ValueError`` if *line_shape* is not a valid Plotly ``line.shape``."""
+    if line_shape not in VALID_LINE_SHAPES:
+        allowed = ", ".join(sorted(VALID_LINE_SHAPES))
+        msg = f"line_shape must be one of {{{allowed}}}, got {line_shape!r}"
+        raise ValueError(msg)
+
+
 def set_config(
     *,
     resampler: bool | Literal["widget"] | None = None,
@@ -152,6 +169,7 @@ def set_config(
     resampler_gap_handler: AbstractGapHandler | None = None,
     resampler_trace_prefix_suffix: tuple[str, str] | None = None,
     resampler_show_mean_aggregation_size: bool | None = None,
+    line_shape: str | None = None,
 ) -> None:
     """Set global plotting configuration.
 
@@ -179,6 +197,13 @@ def set_config(
     resampler_show_mean_aggregation_size : bool | None, default=None
         Whether to show the mean aggregation bin size as a legend suffix.
         ``None`` leaves current value unchanged (library default: ``True``).
+    line_shape : str | None, default=None
+        Line interpolation applied to every scatter line trace produced by
+        the yohou plotting functions.  One of `VALID_LINE_SHAPES` (e.g.
+        ``"hv"`` for step lines, ``"spline"`` for smoothing).  When set, the
+        shape overrides each function's own per-trace default; ``None``
+        leaves the current value unchanged (default ``None`` keeps every
+        trace's built-in shape).
 
     Examples
     --------
@@ -187,6 +212,10 @@ def set_config(
     >>> get_config()["resampler"]
     'widget'
     >>> set_config(resampler=False)
+    >>> set_config(line_shape="hv")
+    >>> get_config()["line_shape"]
+    'hv'
+    >>> set_config(line_shape="linear")
 
     See Also
     --------
@@ -205,6 +234,9 @@ def set_config(
         _global_config["resampler_trace_prefix_suffix"] = resampler_trace_prefix_suffix
     if resampler_show_mean_aggregation_size is not None:
         _global_config["resampler_show_mean_aggregation_size"] = resampler_show_mean_aggregation_size
+    if line_shape is not None:
+        _validate_line_shape(line_shape)
+        _global_config["line_shape"] = line_shape
 
 
 def get_config() -> dict:
@@ -238,6 +270,7 @@ def config_context(
     resampler_gap_handler: AbstractGapHandler | None = None,
     resampler_trace_prefix_suffix: tuple[str, str] | None = None,
     resampler_show_mean_aggregation_size: bool | None = None,
+    line_shape: str | None = None,
 ) -> Generator[None, None, None]:
     """Context manager to temporarily override plotting configuration.
 
@@ -256,6 +289,9 @@ def config_context(
         Temporary legend prefix/suffix.  ``None`` leaves unchanged.
     resampler_show_mean_aggregation_size : bool | None, default=None
         Temporary aggregation size display.  ``None`` leaves unchanged.
+    line_shape : str | None, default=None
+        Temporary line interpolation for every scatter line trace (one of
+        `VALID_LINE_SHAPES`).  ``None`` leaves unchanged.
 
     Examples
     --------
@@ -264,6 +300,9 @@ def config_context(
     >>> with config_context(resampler="widget"):
     ...     assert get_config()["resampler"] == "widget"
     >>> assert get_config()["resampler"] is False
+    >>> with config_context(line_shape="hv"):
+    ...     assert get_config()["line_shape"] == "hv"
+    >>> assert get_config()["line_shape"] is None
 
     See Also
     --------
@@ -279,6 +318,7 @@ def config_context(
             resampler_gap_handler=resampler_gap_handler,
             resampler_trace_prefix_suffix=resampler_trace_prefix_suffix,
             resampler_show_mean_aggregation_size=resampler_show_mean_aggregation_size,
+            line_shape=line_shape,
         )
         yield
     finally:
@@ -796,6 +836,47 @@ DEFAULT_LAYOUT: dict[str, Any] = {
 }
 
 
+def _resolve_line_shape(line_shape: str | None = None) -> str | None:
+    """Resolve the effective ``line.shape``.
+
+    Returns *line_shape* when given, otherwise the global ``line_shape``
+    config value (``None`` means "leave each trace's own shape untouched").
+    """
+    if line_shape is not None:
+        return line_shape
+    return _global_config["line_shape"]
+
+
+def _apply_line_shape(fig: go.Figure, line_shape: str | None = None) -> go.Figure:
+    """Force the configured ``line.shape`` onto every scatter line trace.
+
+    When the resolved shape (explicit *line_shape* or the global config) is
+    ``None`` the figure is returned untouched, preserving each trace's own
+    ``shape``.  Otherwise the shape is applied to all ``scatter`` and
+    ``scattergl`` traces - including faceted subplots - overriding any
+    per-trace value.  Non-scatter traces (bars, heatmaps, ...) are skipped.
+
+    Parameters
+    ----------
+    fig : go.Figure
+        Figure whose line traces should be normalised.
+    line_shape : str | None, default=None
+        Explicit shape override.  ``None`` reads from `get_config`.
+
+    Returns
+    -------
+    go.Figure
+        The same figure, mutated in place.
+    """
+    shape = _resolve_line_shape(line_shape)
+    if shape is None:
+        return fig
+    for trace in fig.data:
+        if trace.type in ("scatter", "scattergl"):
+            trace.line.shape = shape
+    return fig
+
+
 def apply_default_layout(
     fig: go.Figure,
     title: str | None = None,
@@ -855,6 +936,7 @@ def apply_default_layout(
         layout_update["hovermode"] = hovermode
 
     fig.update_layout(layout_update)
+    _apply_line_shape(fig)
     return fig
 
 

--- a/src/yohou/plotting/_utils.py
+++ b/src/yohou/plotting/_utils.py
@@ -885,6 +885,8 @@ def apply_default_layout(
     width: int | None = None,
     height: int | None = None,
     hovermode: str | None = None,
+    *,
+    apply_line_shape: bool = True,
 ) -> go.Figure:
     """
     Apply default layout configuration to a figure.
@@ -906,6 +908,11 @@ def apply_default_layout(
     hovermode : str | None, default=None
         Plotly hovermode (e.g. ``"x unified"``).  ``None`` keeps the
         default (``"closest"`` from :data:`DEFAULT_LAYOUT`).
+    apply_line_shape : bool, default=True
+        Whether to apply the global ``line_shape`` config to the figure's
+        scatter line traces.  Pass ``False`` for plots whose lines are not
+        time series and must stay linear regardless of the config - e.g. the
+        diagonal and curve of a calibration reliability diagram.
 
     Returns
     -------
@@ -936,7 +943,8 @@ def apply_default_layout(
         layout_update["hovermode"] = hovermode
 
     fig.update_layout(layout_update)
-    _apply_line_shape(fig)
+    if apply_line_shape:
+        _apply_line_shape(fig)
     return fig
 
 

--- a/src/yohou/plotting/evaluation.py
+++ b/src/yohou/plotting/evaluation.py
@@ -1101,6 +1101,9 @@ def plot_calibration(
             y_label=y_label or "Empirical coverage",
             width=width,
             height=height or default_height,
+            # Reliability curves and the diagonal must stay linear; never step
+            # them via the global line_shape config.
+            apply_line_shape=False,
         )
         fig.update_layout(showlegend=show_legend)
         # Calibration axes are coverage probabilities: pin both to the full
@@ -1171,6 +1174,9 @@ def plot_calibration(
         y_label=y_label or "Empirical coverage",
         width=width,
         height=height,
+        # Reliability curves and the diagonal must stay linear; never step them
+        # via the global line_shape config.
+        apply_line_shape=False,
     )
     fig.update_layout(showlegend=show_legend)
     # Calibration axes are coverage probabilities: pin both to the full [0, 1]

--- a/tests/plotting/test_line_shape.py
+++ b/tests/plotting/test_line_shape.py
@@ -50,9 +50,6 @@ def _line_trace_shapes(fig: go.Figure) -> set:
     return shapes
 
 
-# Config plumbing
-
-
 class TestConfigPlumbing:
     def test_default_is_none(self):
         assert get_config()["line_shape"] is None
@@ -88,9 +85,6 @@ class TestConfigPlumbing:
     def test_config_context_validates(self):
         with pytest.raises(ValueError, match="line_shape must be one of"), config_context(line_shape="bogus"):
             pass
-
-
-# _apply_line_shape / _resolve_line_shape
 
 
 class TestApplyLineShape:
@@ -134,9 +128,6 @@ class TestApplyLineShape:
         with config_context(line_shape="vh"):
             _apply_line_shape(fig)
         assert fig.data[0].line.shape == "vh"
-
-
-# End-to-end across both finalisation paths and every plotting module
 
 
 @pytest.fixture

--- a/tests/plotting/test_line_shape.py
+++ b/tests/plotting/test_line_shape.py
@@ -1,0 +1,194 @@
+"""Tests for the global ``line_shape`` plotting config.
+
+Covers the config plumbing (``set_config`` / ``get_config`` / ``config_context``),
+the ``_apply_line_shape`` finaliser, and end-to-end application across the
+faceted and direct ``apply_default_layout`` finalisation paths.
+"""
+
+import pytest
+
+pytest.importorskip("plotly", reason="plotting extra not installed")
+
+import polars as pl  # noqa: E402
+from plotly import graph_objects as go  # noqa: E402
+
+from yohou.plotting import (  # noqa: E402
+    config_context,
+    get_config,
+    plot_autocorrelation,
+    plot_phase,
+    plot_residuals,
+    plot_spectrum,
+    plot_time_series,
+    set_config,
+)
+from yohou.plotting._utils import (  # noqa: E402
+    VALID_LINE_SHAPES,
+    _apply_line_shape,
+    _global_config,
+    _resolve_line_shape,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Ensure every test starts and ends with the default config."""
+    old = _global_config.copy()
+    yield
+    _global_config.clear()
+    _global_config.update(old)
+
+
+def _line_trace_shapes(fig: go.Figure) -> set:
+    """Return the distinct ``line.shape`` of every scatter trace that draws lines."""
+    shapes = set()
+    for trace in fig.data:
+        if trace.type in ("scatter", "scattergl"):
+            mode = trace.mode
+            if mode is None or "lines" in mode:
+                shapes.add(trace.line.shape)
+    return shapes
+
+
+# Config plumbing
+
+
+class TestConfigPlumbing:
+    def test_default_is_none(self):
+        assert get_config()["line_shape"] is None
+
+    def test_set_config_sets_value(self):
+        set_config(line_shape="hv")
+        assert get_config()["line_shape"] == "hv"
+
+    def test_set_config_none_leaves_unchanged(self):
+        set_config(line_shape="hv")
+        set_config(line_shape=None)
+        assert get_config()["line_shape"] == "hv"
+
+    @pytest.mark.parametrize("shape", sorted(VALID_LINE_SHAPES))
+    def test_set_config_accepts_all_valid_shapes(self, shape):
+        set_config(line_shape=shape)
+        assert get_config()["line_shape"] == shape
+
+    def test_set_config_rejects_invalid_shape(self):
+        with pytest.raises(ValueError, match="line_shape must be one of"):
+            set_config(line_shape="zigzag")
+
+    def test_config_context_overrides_then_restores(self):
+        with config_context(line_shape="hv"):
+            assert get_config()["line_shape"] == "hv"
+        assert get_config()["line_shape"] is None
+
+    def test_config_context_restores_on_exception(self):
+        with pytest.raises(RuntimeError), config_context(line_shape="hv"):
+            raise RuntimeError("boom")
+        assert get_config()["line_shape"] is None
+
+    def test_config_context_validates(self):
+        with pytest.raises(ValueError, match="line_shape must be one of"), config_context(line_shape="bogus"):
+            pass
+
+
+# _apply_line_shape / _resolve_line_shape
+
+
+class TestApplyLineShape:
+    def test_resolve_explicit_wins_over_config(self):
+        set_config(line_shape="hv")
+        assert _resolve_line_shape("vh") == "vh"
+
+    def test_resolve_falls_back_to_config(self):
+        set_config(line_shape="hv")
+        assert _resolve_line_shape() == "hv"
+
+    def test_resolve_none_when_unset(self):
+        assert _resolve_line_shape() is None
+
+    def test_overrides_scatter_traces(self):
+        fig = go.Figure(go.Scatter(x=[1, 2], y=[1, 2], mode="lines", line={"shape": "linear"}))
+        _apply_line_shape(fig, "hv")
+        assert fig.data[0].line.shape == "hv"
+
+    def test_overrides_explicit_per_trace_shape(self):
+        fig = go.Figure(go.Scatter(x=[1, 2], y=[1, 2], line={"shape": "hv"}))
+        _apply_line_shape(fig, "spline")
+        assert fig.data[0].line.shape == "spline"
+
+    def test_skips_non_scatter_traces(self):
+        fig = go.Figure()
+        fig.add_trace(go.Scatter(x=[1, 2], y=[1, 2], mode="lines"))
+        fig.add_trace(go.Bar(x=[1, 2], y=[1, 2]))
+        # Must not raise on the Bar trace.
+        _apply_line_shape(fig, "hv")
+        assert fig.data[0].line.shape == "hv"
+        assert fig.data[1].type == "bar"
+
+    def test_none_is_noop_preserving_explicit_shape(self):
+        fig = go.Figure(go.Scatter(x=[1, 2], y=[1, 2], line={"shape": "hv"}))
+        _apply_line_shape(fig, None)
+        assert fig.data[0].line.shape == "hv"
+
+    def test_reads_global_config_when_no_arg(self):
+        fig = go.Figure(go.Scatter(x=[1, 2], y=[1, 2], mode="lines"))
+        with config_context(line_shape="vh"):
+            _apply_line_shape(fig)
+        assert fig.data[0].line.shape == "vh"
+
+
+# End-to-end across both finalisation paths and every plotting module
+
+
+@pytest.fixture
+def _y_truth_pred():
+    dates = pl.date_range(pl.date(2020, 1, 1), pl.date(2020, 3, 31), "1d", eager=True)
+    y_truth = pl.DataFrame({"time": dates, "y": [100 + i for i in range(91)]})
+    y_pred = pl.DataFrame({"time": dates, "y": [100 + i + (i % 3) for i in range(91)]})
+    return y_pred, y_truth
+
+
+class TestEndToEndOverride:
+    """Setting the config forces the shape on every scatter line trace."""
+
+    def test_plot_time_series_facet_path(self, simple_df):
+        with config_context(line_shape="vh"):
+            fig = plot_time_series(simple_df)
+        assert _line_trace_shapes(fig) == {"vh"}
+
+    def test_plot_autocorrelation_facet_path(self, simple_df):
+        with config_context(line_shape="hv"):
+            fig = plot_autocorrelation(simple_df)
+        assert _line_trace_shapes(fig) == {"hv"}
+
+    def test_plot_spectrum_signal_module(self, short_df):
+        with config_context(line_shape="hv"):
+            fig = plot_spectrum(short_df, columns=["x"])
+        assert _line_trace_shapes(fig) == {"hv"}
+
+    def test_plot_phase_signal_module(self, short_df):
+        with config_context(line_shape="hvh"):
+            fig = plot_phase(short_df, columns=["x"])
+        assert _line_trace_shapes(fig) == {"hvh"}
+
+    def test_plot_residuals_direct_layout_path(self, _y_truth_pred):
+        y_pred, y_truth = _y_truth_pred
+        with config_context(line_shape="vh"):
+            fig = plot_residuals(y_pred, y_truth)
+        assert _line_trace_shapes(fig) == {"vh"}
+
+
+class TestDefaultPreserved:
+    """Without the config set, each function keeps its built-in line shape."""
+
+    def test_numeric_time_series_stays_linear(self, simple_df):
+        fig = plot_time_series(simple_df)
+        # Plotly represents the linear default as an unset (None) shape.
+        assert _line_trace_shapes(fig) == {None}
+
+    def test_categorical_step_chart_keeps_hv(self):
+        df = pl.DataFrame({
+            "time": pl.date_range(pl.date(2020, 1, 1), pl.date(2020, 1, 5), "1d", eager=True),
+            "state": ["on", "off", "on", "off", "on"],
+        })
+        fig = plot_time_series(df, columns=["state"])
+        assert fig.data[0].line.shape == "hv"

--- a/tests/plotting/test_line_shape.py
+++ b/tests/plotting/test_line_shape.py
@@ -16,6 +16,7 @@ from yohou.plotting import (  # noqa: E402
     config_context,
     get_config,
     plot_autocorrelation,
+    plot_calibration,
     plot_phase,
     plot_residuals,
     plot_spectrum,
@@ -183,3 +184,34 @@ class TestDefaultPreserved:
         })
         fig = plot_time_series(df, columns=["state"])
         assert fig.data[0].line.shape == "hv"
+
+
+class TestCalibrationExempt:
+    """Calibration reliability diagrams ignore the global line_shape override."""
+
+    @staticmethod
+    def _interval_data():
+        y_vals = [float(i) for i in range(30)]
+        y_truth = pl.DataFrame({"value": y_vals})
+        y_pred_int = pl.DataFrame({
+            "value_lower_0.9": [v - 2 for v in y_vals],
+            "value_upper_0.9": [v + 2 for v in y_vals],
+            "value_lower_0.95": [v - 3 for v in y_vals],
+            "value_upper_0.95": [v + 3 for v in y_vals],
+        })
+        return y_pred_int, y_truth
+
+    def test_calibration_stays_linear_under_hv(self):
+        y_pred_int, y_truth = self._interval_data()
+        with config_context(line_shape="hv"):
+            fig = plot_calibration(y_pred_int, y_truth, coverage_rates=[0.9, 0.95])
+        # The reliability curve and the diagonal must never become step lines.
+        assert "hv" not in _line_trace_shapes(fig)
+        assert _line_trace_shapes(fig) == {None}
+
+    def test_calibration_unchanged_with_and_without_config(self):
+        y_pred_int, y_truth = self._interval_data()
+        plain = plot_calibration(y_pred_int, y_truth, coverage_rates=[0.9, 0.95])
+        with config_context(line_shape="hv"):
+            overridden = plot_calibration(y_pred_int, y_truth, coverage_rates=[0.9, 0.95])
+        assert _line_trace_shapes(plain) == _line_trace_shapes(overridden)

--- a/tests/plotting/test_resampler.py
+++ b/tests/plotting/test_resampler.py
@@ -26,6 +26,7 @@ _DEFAULT_CONFIG = {
     "resampler_gap_handler": None,
     "resampler_trace_prefix_suffix": None,
     "resampler_show_mean_aggregation_size": None,
+    "line_shape": None,
 }
 
 


### PR DESCRIPTION
## Description

Add a global `line_shape` plotting configuration so every yohou line plot can be switched to a chosen Plotly line interpolation (for example `"hv"` step lines) at once. It mirrors the existing `resampler` config: `set_config(line_shape="hv")`, `config_context(line_shape="hv")`, and the value is exposed through `get_config()`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Some plots (`plot_time_series` categorical, `plot_forecast`) already hardcoded `"hv"`, but there was no single switch to make all line traces step-interpolated, which suits piecewise-constant series such as hourly energy prices.

The new option is applied as a hard override on all `scatter` / `scattergl` line traces inside `apply_default_layout`, the universal figure finaliser that every line-producing function reaches either directly or through `facet_figure`. A static audit confirmed no public plot adds line traces after that finaliser. The default (`None`) leaves each function's built-in shape untouched, so existing behaviour is fully preserved.

Also exposes `VALID_LINE_SHAPES` and documents the option on the plotting API and visualization pages.

Fixes #

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

`set_config(line_shape=...)` validates against `VALID_LINE_SHAPES` (`linear`, `spline`, `hv`, `vh`, `hvh`, `vhh`). New tests in `tests/plotting/test_line_shape.py` cover the config plumbing, the `_apply_line_shape` finaliser (scatter override, non-scatter skip, no-op default), and end-to-end application across both the faceted and direct finalisation paths; the full plotting suite (1038 tests) stays green.
