### PR TITLE
fix(interval): observe similarity on the scored subset

### DIFF
--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -292,9 +292,21 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             # Drop vintage_time if present (conformity scorer expects time + value cols)
             y_pred_step = y_pred_step.drop("vintage_time", strict=False)
 
-            similarity_step.observe(y=y, y_pred=y_pred_step)
-
             conformity_scores_step = conformity_scorer_step.score(y, y_pred_step)
+
+            # Observe the similarity on the scored subset, the same alignment ``fit``
+            # performs. Scoring aligns y and y_pred by an inner join on time, so it
+            # can return fewer rows than it was given, and none at all for a step
+            # whose prediction reaches past the observed truth. Observing the full
+            # y_pred_step then grew the similarity's state faster than the conformity
+            # scores, and predict_interval later paired an N-weight array with fewer
+            # than N scores. A step that scored nothing observes nothing, so the two
+            # stay in step.
+            if conformity_scores_step.height > 0:
+                scored_times = conformity_scores_step.select("time")
+                y_pred_for_sim = y_pred_step.join(scored_times, on="time", how="semi")
+                similarity_step.observe(y=y, y_pred=y_pred_for_sim)
+
             conformity_scores_step = conformity_scores_step.with_columns(step=step)
             self.conformity_scores_ = pl.concat([self.conformity_scores_, conformity_scores_step])
 

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -823,3 +823,55 @@ class TestSplitConformalObservePredict:
         y_pred = scf.observe_predict(y=y_test, stride=1)
         assert isinstance(y_pred, pl.DataFrame)
         assert len(y_pred) >= 1
+
+
+class TestSimilarityStaysAlignedWithConformityScores:
+    """Similarity state and conformity scores must grow together across observe.
+
+    ``fit`` deliberately fits the similarity on the scored subset, because scoring
+    aligns y and y_pred by an inner join on time and so can return fewer rows than
+    it was given. ``observe`` did not repeat that alignment, so the similarity grew
+    faster than the scores and ``predict_interval`` later paired an N-weight array
+    with N-1 scores, raising "x and weights must have the same length".
+    """
+
+    @staticmethod
+    def _fitted(horizon: int):
+        n = 260
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        rng = np.random.default_rng(7)
+        values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + rng.normal(0, 0.5) for i in range(n)]
+        y = pl.DataFrame({"time": dates, "value": values})
+
+        scf = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            similarity=DistanceSimilarity(metric="euclidean"),
+        )
+        scf.fit(y[:200], forecasting_horizon=horizon, coverage_rates=[0.9])
+        return scf, y[200:]
+
+    @pytest.mark.parametrize("horizon", [1, 2])
+    def test_state_lengths_track_each_other(self, horizon):
+        scf, y_rest = self._fitted(horizon)
+
+        for i in range(10):
+            scf.observe(y_rest[i : i + 1])
+
+        for step in range(1, 1 + horizon):
+            n_weights = len(scf.similarities_[f"step_{step}"]._X_observed)
+            n_scores = scf.conformity_scores_.filter(pl.col("step") == step).height
+            assert n_weights == n_scores, (
+                f"step {step}: similarity holds {n_weights} observations but "
+                f"{n_scores} conformity scores exist; predict_interval pairs these"
+            )
+
+    @pytest.mark.parametrize("horizon", [1, 2])
+    def test_predict_interval_after_observe_does_not_raise(self, horizon):
+        scf, y_rest = self._fitted(horizon)
+
+        for i in range(10):
+            scf.observe(y_rest[i : i + 1])
+
+        scf.predict_interval(forecasting_horizon=horizon, coverage_rates=[0.9])


### PR DESCRIPTION
## Description

`fit` fits each step's similarity on the conformity-scored subset, with the comment "Fit similarity on the same scored subset to ensure length alignment". `_observe_conformity` did not repeat that alignment, so the similarity's state and the conformity scores drifted apart and `predict_interval` later paired mismatched arrays.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Scoring is not length preserving: `validate_scorer_data` aligns `y` and `y_pred` by an inner join on time, keeping common time points only. `_observe_conformity` observed the full `y_pred_step` and scored separately, so any observe where scoring dropped a row grew the similarity without growing the scores.

`predict_interval` pairs the two per step, so the drift surfaced far from its cause:

```
ValueError: x and weights must have the same length, got 699 and 700
```

The extreme case is a step whose prediction reaches past the observed truth. With `forecasting_horizon=2` and a one-row observe, `score()` returns **zero** rows for step 2 while the similarity still records an observation, so the two diverge by one on every call.

Scoring now happens first and the similarity is observed on the scored times only. A step that scored nothing observes nothing, which keeps the two in lockstep and also avoids joining against the null-typed `time` column an empty score frame carries.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

`TestSimilarityStaysAlignedWithConformityScores` adds two tests, parametrised over horizon 1 and 2: one asserting the per-step state lengths track each other, one asserting `predict_interval` does not raise after a sequence of observes. On `main` they reproduce the reported failure directly (`step 2: similarity holds 59 observations but 49 conformity scores exist`, then `x and weights must have the same length, got 49 and 59`).

Verified: the full suite passes (5613 passed, 16 skipped, 2 xfailed), `just fix` and `just lint` clean.

One design question this surfaces, worth a second opinion rather than assuming: with the fix, a step whose predictions reach past the observed truth accumulates no conformity scores during streaming observes, so `predict_interval` for that step relies on fit-time calibration alone. That is self-consistent and follows from the scoring semantics, but if those steps were meant to calibrate incrementally then the real fix is in when truth becomes available to score, and this change would be hiding that.