### PR TITLE
feat(exogenous): guard X_future step expansion and fix routing docs

### DIFF
--- a/docs/pages/explanation/core-concepts.md
+++ b/docs/pages/explanation/core-concepts.md
@@ -41,9 +41,11 @@ leakage by separating features according to their temporal availability:
 - **`X_actual`**: observation features that are only available for past timestamps (e.g.
   sensor readings, realized demand). These flow through the `feature_transformer` pipeline
   and are never available at `predict` time because the future has not happened yet.
-- **`X_future`**: known-future features whose values are deterministic for any date, past
-  or future (e.g. holiday calendars, day-of-week indicators). These bypass the
-  `feature_transformer` and are converted to step-indexed columns.
+- **`X_future`**: known-future features whose value at a future timestamp cannot be
+  derived from the observation point and so needs an external table (e.g. holiday
+  calendars, promotion schedules). These bypass the `feature_transformer` and are
+  converted to step-indexed columns. Features computable from the timestamp alone
+  (Fourier terms, day-of-week) belong in a `feature_transformer` instead.
 - **`X_forecast`**: predictions from external models, each issued at a specific vintage
   time (e.g. weather forecasts, demand projections). These also bypass the
   `feature_transformer` and require a `"vintage_time"` column.

--- a/docs/pages/explanation/exogenous-features.md
+++ b/docs/pages/explanation/exogenous-features.md
@@ -31,16 +31,68 @@ automatically at predict time.
 
 ### X_future: Known-Future Features
 
-Deterministic values available for any date, past or future. Holiday
-calendars, day-of-week indicators, scheduled auction prices, planned
-maintenance windows. Looking up whether December 25th is a holiday gives the
-same answer whether you check in January or November.
+Values you can look up for a future timestamp but cannot derive from the
+observation point. Holiday calendars, scheduled auction prices, planned
+maintenance windows, announced promotions. Looking up whether December 25th is
+a holiday gives the same answer whether you check in January or November, but
+no amount of inspecting today's date tells you when Easter falls next year.
+That takes a calendar.
 
 `X_future` bypasses the `feature_transformer` entirely. Instead, the framework
 windows it forward from each observation point to produce *step-indexed*
 columns (`is_holiday_step_1`, `is_holiday_step_2`, ..., `is_holiday_step_H`).
 Each step column tells the estimator what the holiday status will be at that
 specific forecast horizon.
+
+#### What Belongs Here
+
+`feature_transformer` only ever runs on the observation frame, which stops at
+the observation point `T`. It can compute a feature for `T`, for `T-1`, for any
+timestamp already observed, and for none beyond. That single fact decides the
+channel:
+
+> Does the feature's value at `T` determine its value at `T+h`?
+
+If it does, `feature_transformer` already suffices and `X_future` is the wrong
+home. A Fourier pair is the clearest case: `sin(2*pi*(t+h)/S)` is a fixed linear
+combination of the sine and cosine at `t`, so once the estimator sees the pair
+at `T` it can express the value at every horizon. Windowing it forward across
+`H` steps adds columns without adding information, and those columns are exactly
+collinear with the pair the model already had.
+
+If it does not, nothing computed at `T` can stand in, and the forward window is
+the only way to put the value in front of the estimator. Whether next Tuesday is
+a public holiday is not a function of anything measurable today. It is a lookup.
+
+The same test, in the form you can apply while writing the `fit()` call: **can
+you compute it from the timestamp alone, or do you need an external table?** A
+timestamp alone means a *clock feature*, which belongs in `feature_transformer`
+(see [`FourierFeatureTransformer`](/pages/api/generated/yohou.preprocessing.time_features.FourierFeatureTransformer/)
+and [`CalendarFeatureTransformer`](/pages/api/generated/yohou.preprocessing.calendar.CalendarFeatureTransformer/)).
+An external table means an *event feature*, which belongs in `X_future`.
+
+Note that "deterministic and knowable in advance" does not separate the two. A
+day-of-week indicator and a holiday calendar are both perfectly deterministic
+and both knowable for any future date, yet they belong in different channels.
+Determinism is not the question; derivability from `T` is.
+
+#### Holidays Sit On Both Sides
+
+Holidays deserve a note, because they can legitimately appear on either channel
+and the two uses are complementary rather than competing.
+
+[`HolidayFeatureTransformer`](/pages/api/generated/yohou.preprocessing.calendar.HolidayFeatureTransformer/)
+on `X_actual` gives *past* holiday effects: whether recently observed timestamps
+were holidays, which is what you want when demand rebounds the day after a
+closure. It runs on the observation frame, so it cannot say anything about a
+holiday next week.
+
+A holiday calendar passed through `X_future` gives *future* holiday effects:
+whether each forecast step lands on a holiday, which is what you want when the
+holiday itself moves demand.
+
+Reaching for one does not rule out the other. A model that needs both the
+closure and the rebound uses both.
 
 ### X_forecast: External Forecasts
 
@@ -154,6 +206,26 @@ For an electricity pricing use case, `step_feature_alignment="matched"` means
 estimator $h$ trains on `(wind_step_h, price_step_h)`: the weather forecast
 for time $T+h$ predicting the price at $T+h$. This avoids cross-horizon
 information that could confuse simpler estimators.
+
+### Why Only Direct
+
+The parameter applies to `"direct"` alone. Setting it on another strategy
+warns at fit and changes nothing, but the two exclusions are not the same kind
+of thing.
+
+`"multi-output"` *cannot* filter. One estimator predicts every horizon from a
+single feature vector, and output $h$ reads `wind_step_h` from that same
+vector, so every step column has to be present for some output. There is no
+per-estimator view to narrow, because there is only one estimator. Since
+`"multi-output"` is the default, this is the case most users are in.
+
+`"dir-rec"` *could* filter. It fits $H$ estimators, one per step, exactly as
+`"direct"` does, and a per-step column filter applied before each step's
+feature augmentation would be well defined. It does not, and that is a
+deliberate scope decision rather than a structural limit: combining a filtered
+base with the accumulating augmentation columns raises design questions that
+have not been worked through. Recording it here is what stops the exclusion
+from being read as an oversight.
 
 ## Predict-Time Override (Column Swap)
 

--- a/docs/pages/how-to/exogenous-features.md
+++ b/docs/pages/how-to/exogenous-features.md
@@ -22,12 +22,51 @@ the full conceptual model.
 | Question | Yes | No |
 |---|---|---|
 | Is it a measurement that can only be known after it happens? | `X_actual` | Continue |
-| Is it deterministic and known for any future date? | `X_future` | Continue |
-| Does it come from an external model with an issuance time? | `X_forecast` | N/A |
+| Can you compute it from the timestamp alone, with no external table? | `feature_transformer` | Continue |
+| Does it come from an external model with an issuance time? | `X_forecast` | `X_future` |
+
+The second question is the one that catches people. Day-of-week, hour of day,
+and Fourier terms are all deterministic and all knowable for any future date,
+which makes `X_future` look like the answer. It is not. Their value at the
+observation point already determines their value at every horizon, so
+`feature_transformer` hands the estimator the same information in a fraction of
+the columns. Ask whether you need a *lookup table*, not whether the value is
+*knowable*: a holiday calendar needs one, a day-of-week indicator does not.
 
 If a feature is uncertain but has no vintage (a single "best guess"),
 treat it as `X_future`. If you need multiple versions of that guess at
 predict time, wrap it with a `vintage_time` column and use `X_forecast`.
+
+### Clock Features Versus Event Features
+
+Both of these are calendar-related. Only one of them needs `X_future`.
+
+```python
+from yohou.compose import FeatureUnion
+from yohou.point import PointReductionForecaster
+from yohou.preprocessing import FourierFeatureTransformer, LagTransformer
+
+forecaster = PointReductionForecaster(
+    # Clock feature: weekly seasonality on hourly data. Computable from the
+    # timestamp, so it belongs here and never touches X_future.
+    feature_transformer=FeatureUnion([
+        ("lags", LagTransformer([1, 2, 3])),
+        ("weekly", FourierFeatureTransformer(seasonality=168.0, harmonics=[1, 2])),
+    ]),
+)
+
+forecaster.fit(
+    y=y_train,
+    forecasting_horizon=24,
+    # Event feature: not derivable from the timestamp, so it is windowed
+    # forward into is_holiday_step_1 .. is_holiday_step_24.
+    X_future=holiday_calendar,
+)
+```
+
+Routing that Fourier block through `X_future` instead would window its four
+columns into 96 step columns spanning the same four dimensions, and leave the
+model's predictions unchanged.
 
 ## Pass Exogenous Features to a Forecaster
 
@@ -52,7 +91,7 @@ forecaster.fit(
     y=y_train,
     X_actual=temperature,       # observation features (lagged internally)
     forecasting_horizon=24,
-    X_future=holidays,          # deterministic, known ahead
+    X_future=holidays,          # event calendar, needs a lookup table
     X_forecast=weather_forecast, # vintage-indexed external predictions
 )
 

--- a/docs/pages/reference/data-catalog.md
+++ b/docs/pages/reference/data-catalog.md
@@ -358,10 +358,10 @@ Returns a `Bunch` with:
 |---|---|
 | `y` | `pl.DataFrame` with `time` and `air_quality` (Utf8: `"good"`, `"moderate"`, `"poor"`) |
 | `X_actual` | `pl.DataFrame` with `time` and `pollutant` (Float64) |
-| `X_future` | `pl.DataFrame` with `time` and `is_weekend` (Float64) |
+| `X_future` | `pl.DataFrame` with `time` and `is_holiday` (Float64) |
 | `X_forecast` | `pl.DataFrame` with `vintage_time`, `time`, and `pollutant_forecast` (Float64) |
 | `frame` | `pl.DataFrame` joining `y`, `X_actual`, and `X_future` on `time` |
-| `feature_names` | `["pollutant", "is_weekend", "pollutant_forecast"]` |
+| `feature_names` | `["pollutant", "is_holiday", "pollutant_forecast"]` |
 | `target_names` | `["air_quality"]` |
 | `classes` | `["good", "moderate", "poor"]` |
 | `frequency` | `"1h"` |

--- a/docs/pages/tutorials/exogenous-features.md
+++ b/docs/pages/tutorials/exogenous-features.md
@@ -36,7 +36,7 @@ X_future: (200, 2)
 X_forecast: (1143, 3)
 ```
 
-`X_actual` contains realized temperature (known only after it occurs), `X_future` contains a holiday indicator (deterministic, known for all dates), and `X_forecast` carries weather forecasts with a `vintage_time` column identifying when each forecast was issued. See [Exogenous Features](../explanation/exogenous-features.md) for the full conceptual model.
+`X_actual` contains realized temperature (known only after it occurs), `X_future` contains a holiday indicator (a calendar lookup, so no transformer can derive it from the observation point), and `X_forecast` carries weather forecasts with a `vintage_time` column identifying when each forecast was issued. See [Exogenous Features](../explanation/exogenous-features.md) for the full conceptual model.
 
 ## 2. Split and Fit
 
@@ -143,7 +143,7 @@ print(f"Walk-forward MAE (with weather): {score_with_wx:.4f}")
 ```
 
 ```text
-Walk-forward MAE (with weather): 2.8083
+Walk-forward MAE (with weather): 1.3165
 ```
 
 ## 5. Measure the Value of Weather Forecasts
@@ -174,10 +174,10 @@ print(f"Walk-forward MAE (no weather):   {score_no_wx:.4f}")
 ```
 
 ```text
-Walk-forward MAE (no weather):   3.7157
+Walk-forward MAE (no weather):   2.4031
 ```
 
-The weather signal reduces MAE from 3.72 to 2.81. Notice that `X_future` (holiday indicator) covers the full time range in both cases: it is deterministic and known for all dates, so no slicing is needed.
+The weather signal reduces MAE from 2.40 to 1.32. Notice that `X_future` (holiday indicator) covers the full time range in both cases: the calendar is known for every date in advance, so no slicing is needed.
 
 ## What You Built
 

--- a/src/yohou/base/panel.py
+++ b/src/yohou/base/panel.py
@@ -11,6 +11,7 @@ from yohou.base.utils import (
     _fit_transform_transformers_one,
     _observe_transformers_one,
     _rewind_transformers_one,
+    _warn_rank_deficient_step_columns,
 )
 from yohou.utils import add_interval, get_group_df, inspect_panel
 
@@ -324,6 +325,7 @@ class BasePanelForecaster:
             interval=self.interval_,
             existing_columns=existing_columns,
         )
+        _warn_rank_deficient_step_columns(X_step, X_future, forecasting_horizon)
         if X_step is not None:
             self._step_column_names_ = set(X_step.columns) - {"time"}
             self._X_future_raw_ = X_future

--- a/src/yohou/base/reduction.py
+++ b/src/yohou/base/reduction.py
@@ -50,7 +50,9 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         How to handle panel data. See `BaseForecaster` for details.
     step_feature_alignment : {"all", "matched", "cumulative"}, default="all"
         Controls which step-indexed feature columns each direct estimator
-        sees. Only affects the ``"direct"`` strategy.
+        sees. Only the ``"direct"`` strategy applies this parameter; setting it
+        to a non-default value on any other strategy emits a ``UserWarning`` at
+        fit and changes nothing.
 
         - ``"all"``: every estimator receives all step columns
           (``*_step_1..H``). Backward compatible, maximum information.
@@ -58,6 +60,13 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
           columns. Cleanest signal, no cross-horizon leakage.
         - ``"cumulative"``: estimator for step h receives columns
           ``*_step_1..h``. All information up to horizon h.
+
+        The other strategies are excluded for different reasons.
+        ``"multi-output"`` *cannot* filter: one estimator predicts every
+        horizon from a single feature vector, reading a different step column
+        per output, so it needs them all. ``"dir-rec"`` *could* filter (before
+        each step's feature augmentation) but does not; that is a deliberate
+        scope decision rather than a structural limit.
     nan_handling : {"drop", "pass"}, default="pass"
         How to handle NaN values in tabularized data.
         ``"pass"`` leaves NaN in place (suitable for estimators that
@@ -198,6 +207,45 @@ default="first_step"
         tags.forecaster_tags.supports_vintage_weight = True
 
         return tags
+
+    def _warn_inapplicable_step_alignment(self) -> None:
+        """Warn when the chosen strategy will not apply ``step_feature_alignment``.
+
+        Only ``"direct"`` filters step columns per estimator, so a non-default
+        value on any other strategy is inert. Silently accepting it reads as
+        configured behaviour that never happens.
+
+        Warns rather than raises: an inapplicable value is a no-op, not an
+        error, so a search over ``reduction_strategy`` crossed with
+        ``step_feature_alignment`` explores a smaller effective grid instead of
+        failing on every non-direct cell.
+
+        Call once per ``fit``, after parameter validation.
+        """
+        if self.step_feature_alignment == "all" or self.reduction_strategy == "direct":
+            return
+
+        if self.reduction_strategy == "multi-output":
+            reason = (
+                "a single estimator predicts every horizon from one feature vector, "
+                "so it reads a different step column per output and needs them all"
+            )
+        else:
+            reason = (
+                "dir-rec augments its feature matrix with earlier steps' predictions "
+                "and is excluded from step filtering by design, not by structure"
+            )
+
+        warnings.warn(
+            f"step_feature_alignment={self.step_feature_alignment!r} has no effect with "
+            f"reduction_strategy={self.reduction_strategy!r}, because {reason}. Only "
+            f'reduction_strategy="direct" applies step_feature_alignment; this fit '
+            f'proceeds as though it were "all".',
+            UserWarning,
+            # warn <- _warn_inapplicable_step_alignment <- fit <- sklearn's
+            # _fit_context wrapper <- user.
+            stacklevel=4,
+        )
 
     def _process_fit_weights(
         self,

--- a/src/yohou/base/standard.py
+++ b/src/yohou/base/standard.py
@@ -11,6 +11,7 @@ from yohou.base.utils import (
     _fit_transform_transformers_one,
     _observe_transformers_one,
     _rewind_transformers_one,
+    _warn_rank_deficient_step_columns,
 )
 from yohou.utils import add_interval
 
@@ -236,6 +237,7 @@ class BaseStandardForecaster:
             interval=self.interval_,
             existing_columns=set(X_t.columns) - {"time"} if X_t is not None else None,
         )
+        _warn_rank_deficient_step_columns(X_step, X_future, forecasting_horizon)
         if X_step is not None:
             self._step_column_names_ = set(X_step.columns) - {"time"}
             self._X_future_raw_ = X_future

--- a/src/yohou/base/utils.py
+++ b/src/yohou/base/utils.py
@@ -2,17 +2,49 @@
 
 from __future__ import annotations
 
+import inspect
 import re
 import warnings
 from datetime import timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+import numpy as np
 import polars as pl
 import polars.selectors as cs
+import sklearn
 from sklearn.base import clone
 
 if TYPE_CHECKING:
     from yohou.base import BaseActualTransformer
+
+_YOHOU_ROOT = str(Path(__file__).resolve().parents[1])
+_SKLEARN_ROOT = str(Path(sklearn.__file__).resolve().parent)
+
+
+def _caller_stacklevel() -> int:
+    """Return the ``stacklevel`` that points at the nearest frame outside the library.
+
+    Step columns are derived from ``fit``, ``observe``, and ``predict``, whose
+    call chains reach this module at different depths, and ``fit`` adds another
+    frame for scikit-learn's ``_fit_context`` decorator. No constant
+    ``stacklevel`` points at the caller for all three, so it is measured instead
+    of assumed: walk outward from the warn site and stop at the first frame that
+    belongs to neither yohou nor scikit-learn.
+
+    Call from the frame that calls :func:`warnings.warn`.
+    """
+    frame = inspect.currentframe()
+    if frame is not None:
+        frame = frame.f_back  # the warn site itself
+    level = 1
+    while frame is not None:
+        filename = frame.f_code.co_filename
+        if not filename.startswith(_YOHOU_ROOT) and not filename.startswith(_SKLEARN_ROOT):
+            return level
+        frame = frame.f_back
+        level += 1
+    return 1
 
 
 def _is_forecast_kind(obj: object) -> bool:
@@ -415,6 +447,117 @@ def _rewind_transformers_one(
     return X_t
 
 
+def _rank_deficient_step_columns(
+    X_step: pl.DataFrame,
+    value_columns: list[str],
+    forecasting_horizon: int,
+) -> list[tuple[str, int, int]]:
+    """Find X_future value columns whose step expansion is rank deficient.
+
+    A column whose value at ``T`` already determines its value at ``T+h`` (a
+    Fourier term, a calendar cycle) expands into ``H`` step columns that span
+    fewer than ``H`` dimensions, because each step column is a fixed function of
+    the value at ``T``. A genuine event calendar spans the full ``H``.
+
+    Rank rather than pairwise similarity is the right test: Fourier step columns
+    are rotations of the base pair, not copies, so they are neither duplicated
+    nor strongly pairwise correlated while still spanning only two dimensions.
+
+    Parameters
+    ----------
+    X_step : pl.DataFrame
+        The derived step frame, as returned by :func:`_derive_step_columns`.
+    value_columns : list of str
+        Base column names from ``X_future``, excluding ``"time"``.
+    forecasting_horizon : int
+        Number of forward steps (H) per observation time.
+
+    Returns
+    -------
+    list of (str, int, int)
+        One ``(column, n_step_columns, rank)`` triple per rank-deficient column.
+        Empty when nothing is deficient or nothing can be checked.
+
+    Notes
+    -----
+    The check is deliberately incomplete. It reports only what it can prove from
+    the step block alone, and stays silent whenever the measurement would not
+    support a conclusion:
+
+    - Rows carrying nulls are dropped first. Null step columns are a supported
+      state (an ``X_future`` that does not cover every observation time), and
+      ranking them would report an under-covering event calendar as a clock
+      feature, which is the opposite of the truth.
+    - A column is skipped when fewer than ``2 * H`` usable rows remain, since
+      rank is bounded by row count and a short frame would otherwise look
+      deficient for a reason unrelated to the feature.
+    - Non-numeric columns are skipped; rank is not defined for them.
+
+    """
+    findings: list[tuple[str, int, int]] = []
+    for col in value_columns:
+        step_names = [f"{col}_step_{h}" for h in range(1, forecasting_horizon + 1)]
+        if any(name not in X_step.columns for name in step_names):
+            continue
+
+        block = X_step.select(step_names)
+        if block.select(cs.numeric()).width != len(step_names):
+            continue
+
+        block = block.drop_nulls()
+        if len(block) < 2 * forecasting_horizon:
+            continue
+
+        array = block.to_numpy().astype(float)
+        array = array[np.isfinite(array).all(axis=1)]
+        if len(array) < 2 * forecasting_horizon:
+            continue
+
+        rank = int(np.linalg.matrix_rank(array))
+        if rank < forecasting_horizon:
+            findings.append((col, len(step_names), rank))
+
+    return findings
+
+
+def _warn_rank_deficient_step_columns(
+    X_step: pl.DataFrame | None,
+    X_future: pl.DataFrame | None,
+    forecasting_horizon: int,
+) -> None:
+    """Warn when an X_future column's step expansion carries no extra information.
+
+    Call from the fit path only. ``_derive_step_columns`` also serves observe and
+    predict, so a warning raised there would repeat once per stride of a
+    walk-forward loop, and the condition being reported is a property of the
+    caller's feature routing that cannot change between strides.
+
+    The message reports the measurement rather than asserting a diagnosis: a
+    constant column is rank deficient too, and this check cannot tell it apart
+    from a clock feature.
+    """
+    if X_step is None or X_future is None:
+        return
+
+    value_columns = [c for c in X_future.columns if c != "time"]
+    for col, n_steps, rank in _rank_deficient_step_columns(X_step, value_columns, forecasting_horizon):
+        warnings.warn(
+            f"X_future column '{col}' expands to {n_steps} step columns spanning "
+            f"a rank of only {rank}, so {n_steps - rank} of them add no information "
+            f"the others do not already carry. This is what a deterministic clock "
+            f"feature looks like (a Fourier term, or a calendar cycle): its value "
+            f"at the observation point already determines its value at every "
+            f"forecast step, so the forward window buys nothing and the collinear "
+            f"copies dilute any regularisation applied to them. If '{col}' is "
+            f"computable from the timestamp alone, generate it with a "
+            f"feature_transformer instead of passing it through X_future. If it is "
+            f"constant, or genuinely needs an external table, this warning does not "
+            f"apply and can be silenced.",
+            UserWarning,
+            stacklevel=_caller_stacklevel(),
+        )
+
+
 def _derive_step_columns(
     X_future: pl.DataFrame | None,
     X_forecast: pl.DataFrame | None,
@@ -526,9 +669,7 @@ def _derive_step_columns(
                     f"timestamps. Tree-based estimators (e.g. XGBoost, LightGBM, "
                     f"HistGradientBoosting) handle null features natively.",
                     UserWarning,
-                    # user -> fit/observe -> _pre_fit(_standard) -> _derive_step_columns
-                    # -> warn; point at the user's fit()/observe() call.
-                    stacklevel=5,
+                    stacklevel=_caller_stacklevel(),
                 )
 
         # Pad missing step columns to H (partial coverage → null columns)

--- a/src/yohou/class_proba/reduction.py
+++ b/src/yohou/class_proba/reduction.py
@@ -52,7 +52,11 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
         a feature.
     step_feature_alignment : {"all", "matched", "cumulative"}, default="all"
         Controls which step-indexed feature columns each direct estimator
-        sees. Only affects the ``"direct"`` strategy.
+        sees. Only the ``"direct"`` strategy applies this parameter; a
+        non-default value on any other strategy warns at fit and changes
+        nothing. ``"multi-output"`` cannot filter, since one estimator reads a
+        different step column per output and needs them all; ``"dir-rec"``
+        could, but is excluded by a deliberate scope decision.
 
         - ``"all"``: every estimator receives all step columns.
         - ``"matched"``: estimator for step h receives only ``*_step_h``.
@@ -217,6 +221,7 @@ class ClassProbaReductionForecaster(BaseReductionForecaster, BaseClassProbaForec
 
         """
         forecasting_horizon = self._validate_fit_params(forecasting_horizon)
+        self._warn_inapplicable_step_alignment()
 
         # Discover classes from y before _pre_fit (which may transform y)
         # Use unprefixed (base) column names so panel groups share class labels.

--- a/src/yohou/compose/forecasted_feature_forecaster.py
+++ b/src/yohou/compose/forecasted_feature_forecaster.py
@@ -73,7 +73,10 @@ class ForecastedFeatureForecaster(BaseForecaster):
         Quality of the in-sample feature forecast the target trains on. In every
         strategy the forecast is supplied to the target through the ``X_forecast``
         channel (as ``vintage_time + time + features``), and the target decides how
-        to consume the resulting step features via its own ``step_feature_alignment``.
+        to consume the resulting step features. A reduction target consumes them via
+        its own ``step_feature_alignment`` only when it uses
+        ``reduction_strategy="direct"``; the other strategies ignore that parameter,
+        so a default ``"multi-output"`` target receives every step column.
 
         - "actual": Train the target on perfect-foresight features (actual values
           windowed forward and labelled with a vintage). Uses all data, but creates
@@ -163,8 +166,11 @@ class ForecastedFeatureForecaster(BaseForecaster):
     - The feature_forecaster is trained with X_actual as y (forecasting the features).
     - At both fit and predict the feature forecast is passed to the target as
       ``X_forecast`` (keeping ``vintage_time``); the target builds step columns and
-      consumes them per its ``step_feature_alignment``. A target with
-      ``requires_exogenous=False`` (e.g. a naive forecaster) ignores the forecast.
+      consumes them per its ``step_feature_alignment``, which applies only when the
+      target is a reduction forecaster with ``reduction_strategy="direct"``; the
+      default ``"multi-output"`` ignores it and receives every step column. A target
+      with ``requires_exogenous=False`` (e.g. a naive forecaster) ignores the
+      forecast.
     - Use strategy="predicted" or "rewind" when feature forecasts are noisy and you
       want the target to learn from similar-quality inputs as it sees at predict time.
     - A caller-supplied ``X_forecast`` (external forecasts for other features) is

--- a/src/yohou/datasets/_generators.py
+++ b/src/yohou/datasets/_generators.py
@@ -13,6 +13,52 @@ import numpy as np
 import polars as pl
 from sklearn.utils import Bunch
 
+_HOLIDAY_MONTH_DAYS: tuple[tuple[int, int], ...] = (
+    (1, 1),
+    (1, 6),
+    (1, 8),
+    (1, 15),
+    (2, 19),
+    (3, 29),
+    (4, 1),
+    (5, 1),
+    (5, 27),
+    (7, 4),
+    (9, 2),
+    (11, 28),
+    (12, 25),
+    (12, 26),
+)
+"""Fixed civil holiday calendar as ``(month, day)`` pairs.
+
+The dates are deliberately irregular with respect to weekday, so the resulting
+indicator cannot be reconstructed from any cyclical encoding of the clock. That
+is what makes it a genuine ``X_future`` feature: a forecaster must be told the
+holiday status of each future step, because no transformer can derive it from
+the observation point. A weekday predicate would instead be a clock feature and
+would belong in a ``feature_transformer``.
+
+The early-January entries are load-bearing. The default series is 200 hourly
+rows, spanning only 2024-01-01 to 2024-01-09, so a calendar carrying nothing but
+widely spaced real holidays would leave the tail of that window (the usual test
+split) with no holiday at all, and the feature would never move an evaluated
+prediction.
+"""
+
+
+def _holiday_indicator(times: pl.Series) -> np.ndarray:
+    """Mark timestamps whose date appears in the fixed holiday calendar.
+
+    Depends only on the calendar, never on ``random_state``, so the holidays are
+    a property of the dataset rather than of the seed.
+    """
+    # dt.month() and dt.day() are Int8, so the 100 * month term overflows for
+    # every month past January unless the operands are widened first.
+    month = times.dt.month().cast(pl.Int32)
+    day = times.dt.day().cast(pl.Int32)
+    keys = [100 * m + d for m, d in _HOLIDAY_MONTH_DAYS]
+    return (100 * month + day).is_in(keys).cast(pl.Float64).to_numpy()
+
 
 def _forecast_index_grid(n_samples: int, forecasting_horizon: int) -> tuple[np.ndarray, np.ndarray]:
     """Build vintage and target index arrays for X_forecast construction.
@@ -49,8 +95,11 @@ def make_exogenous_regression(
 
     - **X_actual** (observation features): realized temperature readings
       with a 24 hour sinusoidal cycle plus measurement noise (std=0.5).
-    - **X_future** (known future): a deterministic ``is_holiday`` indicator
-      (Sundays = 1.0) covering the full time range.
+    - **X_future** (known future): an ``is_holiday`` indicator drawn from a
+      fixed civil holiday calendar, covering the full time range. The dates
+      are irregular with respect to weekday, so the indicator cannot be
+      derived from the timestamp and genuinely requires the ``X_future``
+      channel.
     - **X_forecast** (external forecasts): weather temperature forecasts
       with one vintage per observation from index ``forecasting_horizon``
       up to (but not including) the last observation, each covering the
@@ -127,8 +176,7 @@ def make_exogenous_regression(
     t = np.arange(n_samples, dtype=float)
 
     actual_temp = 15.0 + 5.0 * np.sin(2 * np.pi * t / 24) + rng.normal(0, 0.5, n_samples)
-    # Sundays = 1.0 (polars weekday(): Monday=1 .. Sunday=7).
-    holidays = (times.dt.weekday() == 7).cast(pl.Float64).to_numpy()
+    holidays = _holiday_indicator(times)
     price = 50.0 + 2.0 * actual_temp + 10.0 * holidays + rng.normal(0, noise, n_samples)
 
     y = pl.DataFrame({"time": times, "price": price})
@@ -161,7 +209,8 @@ def make_exogenous_regression(
             "Synthetic hourly electricity prices with exogenous features.\n"
             "Target: price = 50 + 2 * temperature + 10 * is_holiday + noise.\n"
             "X_actual: realized temperature (sinusoidal 24h cycle + noise).\n"
-            "X_future: is_holiday indicator (Sundays = 1.0).\n"
+            "X_future: is_holiday indicator from a fixed civil holiday calendar\n"
+            "  (irregular dates, not derivable from the timestamp).\n"
             "X_forecast: weather temperature forecasts with systematic bias."
         ),
     )
@@ -184,8 +233,11 @@ def make_exogenous_classification(
 
     - **X_actual** (observation features): realized pollutant readings
       with a 24 hour sinusoidal cycle.
-    - **X_future** (known future): a deterministic ``is_weekend``
-      indicator covering the full time range.
+    - **X_future** (known future): an ``is_holiday`` indicator drawn from a
+      fixed civil holiday calendar, covering the full time range. Holidays
+      reduce traffic and therefore pollutant levels. The dates are irregular
+      with respect to weekday, so the indicator cannot be derived from the
+      timestamp and genuinely requires the ``X_future`` channel.
     - **X_forecast** (external forecasts): pollutant concentration
       forecasts with one vintage per observation from index
       ``forecasting_horizon`` up to (but not including) the last
@@ -232,14 +284,14 @@ def make_exogenous_classification(
         X_actual : pl.DataFrame
             Observation features with columns ``["time", "pollutant"]``.
         X_future : pl.DataFrame
-            Known future features with columns ``["time", "is_weekend"]``.
+            Known future features with columns ``["time", "is_holiday"]``.
         X_forecast : pl.DataFrame
             External forecasts with columns
             ``["vintage_time", "time", "pollutant_forecast"]``.
         frame : pl.DataFrame
             ``y``, ``X_actual``, and ``X_future`` joined on ``"time"``.
         feature_names : list of str
-            ``["pollutant", "is_weekend", "pollutant_forecast"]``.
+            ``["pollutant", "is_holiday", "pollutant_forecast"]``.
         target_names : list of str
             ``["air_quality"]``.
         classes : list of str
@@ -276,11 +328,10 @@ def make_exogenous_classification(
     # Pollutant with 24h cycle centered at 50, amplitude 20
     pollutant = 50.0 + 20.0 * np.sin(2 * np.pi * t / 24) + rng.normal(0, 5.0, n_samples)
 
-    # Saturday/Sunday = 1.0 (polars weekday(): Monday=1 .. Sunday=7).
-    is_weekend = (times.dt.weekday() >= 6).cast(pl.Float64).to_numpy()
+    is_holiday = _holiday_indicator(times)
 
-    # Weekend effect: lower pollutant readings
-    effective_pollutant = pollutant - 5.0 * is_weekend + rng.normal(0, noise, n_samples)
+    # Holiday effect: less traffic, lower pollutant readings
+    effective_pollutant = pollutant - 5.0 * is_holiday + rng.normal(0, noise, n_samples)
 
     # Classify
     classes = ["good", "moderate", "poor"]
@@ -292,7 +343,7 @@ def make_exogenous_classification(
 
     y = pl.DataFrame({"time": times, "air_quality": labels})
     X_actual = pl.DataFrame({"time": times, "pollutant": pollutant})
-    X_future = pl.DataFrame({"time": times, "is_weekend": is_weekend})
+    X_future = pl.DataFrame({"time": times, "is_holiday": is_holiday})
 
     vintage_idx, target_idx = _forecast_index_grid(n_samples, forecasting_horizon)
     pollutant_noise = rng.normal(0, 2.0, vintage_idx.shape[0])
@@ -313,7 +364,7 @@ def make_exogenous_classification(
         X_future=X_future,
         X_forecast=X_forecast,
         frame=frame,
-        feature_names=["pollutant", "is_weekend", "pollutant_forecast"],
+        feature_names=["pollutant", "is_holiday", "pollutant_forecast"],
         target_names=["air_quality"],
         classes=classes,
         frequency="1h",
@@ -321,7 +372,8 @@ def make_exogenous_classification(
             "Synthetic hourly air quality classification with exogenous features.\n"
             "Target: air_quality in {good, moderate, poor} based on pollutant thresholds.\n"
             "X_actual: realized pollutant readings (sinusoidal 24h cycle + noise).\n"
-            "X_future: is_weekend indicator.\n"
+            "X_future: is_holiday indicator from a fixed civil holiday calendar\n"
+            "  (irregular dates, not derivable from the timestamp).\n"
             "X_forecast: pollutant concentration forecasts with systematic bias."
         ),
     )

--- a/src/yohou/interval/reduction.py
+++ b/src/yohou/interval/reduction.py
@@ -58,7 +58,11 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
         ``"dir-rec"`` strategies.
     step_feature_alignment : {"all", "matched", "cumulative"}, default="all"
         Controls which step-indexed feature columns each direct estimator
-        sees. Only affects the ``"direct"`` strategy.
+        sees. Only the ``"direct"`` strategy applies this parameter; a
+        non-default value on any other strategy warns at fit and changes
+        nothing. ``"multi-output"`` cannot filter, since one estimator reads a
+        different step column per output and needs them all; ``"dir-rec"``
+        could, but is excluded by a deliberate scope decision.
 
         - ``"all"``: every estimator receives all step columns.
         - ``"matched"``: estimator for step h receives only ``*_step_h``.
@@ -311,6 +315,7 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
         forecasting_horizon, self.fit_coverage_rates_ = self._validate_interval_fit_params(
             forecasting_horizon, coverage_rates
         )
+        self._warn_inapplicable_step_alignment()
 
         y_t, X_t = self._pre_fit(
             y=y,

--- a/src/yohou/point/reduction.py
+++ b/src/yohou/point/reduction.py
@@ -54,7 +54,11 @@ class PointReductionForecaster(BaseReductionForecaster, BasePointForecaster):
         ``"dir-rec"`` strategies.
     step_feature_alignment : {"all", "matched", "cumulative"}, default="all"
         Controls which step-indexed feature columns each direct estimator
-        sees. Only affects the ``"direct"`` strategy.
+        sees. Only the ``"direct"`` strategy applies this parameter; a
+        non-default value on any other strategy warns at fit and changes
+        nothing. ``"multi-output"`` cannot filter, since one estimator reads a
+        different step column per output and needs them all; ``"dir-rec"``
+        could, but is excluded by a deliberate scope decision.
 
         - ``"all"``: every estimator receives all step columns.
         - ``"matched"``: estimator for step h receives only ``*_step_h``.
@@ -232,6 +236,7 @@ class PointReductionForecaster(BaseReductionForecaster, BasePointForecaster):
 
         """
         forecasting_horizon = self._validate_fit_params(forecasting_horizon)
+        self._warn_inapplicable_step_alignment()
 
         y_t, X_t = self._pre_fit(
             y=y,

--- a/tests/base/test_step_expansion_diagnostics.py
+++ b/tests/base/test_step_expansion_diagnostics.py
@@ -1,0 +1,222 @@
+"""Tests for the X_future rank-deficiency diagnostic.
+
+A clock feature routed through X_future expands into H step columns that carry
+no information its value at the observation point did not already carry. The
+warning under test reports that; these tests pin both that it fires when it
+should and, more importantly, that it stays quiet when it should.
+"""
+
+import contextlib
+import warnings
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from sklearn.dummy import DummyRegressor
+from sklearn.linear_model import LinearRegression
+
+from yohou.point import PointReductionForecaster
+
+H = 12
+
+
+@pytest.fixture
+def y_series():
+    """A year of daily observations with a weekly cycle."""
+    time = pl.datetime_range(datetime(2021, 1, 1), datetime(2021, 12, 31), interval="1d", eager=True)
+    t = np.arange(len(time), dtype=float)
+    return pl.DataFrame({"time": time, "value": np.sin(2 * np.pi * t / 7) + 0.01 * t})
+
+
+@pytest.fixture
+def future_time():
+    """Timestamps covering the observations plus room beyond every target."""
+    return pl.datetime_range(datetime(2021, 1, 1), datetime(2022, 6, 30), interval="1d", eager=True)
+
+
+@pytest.fixture
+def fourier_future(future_time):
+    """A clock feature: its value at T determines its value at every T+h."""
+    t = np.arange(len(future_time), dtype=float)
+    return pl.DataFrame({
+        "time": future_time,
+        "f_sin": np.sin(2 * np.pi * t / 7),
+        "f_cos": np.cos(2 * np.pi * t / 7),
+    })
+
+
+@pytest.fixture
+def event_future(future_time):
+    """An event calendar: not derivable from the timestamp."""
+    rng = np.random.default_rng(0)
+    return pl.DataFrame({
+        "time": future_time,
+        "promo": rng.integers(0, 2, len(future_time)).astype(float),
+    })
+
+
+def _rank_warnings(record):
+    """Select the rank-deficiency warnings out of a warning record."""
+    return [w for w in record if "expands to" in str(w.message)]
+
+
+@contextlib.contextmanager
+def _captured_warnings():
+    """Record every warning without requiring one.
+
+    ``pytest.warns`` asserts that at least one warning is raised, so it cannot
+    express "this must not warn" when nothing warns at all.
+    """
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        yield record
+
+
+class TestRankDeficiencyWarning:
+    """The diagnostic fires on clock features and only on clock features."""
+
+    def test_fourier_payload_warns_with_measurements(self, y_series, fourier_future):
+        """A Fourier payload warns per column, reporting step count and rank."""
+        with pytest.warns(UserWarning) as record:
+            PointReductionForecaster(estimator=LinearRegression()).fit(
+                y=y_series, forecasting_horizon=H, X_future=fourier_future
+            )
+        messages = [str(w.message) for w in _rank_warnings(record)]
+        assert len(messages) == 2
+        assert any("'f_sin'" in m for m in messages)
+        assert any("'f_cos'" in m for m in messages)
+        assert all(f"expands to {H} step columns" in m for m in messages)
+        assert all("rank of only 2" in m for m in messages)
+        assert all("feature_transformer" in m for m in messages)
+
+    def test_event_calendar_does_not_warn(self, y_series, event_future):
+        """An irregular event calendar is what the channel is for."""
+        with _captured_warnings() as record:
+            PointReductionForecaster(estimator=LinearRegression()).fit(
+                y=y_series, forecasting_horizon=H, X_future=event_future
+            )
+        assert _rank_warnings(record) == []
+
+    def test_undercovering_event_calendar_does_not_warn(self, y_series, future_time):
+        """Null step columns must not be mistaken for a clock feature.
+
+        An X_future that stops short of the last required target produces null
+        step values. Those rows are excluded before ranking; without that, an
+        under-covering event calendar would be reported as clock-derived, which
+        is the exact opposite of the truth.
+        """
+        short_time = future_time.filter(future_time <= datetime(2021, 12, 25))
+        rng = np.random.default_rng(1)
+        short_future = pl.DataFrame({
+            "time": short_time,
+            "promo": rng.integers(0, 2, len(short_time)).astype(float),
+        })
+        with _captured_warnings() as record:
+            PointReductionForecaster(estimator=LinearRegression(), nan_handling="drop").fit(
+                y=y_series, forecasting_horizon=H, X_future=short_future
+            )
+        assert _rank_warnings(record) == []
+
+    def test_short_frame_skips_the_check(self, fourier_future):
+        """Too few rows to rank means no claim is made."""
+        time = pl.datetime_range(datetime(2021, 1, 1), datetime(2021, 1, 20), interval="1d", eager=True)
+        t = np.arange(len(time), dtype=float)
+        y_short = pl.DataFrame({"time": time, "value": np.sin(2 * np.pi * t / 7)})
+        with _captured_warnings() as record:
+            PointReductionForecaster(estimator=LinearRegression()).fit(
+                y=y_short, forecasting_horizon=H, X_future=fourier_future
+            )
+        assert _rank_warnings(record) == []
+
+
+class TestDiagnosticFiresOnceAtFit:
+    """The condition is a property of routing, so it is said once."""
+
+    def test_no_repeat_across_observe_predict_and_predict(self, y_series, fourier_future):
+        """Walk-forward must not repeat the warning once per stride."""
+        with pytest.warns(UserWarning):
+            forecaster = PointReductionForecaster(estimator=LinearRegression())
+            forecaster.fit(y=y_series, forecasting_horizon=H, X_future=fourier_future)
+
+        new_time = pl.datetime_range(datetime(2022, 1, 1), datetime(2022, 2, 15), interval="1d", eager=True)
+        y_new = pl.DataFrame({
+            "time": new_time,
+            "value": np.sin(2 * np.pi * np.arange(len(new_time)) / 7),
+        })
+        with _captured_warnings() as record:
+            forecaster.observe_predict(y=y_new, X_future=fourier_future, stride=H)
+            forecaster.predict(X_future=fourier_future)
+        assert _rank_warnings(record) == []
+
+
+class TestWarningsPointAtTheCaller:
+    """Step-column warnings blame the user's call, not library internals.
+
+    Step columns are derived from fit, observe, and predict, whose chains reach
+    the warn site at different depths, and fit adds a frame for scikit-learn's
+    _fit_context decorator. A constant stacklevel cannot serve all three: the
+    X_forecast coverage warning shipped with ``stacklevel=5``, which was right
+    for observe, pointed at ``sklearn/base.py`` from fit, and overshot the
+    caller from predict. These tests pin the measured behaviour so the numbers
+    cannot silently drift again.
+    """
+
+    def test_rank_warning_points_at_the_caller(self, y_series, fourier_future):
+        """The rank diagnostic blames this test, not yohou or sklearn."""
+        with pytest.warns(UserWarning) as record:
+            PointReductionForecaster(estimator=LinearRegression()).fit(
+                y=y_series, forecasting_horizon=H, X_future=fourier_future
+            )
+        warning = _rank_warnings(record)[0]
+        assert warning.filename == __file__
+
+    @pytest.mark.parametrize("phase", ["fit", "observe", "predict"])
+    def test_x_forecast_coverage_warning_points_at_the_caller(self, phase):
+        """The X_forecast coverage warning blames the caller from every phase."""
+        n = 60
+        time = pl.datetime_range(datetime(2021, 1, 1), datetime(2021, 3, 1), interval="1d", eager=True)[:n]
+        y = pl.DataFrame({"time": time, "value": np.arange(len(time), dtype=float)})
+        # Cover only 2 of 4 steps, so the under-coverage warning fires.
+        forecast = pl.DataFrame([
+            {"vintage_time": vintage, "time": vintage + timedelta(days=step), "wx": float(i + step)}
+            for i, vintage in enumerate(time)
+            for step in (1, 2)
+        ])
+        # The warning needs the last step column to be entirely null, which
+        # nan_handling="drop" would strip every row for. DummyRegressor ignores
+        # X, so the real fit/observe/predict chains run without an estimator
+        # that has an opinion about NaN.
+        forecaster = PointReductionForecaster(estimator=DummyRegressor(), nan_handling="pass")
+
+        with _captured_warnings():
+            forecaster.fit(y=y, forecasting_horizon=4, X_forecast=forecast)
+
+        later = pl.datetime_range(datetime(2021, 3, 2), datetime(2021, 3, 11), interval="1d", eager=True)
+        y_later = pl.DataFrame({"time": later, "value": np.arange(n, n + len(later), dtype=float)})
+        calls = {
+            "fit": lambda: PointReductionForecaster(estimator=DummyRegressor(), nan_handling="pass").fit(
+                y=y, forecasting_horizon=4, X_forecast=forecast
+            ),
+            "observe": lambda: forecaster.observe(y=y_later, X_forecast=forecast),
+            "predict": lambda: forecaster.predict(X_forecast=forecast),
+        }
+        with _captured_warnings() as record:
+            calls[phase]()
+        coverage = [w for w in record if "X_forecast covers" in str(w.message)]
+        assert coverage, f"expected a coverage warning from {phase}"
+        assert coverage[0].filename == __file__
+
+
+class TestDiagnosticDoesNotMutate:
+    """Report, never repair."""
+
+    def test_step_columns_survive_the_warning(self, y_series, fourier_future):
+        """Every generated step column is still present after the warning."""
+        with pytest.warns(UserWarning):
+            forecaster = PointReductionForecaster(estimator=LinearRegression())
+            forecaster.fit(y=y_series, forecasting_horizon=H, X_future=fourier_future)
+        assert len(forecaster._step_column_names_) == 2 * H
+        for col in ("f_sin", "f_cos"):
+            for step in range(1, H + 1):
+                assert f"{col}_step_{step}" in forecaster._step_column_names_

--- a/tests/datasets/test_generators.py
+++ b/tests/datasets/test_generators.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import polars as pl
 
 from yohou.datasets._generators import (
+    _HOLIDAY_MONTH_DAYS,
     make_exogenous_classification,
     make_exogenous_regression,
 )
@@ -123,6 +124,63 @@ class TestMakeExogenousRegression:
             assert len(subset) <= 3
 
 
+class TestHolidayCalendarIsAnEventFeature:
+    """The generators' is_holiday must be a genuine X_future feature.
+
+    A weekday predicate would be a clock feature: derivable from the timestamp,
+    and therefore something a feature_transformer should produce rather than
+    something the X_future channel must carry. These tests pin the property the
+    channel's semantics depend on.
+    """
+
+    def test_is_holiday_is_not_a_weekday_predicate(self):
+        """is_holiday matches no single-weekday indicator."""
+        X_future = make_exogenous_regression(n_samples=24 * 60).X_future
+        weekday = X_future["time"].dt.weekday()
+        for day in range(1, 8):
+            indicator = (weekday == day).cast(pl.Float64)
+            assert not (indicator == X_future["is_holiday"]).all(), f"is_holiday is just weekday == {day}"
+
+    def test_holidays_span_at_least_three_weekdays(self):
+        """Over a year the holiday dates fall on at least three weekdays.
+
+        Regression guard: the month/day lookup key is built with arithmetic on
+        Int8 columns, which silently overflowed past January and collapsed the
+        calendar onto the wrong dates. A January-only window cannot catch that.
+        """
+        X_future = make_exogenous_regression(n_samples=24 * 366).X_future
+        holidays = X_future.filter(pl.col("is_holiday") == 1.0)
+        weekdays = {t.strftime("%a") for t in holidays["time"]}
+        assert len(weekdays) >= 3, f"holidays only fall on {sorted(weekdays)}"
+
+    def test_every_calendar_entry_lands_within_a_year(self):
+        """A full year marks exactly one date per calendar entry."""
+        X_future = make_exogenous_regression(n_samples=24 * 366).X_future
+        holidays = X_future.filter(pl.col("is_holiday") == 1.0)
+        dates = {t.date() for t in holidays["time"]}
+        assert len(dates) == len(_HOLIDAY_MONTH_DAYS)
+
+    def test_default_window_has_distributed_holidays(self):
+        """The default window carries at least two dates, not all at the start."""
+        X_future = make_exogenous_regression().X_future
+        holidays = X_future.filter(pl.col("is_holiday") == 1.0)
+        dates = sorted({t.date() for t in holidays["time"]})
+        assert len(dates) >= 2
+        assert any(d > X_future["time"][0].date() for d in dates)
+
+    def test_calendar_is_seed_independent(self):
+        """The holiday calendar is a property of the dataset, not the seed."""
+        a = make_exogenous_regression(random_state=0).X_future
+        b = make_exogenous_regression(random_state=99).X_future
+        assert a["is_holiday"].equals(b["is_holiday"])
+
+    def test_classification_holiday_is_also_an_event_feature(self):
+        """The classification generator's X_future is not a weekend predicate."""
+        X_future = make_exogenous_classification(n_samples=24 * 60).X_future
+        weekend = (X_future["time"].dt.weekday() >= 6).cast(pl.Float64)
+        assert not (weekend == X_future["is_holiday"]).all()
+
+
 class TestMakeExogenousClassification:
     """Tests for make_exogenous_classification."""
 
@@ -154,9 +212,9 @@ class TestMakeExogenousClassification:
         assert data.X_actual.columns == ["time", "pollutant"]
 
     def test_x_future_schema(self):
-        """X_future has [time, is_weekend] columns."""
+        """X_future has [time, is_holiday] columns."""
         data = make_exogenous_classification()
-        assert data.X_future.columns == ["time", "is_weekend"]
+        assert data.X_future.columns == ["time", "is_holiday"]
 
     def test_x_forecast_schema(self):
         """X_forecast has [vintage_time, time, pollutant_forecast] columns."""
@@ -206,7 +264,7 @@ class TestMakeExogenousClassification:
     def test_feature_names(self):
         """feature_names lists all three feature columns."""
         data = make_exogenous_classification()
-        assert data.feature_names == ["pollutant", "is_weekend", "pollutant_forecast"]
+        assert data.feature_names == ["pollutant", "is_holiday", "pollutant_forecast"]
 
     def test_target_names(self):
         """target_names is ['air_quality']."""

--- a/tests/point/test_reduction.py
+++ b/tests/point/test_reduction.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime
 
 import numpy as np
@@ -1327,28 +1328,72 @@ class TestStepFeatureAlignment:
             assert preds["all"][target_col].to_list() == preds[mode][target_col].to_list()
 
     def test_multi_output_ignores_alignment(self, step_alignment_data):
-        """multi-output strategy ignores step_feature_alignment (single model)."""
+        """multi-output feeds its estimator every step column regardless.
+
+        Asserts the feature count, not the prediction length: a length check
+        holds whether or not the parameter is honored, so it cannot detect the
+        behaviour it names.
+        """
         y, X_future = step_alignment_data
         fh = 3
-        f = PointReductionForecaster(
-            reduction_strategy="multi-output",
-            step_feature_alignment="matched",
-        )
-        f.fit(y[:25], forecasting_horizon=fh, X_future=X_future)
-        y_pred = f.predict(forecasting_horizon=fh)
-        assert len(y_pred) == fh
+
+        def n_features(alignment):
+            f = PointReductionForecaster(
+                reduction_strategy="multi-output",
+                step_feature_alignment=alignment,
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                f.fit(y[:25], forecasting_horizon=fh, X_future=X_future)
+            assert len(f.predict(forecasting_horizon=fh)) == fh
+            return f.estimator_.n_features_in_
+
+        assert n_features("matched") == n_features("all")
 
     def test_dir_rec_ignores_alignment(self, step_alignment_data):
-        """dir-rec strategy ignores step_feature_alignment (own augmentation)."""
+        """dir-rec feeds every estimator every step column regardless."""
         y, X_future = step_alignment_data
         fh = 3
-        f = PointReductionForecaster(
-            reduction_strategy="dir-rec",
-            step_feature_alignment="matched",
-        )
-        f.fit(y[:25], forecasting_horizon=fh, X_future=X_future)
-        y_pred = f.predict(forecasting_horizon=fh)
-        assert len(y_pred) == fh
+
+        def n_features(alignment):
+            f = PointReductionForecaster(
+                reduction_strategy="dir-rec",
+                step_feature_alignment=alignment,
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                f.fit(y[:25], forecasting_horizon=fh, X_future=X_future)
+            assert len(f.predict(forecasting_horizon=fh)) == fh
+            return [est.n_features_in_ for est in f.estimator_]
+
+        assert n_features("matched") == n_features("all")
+
+    def test_inapplicable_alignment_warns(self, step_alignment_data):
+        """A non-default alignment on a strategy that ignores it says so."""
+        y, X_future = step_alignment_data
+        for strategy in ("multi-output", "dir-rec"):
+            f = PointReductionForecaster(
+                reduction_strategy=strategy,
+                step_feature_alignment="matched",
+            )
+            with pytest.warns(UserWarning, match="has no effect"):
+                f.fit(y[:25], forecasting_horizon=3, X_future=X_future)
+
+    def test_applicable_or_default_alignment_is_silent(self, step_alignment_data):
+        """direct applies the parameter, and "all" is what everyone already does."""
+        y, X_future = step_alignment_data
+        cases = [("direct", "matched"), ("multi-output", "all"), ("dir-rec", "all")]
+        for strategy, alignment in cases:
+            f = PointReductionForecaster(
+                reduction_strategy=strategy,
+                step_feature_alignment=alignment,
+            )
+            with warnings.catch_warnings(record=True) as record:
+                warnings.simplefilter("always")
+                f.fit(y[:25], forecasting_horizon=3, X_future=X_future)
+            assert [w for w in record if "has no effect" in str(w.message)] == [], (
+                f"{strategy} + {alignment} should not warn"
+            )
 
 
 class TestPipelineSampleWeightRouting:

--- a/tests/point/test_wide_x_future.py
+++ b/tests/point/test_wide_x_future.py
@@ -1,0 +1,84 @@
+"""Coverage for X_future payloads wider than the historic test envelope.
+
+Nothing in the suite used X_future above 2 value columns at a horizon of 6, and
+nothing used it at a horizon of 7 or more. That is exactly the regime in which
+step expansion is cheap, which is why a payload blowing up to hundreds of
+columns went unnoticed. These tests move the envelope.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import polars as pl
+import pytest
+from sklearn.linear_model import LinearRegression
+
+from yohou.point import PointReductionForecaster
+
+H = 48
+N_FEATURES = 5
+N_STEP_COLUMNS = N_FEATURES * H
+
+
+@pytest.fixture(scope="module")
+def wide_data():
+    """A daily series plus a 5-column event-like X_future covering every target."""
+    time = pl.datetime_range(datetime(2021, 1, 1), datetime(2022, 12, 31), interval="1d", eager=True)
+    rng = np.random.default_rng(7)
+    y = pl.DataFrame({"time": time, "value": rng.standard_normal(len(time)).cumsum()})
+
+    future_time = pl.datetime_range(datetime(2021, 1, 1), datetime(2023, 6, 30), interval="1d", eager=True)
+    X_future = pl.DataFrame({
+        "time": future_time,
+        **{f"feat_{i}": rng.standard_normal(len(future_time)) for i in range(N_FEATURES)},
+    })
+    return y, X_future
+
+
+class TestWideXFuture:
+    """A wide X_future fits, predicts, and filters as documented."""
+
+    def test_wide_x_future_fits_and_predicts(self, wide_data):
+        """5 value columns at H=48 produce 240 step columns and a usable forecast."""
+        y, X_future = wide_data
+        forecaster = PointReductionForecaster(estimator=LinearRegression())
+        forecaster.fit(y=y, forecasting_horizon=H, X_future=X_future)
+
+        assert len(forecaster._step_column_names_) == N_STEP_COLUMNS
+        assert len(forecaster.predict()) == H
+
+    def test_matched_drops_the_other_steps(self, wide_data):
+        """Each direct estimator sees its own 5 step columns, not the other 235."""
+        y, X_future = wide_data
+        forecaster = PointReductionForecaster(
+            estimator=LinearRegression(),
+            reduction_strategy="direct",
+            step_feature_alignment="matched",
+        )
+        forecaster.fit(y=y, forecasting_horizon=H, X_future=X_future)
+
+        all_steps = PointReductionForecaster(
+            estimator=LinearRegression(),
+            reduction_strategy="direct",
+            step_feature_alignment="all",
+        )
+        all_steps.fit(y=y, forecasting_horizon=H, X_future=X_future)
+
+        n_non_step = all_steps.estimator_[0].n_features_in_ - N_STEP_COLUMNS
+        for estimator in forecaster.estimator_:
+            assert estimator.n_features_in_ == N_FEATURES + n_non_step
+
+    def test_cumulative_grows_with_horizon(self, wide_data):
+        """Step h sees steps 1..h, so the feature count rises monotonically."""
+        y, X_future = wide_data
+        forecaster = PointReductionForecaster(
+            estimator=LinearRegression(),
+            reduction_strategy="direct",
+            step_feature_alignment="cumulative",
+        )
+        forecaster.fit(y=y, forecasting_horizon=H, X_future=X_future)
+
+        counts = [estimator.n_features_in_ for estimator in forecaster.estimator_]
+        assert counts == sorted(counts)
+        assert counts[0] < counts[-1]
+        assert counts[-1] - counts[0] == N_STEP_COLUMNS - N_FEATURES


### PR DESCRIPTION
## Description

The docs routed deterministic clock features (Fourier terms, day-of-week) into `X_future`, where the framework windows them into `H` step-indexed columns. This corrects the routing guidance, makes the canonical example model the rule it teaches, and adds guards so the mistake is visible rather than silent.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

For a Fourier payload the step expansion is **exactly** redundant, not approximately: at `H=24` it produces 144 columns spanning **rank 6**, adding zero dimensions over the feature's value at the observation point. Predictions are bit-identical to correct routing (max diff `2.9e-13`), and `Ridge(alpha=A)` on the expanded matrix matches `Ridge(alpha=A/H)` on the base pair to six decimals, so the collinear copies dilute regularisation by exactly `H`. `CalendarFeatureTransformer()` at defaults yields 336 step columns at `H=24`.

The cause is a discriminator that does not discriminate. The how-to asked *"Is it deterministic and known for any future date?"* and routed a yes to `X_future` — but a day-of-week indicator and a holiday calendar both answer yes, and they belong in different channels.

The library then taught the mistake through its own exemplars: `make_exogenous_regression` defined its holiday indicator as `weekday() == 7` (literally "is Sunday", pure clock, no table), while `HolidayFeatureTransformer` — the one feature that genuinely needs an external table — sits on the `X_actual` channel. Every `X_future` teaching surface in the repo was powered by a clock feature wearing an event feature's name.

Nobody hit this because the tested envelope (max 2 columns at `H=6`) is exactly the regime where expansion is cheap.

**The rule this introduces:** `X_future` is for features whose value at `T+h` is *not* determined by their value at `T`. That follows from a structural fact the docs never stated: `feature_transformer` only ever runs on the observation frame. Operationally: computable from the timestamp alone → `feature_transformer`; needs an external table → `X_future`.

### Routing

- Decision table now asks whether an external table is needed, not whether the value is knowable.
- Explanation states why the channel exists, the clock-vs-event split, and that `HolidayFeatureTransformer` on `X_actual` (past holiday effects) and a holiday calendar via `X_future` (future ones) are complementary, not alternatives.
- `make_exogenous_regression` gets a real irregular calendar. Its dates span 5 weekdays, so `is_holiday` is genuinely not clock-derivable.

### Guards

- **Rank diagnostic** at fit: warns when an `X_future` column's step expansion is rank deficient. Uses rank rather than pairwise correlation, because Fourier step blocks are *rotations*, not copies — a pairwise test sees nothing while the block spans 2 of 24 dimensions. Validated against all three regimes: zero false positives on genuine event calendars, one known miss (`cal_month`, wasteful but full-rank). It reports the measurement rather than asserting a cause, since a constant column is rank deficient without being a clock feature. It never mutates the feature matrix.
- **`step_feature_alignment` hygiene**: it was silently inert unless `reduction_strategy="direct"`. `multi-output` (the default) *cannot* filter — one estimator reads a different step column per output. `dir-rec` *could* but does not; that scope decision is now recorded rather than left to be inferred. `ForecastedFeatureForecaster`'s docstrings promised the knob works for its default `multi-output` target; now qualified.
- **`stacklevel` fix**: the shipped `X_forecast` coverage warning used a constant `stacklevel=5`, which pointed at `sklearn/base.py` from `fit` and overshot the caller from `predict`. fit/observe/predict reach the warn site at depths 6/5/4, so no constant can serve all three (`skip_file_prefixes` would, but needs Python 3.12 and we support 3.11). It is now measured by walking out to the first frame outside yohou and sklearn.
- **Wide `X_future` coverage**: 5 columns × 48 steps = 240 step columns, asserting `matched` drops the right 235.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

**Test results.** `just test-fast`: 4798 passed. The 5 notebook timeouts it reports (`choose_forecasting_method`, `advanced_imputation`, `multi_vintage_forecasting`, `exogenous_features`, `step_feature_alignment`) **reproduce identically on clean `main`** (baseline: 4777 passed, same 5 timeouts) and are unrelated to this change — two of them do not touch any code here. They are timing-dependent; a clean isolated run of all notebook tests passes 49/49.

Separately, the whole suite was run with both new warnings promoted to errors: **5458 passed, zero failures**, confirming no existing test routes a clock feature through `X_future` or sets an inapplicable alignment.

**This is deliberately user-visible.** Pipelines that route clock features through `X_future` will now warn. That is the intent.

**Behaviour deliberately unchanged.** No edits to `_derive_step_columns`, `window_futures`, `_filter_step_features`, or any forecaster's arithmetic. Step expansion is correct for the payloads the channel is actually for; the guards only report.

**Example outputs shift.** The generator change moves `make_exogenous_regression`'s data, so the tutorial's MAE figures are updated (2.40 → 1.32 with weather). Notebooks are re-exported; no test asserted the old Sunday semantics.

**Rejected, recorded so it is not relitigated:** a per-column expansion opt-out; gating expansion on `reduction_strategy` (that would fix only `direct`, already provably clean via `matched`, and miss the default `multi-output`, which cannot filter); and auto-detecting and collapsing redundant columns — warn, never silently rewrite a user's feature matrix.
