### PR TITLE
fix(exogenous): verify and report X_forecast coverage

### DIFF
--- a/docs/pages/explanation/exogenous-features.md
+++ b/docs/pages/explanation/exogenous-features.md
@@ -363,7 +363,12 @@ All composition forecasters propagate the three parameters to their children:
   each pass all three parameters to every ensemble member.
 
 - [**`SplitConformalForecaster`**](/pages/api/generated/yohou.interval.SplitConformalForecaster/) forwards all parameters to the wrapped point
-  forecaster.
+  forecaster. It declares no transformer slots of its own, so the inner
+  forecaster's slots are the configuration surface: reach them through the nested
+  path, as in `point_forecaster__forecast_transformer`. Configuring the transform
+  there rather than outside the forecaster keeps it tunable through search and
+  applied consistently across fit, calibration, and prediction, since all three go
+  through the same inner.
 
 ## Connections
 

--- a/docs/pages/how-to/exogenous-features.md
+++ b/docs/pages/how-to/exogenous-features.md
@@ -363,13 +363,29 @@ pred = restored.predict(X_forecast=new_vintage)
   present at `predict()` time with the same names.
 
 **Problem: `UserWarning` about X_forecast covering fewer steps than the horizon**
-: The forecast vintage covers fewer future timestamps than `forecasting_horizon`.
-  This is normal for short-range forecasts or when the observation point has
-  advanced past some forecast timestamps (e.g., after `observe()`). The missing
-  step columns are filled with null. Tree-based estimators (XGBoost, LightGBM,
-  HistGradientBoosting) handle null features natively. For estimators that do
-  not support nulls, set `nan_handling="drop"` so null rows are excluded from
-  training, or provide forecasts with full horizon coverage.
+: The forecast vintage covers fewer future timestamps than `forecasting_horizon`,
+  so the uncovered step columns are filled with null. This arises for short-range
+  forecasts, and after `observe()` when the observation point has advanced past
+  some forecast timestamps. If the covered steps are the ones your model relies
+  on, this is workable: for estimators that do not accept nulls, set
+  `nan_handling="drop"` to exclude null rows from training, or supply forecasts
+  that reach the full horizon.
+
+**Problem: `UserWarning` that X_forecast covers 0 steps**
+: A different condition, and not a degree of the one above. No step column derived
+  from `X_forecast` carries a value, so a model fitted on those features is
+  predicting without them.
+
+  A vintage covers only the `forecasting_horizon` timestamps after its own
+  `vintage_time`, and step columns come from the newest vintage at or before each
+  observation point, so coverage falls by one step per interval of age and reaches
+  zero once the newest usable vintage is a full horizon old.
+
+  The usual cause is a cached frame that has been outrun: omitting `X_forecast` at
+  `observe()` or `predict()` reuses the frame cached at `fit()`, which works until
+  serving passes the vintages it holds. Supply a current `X_forecast` rather than
+  reaching for a null-tolerant estimator; tolerating the nulls removes the error
+  without restoring the information.
 
 ## See Also
 

--- a/docs/pages/how-to/transform-forecast-features.md
+++ b/docs/pages/how-to/transform-forecast-features.md
@@ -142,6 +142,23 @@ Each slot takes the kind it is named for. A forecast-kind transformer belongs in
     `forecast_transformer__transformer__lag` in a search, the nearest-term steps
     are what you trade away.
 
+!!! warning "A stale frame stops covering any step at all"
+
+    A vintage carries only the `forecasting_horizon` timestamps that follow its own
+    `vintage_time`, and step columns are derived by taking the newest vintage at or
+    before each observation point. So a vintage loses one usable step per interval
+    of age, and covers nothing once it is a full horizon old.
+
+    This is reachable without passing a bad frame. If you omit `X_forecast` at
+    `observe` or `predict`, the forecaster reuses the frame it cached at fit, which
+    is convenient while that frame still reaches ahead of the observation point and
+    silent once it does not. Every step feature is then null and the model predicts
+    without the channel it was fitted on.
+
+    Fit emits a distinct warning naming this case, separate from the one for merely
+    partial coverage. Treat it as a signal that the forecast frame needs refreshing
+    rather than as routine.
+
 ## Related
 
 - [How to Work with Forecast Vintages](forecast-vintages.md)

--- a/src/yohou/base/utils.py
+++ b/src/yohou/base/utils.py
@@ -697,14 +697,31 @@ def _derive_step_columns(
                 if null_count < n_rows:
                     per_col_max[base] = max(per_col_max[base], int(m.group(2)))
             max_covered = min(per_col_max.values(), default=0)
-            if max_covered < forecasting_horizon:
+            if max_covered == 0:
+                # Distinct from partial coverage rather than its extreme: nothing
+                # derived from X_forecast carries a value here, so a model relying
+                # on that channel is predicting without it. Reachable from ordinary
+                # use, because a vintage covers only the forecasting_horizon
+                # timestamps after its own vintage_time, so as-of selection yields
+                # zero coverage once the observation point is a full horizon past
+                # the newest available vintage. Stated as a measurement rather than
+                # an error: a caller may reach this deliberately.
+                warnings.warn(
+                    f"X_forecast covers 0 of {forecasting_horizon} forecast steps for this "
+                    f"observation, so every step feature derived from it is null. A model "
+                    f"fitted on those features is predicting without them here. This happens "
+                    f"when the newest usable vintage is at least {forecasting_horizon} "
+                    f"intervals older than the observation point, which a cached frame "
+                    f"reaches once serving advances past the vintages it holds.",
+                    UserWarning,
+                    stacklevel=_caller_stacklevel(),
+                )
+            elif max_covered < forecasting_horizon:
                 warnings.warn(
                     f"X_forecast covers {max_covered} of {forecasting_horizon} "
                     f"forecast steps. The remaining step features will be null. "
-                    f"This is normal for short-range forecasts or when the "
-                    f"observation point has advanced past some forecast "
-                    f"timestamps. Tree-based estimators (e.g. XGBoost, LightGBM, "
-                    f"HistGradientBoosting) handle null features natively.",
+                    f"This arises for short-range forecasts and when the "
+                    f"observation point has advanced past some forecast timestamps.",
                     UserWarning,
                     stacklevel=_caller_stacklevel(),
                 )

--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -141,7 +141,9 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             values available for past and future dates.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"``
-            columns.
+            columns. Passed to the wrapped ``point_forecaster_``; any
+            feature transformation is the responsibility of that inner
+            estimator, reachable as ``point_forecaster__forecast_transformer``.
         **params : dict
             Metadata to route to nested estimators.
 
@@ -375,7 +377,9 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             Known future features with a ``"time"`` column.
         X_forecast : pl.DataFrame or None, default=None
             External forecasts with ``"vintage_time"`` and ``"time"``
-            columns.
+            columns. Passed to the wrapped ``point_forecaster_``; any
+            feature transformation is the responsibility of that inner
+            estimator, reachable as ``point_forecaster__forecast_transformer``.
 
         Returns
         -------

--- a/tests/base/test_step_expansion_diagnostics.py
+++ b/tests/base/test_step_expansion_diagnostics.py
@@ -220,3 +220,151 @@ class TestDiagnosticDoesNotMutate:
         for col in ("f_sin", "f_cos"):
             for step in range(1, H + 1):
                 assert f"{col}_step_{step}" in forecaster._step_column_names_
+
+
+def _zero_coverage_warnings(record):
+    """Select the dead-channel warnings out of a warning record."""
+    return [w for w in record if "covers 0 of" in str(w.message)]
+
+
+def _partial_coverage_warnings(record):
+    """Select the partial-coverage warnings, excluding the dead-channel ones."""
+    return [w for w in record if "X_forecast covers" in str(w.message) and "covers 0 of" not in str(w.message)]
+
+
+class TestForecastCoverageDiagnostic:
+    """A dead forecast channel reads differently from a short-range one.
+
+    Zero coverage is not the extreme of partial coverage. Under partial coverage
+    some step features carry values; at zero every one is null and a model fitted
+    on them is predicting without them. Sharing a message would train readers to
+    ignore both.
+    """
+
+    HORIZON = 3
+
+    @staticmethod
+    def _y(n: int = 40) -> pl.DataFrame:
+        time = pl.datetime_range(
+            datetime(2021, 1, 1), datetime(2021, 1, 1) + timedelta(days=n - 1), interval="1d", eager=True
+        )
+        return pl.DataFrame({"time": time, "value": np.arange(n, dtype=float)})
+
+    @classmethod
+    def _forecast(cls, n_vintages: int, span: int | None = None) -> pl.DataFrame:
+        """Vintages issued daily, each carrying ``span`` steps of its own future."""
+        span = cls.HORIZON if span is None else span
+        rows = []
+        for i in range(n_vintages):
+            vintage = datetime(2021, 1, 1) + timedelta(days=i)
+            for step in range(1, span + 1):
+                rows.append({
+                    "vintage_time": vintage,
+                    "time": vintage + timedelta(days=step),
+                    "temp": float(i + step),
+                })
+        return pl.DataFrame(rows)
+
+    def _fitted(self, n_vintages: int, span: int | None = None):
+        forecaster = PointReductionForecaster(estimator=DummyRegressor(), nan_handling="pass")
+        with _captured_warnings():
+            forecaster.fit(y=self._y(), forecasting_horizon=self.HORIZON, X_forecast=self._forecast(n_vintages, span))
+        return forecaster
+
+    def test_exhausted_cache_reports_a_dead_channel(self):
+        """Driven the way a caller reaches it: serving past the vintages held.
+
+        No ``X_forecast`` is passed at observe, so the forecaster falls back to its
+        cached frame. Once the observation point is a full horizon past the newest
+        cached vintage, as-of selection resolves to a vintage that covers nothing.
+        """
+        forecaster = self._fitted(n_vintages=20)
+
+        later = pl.DataFrame({
+            "time": pl.datetime_range(
+                datetime(2021, 1, 21) + timedelta(days=self.HORIZON),
+                datetime(2021, 1, 21) + timedelta(days=self.HORIZON + 1),
+                interval="1d",
+                eager=True,
+            ),
+            "value": np.arange(2, dtype=float),
+        })
+        with _captured_warnings() as record:
+            forecaster.observe(y=later)
+
+        assert _zero_coverage_warnings(record), "expected the dead-channel warning"
+        assert not _partial_coverage_warnings(record)
+
+    def test_partial_coverage_keeps_its_own_message(self):
+        """A vintage that carries fewer steps than the horizon is short-range, not dead."""
+        forecaster = PointReductionForecaster(estimator=DummyRegressor(), nan_handling="pass")
+        with _captured_warnings() as record:
+            forecaster.fit(y=self._y(), forecasting_horizon=self.HORIZON, X_forecast=self._forecast(20, span=2))
+
+        assert _partial_coverage_warnings(record), "expected the partial-coverage warning"
+        assert not _zero_coverage_warnings(record)
+
+    def test_full_coverage_is_silent(self):
+        """Neither message fires when every step is covered."""
+        forecaster = PointReductionForecaster(estimator=DummyRegressor(), nan_handling="pass")
+        with _captured_warnings() as record:
+            forecaster.fit(y=self._y(), forecasting_horizon=self.HORIZON, X_forecast=self._forecast(20))
+
+        assert not _zero_coverage_warnings(record)
+        assert not _partial_coverage_warnings(record)
+
+    @pytest.mark.parametrize("span", [2, 3])
+    def test_no_coverage_message_recommends_an_estimator_or_asserts_normality(self, span):
+        """The message reports a measurement; it does not prescribe a remedy.
+
+        A null-tolerant estimator makes a dead channel survivable rather than
+        correct, so naming one directs a reader from a visible failure toward an
+        invisible one. And the same measurement has several causes, only some of
+        which are routine, so the warn site cannot call it normal.
+        """
+        forecaster = PointReductionForecaster(estimator=DummyRegressor(), nan_handling="pass")
+        with _captured_warnings() as record:
+            forecaster.fit(y=self._y(), forecasting_horizon=self.HORIZON, X_forecast=self._forecast(20, span=span))
+            later = pl.DataFrame({
+                "time": pl.datetime_range(datetime(2021, 2, 1), datetime(2021, 2, 2), interval="1d", eager=True),
+                "value": np.arange(2, dtype=float),
+            })
+            forecaster.observe(y=later)
+
+        messages = [str(w.message) for w in record if "X_forecast covers" in str(w.message)]
+        assert messages, "expected at least one coverage warning to inspect"
+        for message in messages:
+            for estimator in ("XGBoost", "LightGBM", "HistGradientBoosting", "estimator"):
+                assert estimator not in message, f"message recommends {estimator}: {message}"
+            assert "is normal" not in message, f"message asserts normality: {message}"
+
+    @pytest.mark.parametrize("age", [1, 2, 3, 4])
+    def test_coverage_falls_one_step_per_interval_of_age(self, age):
+        """The bound this change relies on: coverage reaches zero at age == horizon.
+
+        A vintage carries the ``forecasting_horizon`` timestamps after its own
+        ``vintage_time``, so an observation ``age`` intervals later retains
+        ``horizon - age`` of them. That is why no staleness parameter is needed.
+        """
+        forecaster = self._fitted(n_vintages=20)
+        newest_vintage = datetime(2021, 1, 1) + timedelta(days=19)
+
+        later = pl.DataFrame({
+            "time": pl.datetime_range(
+                newest_vintage + timedelta(days=age),
+                newest_vintage + timedelta(days=age),
+                interval="1d",
+                eager=True,
+            ),
+            "value": np.zeros(1),
+        })
+        with _captured_warnings() as record:
+            forecaster.observe(y=later)
+
+        expected_covered = max(self.HORIZON - age, 0)
+        if expected_covered == 0:
+            assert _zero_coverage_warnings(record), f"age={age} should exhaust coverage"
+        else:
+            partial = _partial_coverage_warnings(record)
+            assert partial, f"age={age} should report partial coverage"
+            assert f"covers {expected_covered} of {self.HORIZON}" in str(partial[0].message)

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -468,19 +468,43 @@ class TestSplitConformalSystematicChecks:
 
     @pytest.mark.slow
     def test_split_conformal_systematic_checks(self, y_X_factory):
-        """Run all standard forecaster checks on SplitConformalForecaster."""
-        y, _ = y_X_factory(length=200, n_targets=1, n_features=0, seed=42)
+        """Run all standard forecaster checks on SplitConformalForecaster.
+
+        ``X_forecast`` is supplied because the generator gates a block of checks on
+        its presence. Passing ``None`` yields a strictly smaller suite and reports
+        nothing, so the run would pass while the checks covering this forecaster's
+        heaviest input channel never executed.
+        """
+        y, _, _, X_forecast = y_X_factory(
+            length=200,
+            n_targets=1,
+            n_features=0,
+            seed=42,
+            n_forecast_features=2,
+            return_exogenous=True,
+        )
         y_train, y_test = y[:180], y[180:]
 
         forecaster = SplitConformalForecaster(
             point_forecaster=SeasonalNaive(seasonality=7),
             calibration_size=50,
         )
-        forecaster.fit(y_train, forecasting_horizon=5)
+        # Fit with X_forecast: the step-column checks require a forecaster that
+        # derived step columns at fit, as check_observe_auto_rederives_step_columns
+        # documents in its parameter description.
+        forecaster.fit(y_train, forecasting_horizon=5, X_forecast=X_forecast)
 
         run_checks(
             forecaster,
-            _yield_yohou_forecaster_checks(forecaster, y_train, None, y_test, None),
+            _yield_yohou_forecaster_checks(
+                forecaster,
+                y_train,
+                None,
+                y_test,
+                None,
+                X_forecast_train=X_forecast,
+                X_forecast_test=X_forecast,
+            ),
             expected_failures=set(),
         )
 
@@ -823,3 +847,110 @@ class TestSplitConformalObservePredict:
         y_pred = scf.observe_predict(y=y_test, stride=1)
         assert isinstance(y_pred, pl.DataFrame)
         assert len(y_pred) >= 1
+
+
+class TestSplitConformalTransformerRouting:
+    """Configuration reaches this forecaster through its inner, not through slots of its own.
+
+    These assertions are deliberately ad-hoc rather than generic checks: they name
+    ``point_forecaster__``, which the shared suite cannot express because it knows
+    nothing about a meta's parameter names.
+    """
+
+    @staticmethod
+    def _x_forecast(n: int = 60, n_steps: int = 3) -> pl.DataFrame:
+        rows = []
+        for i in range(n):
+            vintage = datetime(2024, 1, 1) + timedelta(days=i)
+            for step in range(1, n_steps + 1):
+                rows.append({
+                    "vintage_time": vintage,
+                    "time": vintage + timedelta(days=step),
+                    "load": float(i + step),
+                })
+        return pl.DataFrame(rows)
+
+    @staticmethod
+    def _y(n: int = 60) -> pl.DataFrame:
+        times = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n)]
+        return pl.DataFrame({"time": times, "value": [float(i % 7) + i * 0.1 for i in range(n)]})
+
+    def test_predict_returns_the_inner_forecasters_frame(self):
+        """The meta's point prediction is the inner's.
+
+        Asserted on the returned frames rather than by counting calls, so the test
+        pins the delegation itself and survives any refactor that preserves it.
+        Interval bounds are excluded on purpose: those are computed on the meta from
+        its conformity scorers, so the meta is not a pure pass-through.
+        """
+        forecaster = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=20,
+        )
+        forecaster.fit(self._y(), forecasting_horizon=3)
+
+        from_meta = forecaster.predict(forecasting_horizon=3)
+        from_inner = forecaster.point_forecaster_.predict(forecasting_horizon=3)
+
+        assert from_meta.equals(from_inner)
+
+    def test_slots_are_reachable_only_through_the_inner(self):
+        """The meta declares no slot; the inner's are reachable by nested path.
+
+        The default ``SeasonalNaive`` fixes both slots to ``None`` without exposing
+        them, so a slot-declaring inner is required for the nested paths to resolve.
+        """
+        from sklearn.linear_model import LinearRegression
+
+        from yohou.point import PointReductionForecaster
+
+        forecaster = SplitConformalForecaster(
+            point_forecaster=PointReductionForecaster(LinearRegression()),
+            calibration_size=20,
+        )
+        params = forecaster.get_params()
+
+        assert "point_forecaster__forecast_transformer" in params
+        assert "point_forecaster__actual_transformer" in params
+        assert "forecast_transformer" not in params
+        assert "actual_transformer" not in params
+
+    def test_nested_forecast_transformer_path_is_tunable(self):
+        """A search reaches the inner's slot through the nested path.
+
+        ``cv_results_`` carries the grid and ``best_forecaster_`` the refit winner;
+        it exposes no fitted forecaster per candidate, since only the best estimator
+        is refitted.
+        """
+        from sklearn.linear_model import LinearRegression
+
+        from yohou.compose import PerVintageActualTransformer
+        from yohou.metrics import MeanAbsoluteError
+        from yohou.model_selection import GridSearchCV
+        from yohou.point import PointReductionForecaster
+        from yohou.preprocessing import FunctionTransformer
+
+        def _scaled(factor: float) -> PerVintageActualTransformer:
+            # Stateless on purpose. A lifted lag consumes rows from the start of
+            # every vintage, which leaves the nearest step columns null for every
+            # row and fails the estimator before the grid can be compared. That
+            # hazard is real but belongs to the transformer tests, not here.
+            return PerVintageActualTransformer(
+                FunctionTransformer(
+                    func=lambda df, f=factor: df.select((pl.col("load") * f).alias("scaled")),
+                    feature_names_out=lambda self, names: ["scaled"],
+                )
+            )
+
+        inner = PointReductionForecaster(LinearRegression(), reduction_strategy="direct")
+        search = GridSearchCV(
+            forecaster=SplitConformalForecaster(point_forecaster=inner, calibration_size=15),
+            param_grid={"point_forecaster__forecast_transformer": [_scaled(1.0), _scaled(2.0)]},
+            scoring=MeanAbsoluteError(),
+            cv=2,
+        )
+        search.fit(self._y(), forecasting_horizon=3, X_forecast=self._x_forecast())
+
+        assert len(search.cv_results_["params"]) == 2
+        best_slot = search.best_forecaster_.point_forecaster_.forecast_transformer_
+        assert best_slot is not None


### PR DESCRIPTION
## Description

Runs the `X_forecast` generic checks for `SplitConformalForecaster`, which had been silently skipped, and reports a forecast channel covering zero steps distinctly from one merely covering fewer than the horizon.

Two commits, independently reviewable. No behaviour change: the only `src` edits are a docstring and the text and branching of a `UserWarning`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): test coverage for a check block that was never yielded

## Motivation and Context

The systematic-check call passed `None` for both forecast frames, and the generator gates a block of checks on their presence, so five checks never ran for the library's heaviest `X_forecast` consumer. A check that is never yielded is never reported, so the suite passed while the gap stayed invisible.

Separately, when `X_forecast` resolves to a vintage too old to cover any step, every step feature is null and the model predicts without the channel it was fitted on. The only diagnostic opened with "This is normal" and recommended the estimator class that hides the symptom. Measured on `v0.1.0-alpha.11`, a conformal forecaster served without a fresh frame returned 6.3% empirical coverage against a nominal 90%, at unchanged interval width.

No linked issue; found while investigating `SplitConformalForecaster`'s transformer slots.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

- This PR deliberately adds one new `UserWarning`, for the zero-coverage case. That is its purpose, not an unintended side effect.
- `just fix` and `just lint` both report 7 pre-existing `MD057` issues in untracked `.claude/skills/` directories. Neither is touched by this PR, and both tools are clean for every file that is.
- Full fast suite: 4887 passed, 0 failures.
- The zero-coverage bound needs no new parameter. A vintage carries only the `forecasting_horizon` timestamps after its own `vintage_time`, so usable coverage falls one step per interval of age and reaches zero at the horizon; `max_covered` already measures it. A parametrized test pins that ramp.