### PR TITLE
chore: update from template v0.28.4 and fix stale pre-commit docs

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: c3f6fcf8b6f2ce00e96ae5b918cff755cda0a545
+_commit: d6d0e8260d71339ffe46610d42b2ee4e5061ca93
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 git clone <repo-url>
 cd <project-dir>
 uv sync --group dev
-uv run prek install
+uv run prek install -f
 just test-fast
 ```
 

--- a/docs/pages/how-to/contributing.md
+++ b/docs/pages/how-to/contributing.md
@@ -32,10 +32,10 @@ cd yohou
 uv sync --group dev
 ```
 
-4. Install pre-commit hooks:
+4. Install the git hooks:
 
 ```bash
-uv run pre-commit install
+uv run prek install -f
 ```
 
 ## Development Workflow
@@ -99,7 +99,7 @@ git add .
 git commit -m "feat: add my feature"
 ```
 
-We follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages. The commit message format is enforced by commitizen pre-commit hooks, which will validate your commit messages automatically. See [Commit Message Convention](#commit-message-convention) below for the full list of types and examples.
+We follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages. The commit message format is enforced by commitizen's commit-msg hook, which will validate your commit messages automatically. See [Commit Message Convention](#commit-message-convention) below for the full list of types and examples.
 
 ### Running Tests
 
@@ -237,7 +237,7 @@ Run all quality checks by combining the fix and test steps above:
 === "uv run"
 
     ```bash
-    uvx pre-commit run --all-files --show-diff-on-failure && uv run pytest
+    uv run prek run --all-files --show-diff-on-failure && uv run pytest
     ```
 
 ### Docstring Standards
@@ -515,7 +515,7 @@ feat: redesign authentication system
 BREAKING CHANGE: authentication now requires API keys instead of passwords
 ```
 
-The pre-commit hook will validate your commit messages and prevent commits that don't follow the convention.
+The commit-msg hook will validate your commit messages and prevent commits that don't follow the convention.
 
 ## Release Process
 

--- a/docs/pages/how-to/installation.md
+++ b/docs/pages/how-to/installation.md
@@ -77,7 +77,7 @@ To contribute to Yohou or install from source:
     ```bash
     git clone https://github.com/stateful-y/yohou.git
     cd yohou
-    just install  # Installs dev dependencies + pre-commit hooks
+    just install  # Installs dev dependencies + git hooks
     ```
 
 === "uv"
@@ -86,7 +86,7 @@ To contribute to Yohou or install from source:
     git clone https://github.com/stateful-y/yohou.git
     cd yohou
     uv sync --group dev
-    uv run pre-commit install
+    uv run prek install -f
     ```
 
 ## Optional Packages

--- a/justfile
+++ b/justfile
@@ -7,7 +7,11 @@ default:
 # Install dependencies and git hooks
 install:
     uv sync --group dev
-    uv run prek install
+    # -f matters: without it prek finds a pre-v0.27.0 shim, moves it to
+    # `.git/hooks/pre-commit.legacy` and CHAINS it -- both hooks then run on
+    # every commit. `-f` overwrites instead. Measured; the migration notice
+    # prek prints names this flag, and this is the command people actually run.
+    uv run prek install -f
 
 # Run tests and doctests with parallel execution
 test:


### PR DESCRIPTION
Updates the template from **v0.28.3** to **v0.28.4** (`d6d0e8260d71339ffe46610d42b2ee4e5061ca93`).

The release changes `uv run prek install` → `uv run prek install -f`. Without `-f`, prek finds a pre-v0.27.0 shim, moves it to `.git/hooks/pre-commit.legacy` and **chains** it, so both hooks run on every commit; `-f` overwrites instead. `just install` is what people actually run, so this makes the routine path self-healing.

## Files changed: 2 of the release's 3

| file | change |
|---|---|
| `justfile` | `-f` plus a 4-line explanatory comment |
| `CONTRIBUTING.md` | `-f` |
| ~~`docs/pages/how-to/contribute.md`~~ | **does not exist here** — inert |

This repo deleted the seed how-tos for its 36 curated ones, so the third file is genuinely inert. Worth stating explicitly: the update **did not resurrect it**. That file is not `_skip_if_exists`-listed, so copier's "does not recreate a locally-deleted file" behaviour held — the resurrection hazard that has fired on skip-listed pages did not apply.

Every actionable `prek install` in the repo now carries `-f`. The one remaining occurrence without it is prose inside a `.pre-commit-config.yaml` comment, correctly untouched.

## The forked justfile survived

This is the fleet's only forked `justfile` — it carries a local `export-notebooks` recipe — and this release edits that file, so it was the whole risk surface here.

- **Whole-file diff is the template's change and nothing else**: one hunk at line 10.
- **Recipe set identical before → after: 20 recipes**, parsed rather than eyeballed, with `export-notebooks` present in both.
- The recipe body is **byte-identical** to the pre-update copy.
- `just --list` parses the file and reports all 20 recipes — a real parse, stronger than a regex.
- The justfile's **only** remaining delta against a pristine `copier copy --vcs-ref v0.28.4` is that same 4-line block, so nothing else drifted.

No `.rej` or `.orig` anywhere in the working tree, and `git status --porcelain` showed no `U`/`AA`/`DD` states.

## Unchanged, re-confirmed

No code or config moved in this release, so the API surface could not change — confirmed rather than assumed:

- **364 symbols, 364-entry name lookup**, byte-identical as *whole dictionaries* to the v0.28.3 measurement, not merely equal in count.
- `docs/_api_pages.py` and `docs/hooks.py`: untouched by this release.
- `nox -s check_docs`: **0 warnings**, 0 `could not be resolved`, 364 API member pages.
- `git diff --stat -- docs/assets`: **empty**; all 7 sha256s still match the original pre-v0.28.2 baseline.
- `.github/workflows/`: byte-identical. `mkdocs.yml`: untouched.
- Every prek hook passes, including `ruff` — `Lint and format` stays green.

## Two notes on the local `export-notebooks` recipe

Neither is a defect and neither is changed here, but both are worth recording:

1. **It works.** `on_pre_build(config)` never reads `config` — it derives `project_root` from `__file__` — so passing `None` is fine.
2. **It does more than its name says.** Since v0.27.2 split the build steps out, `on_pre_build` runs `_api_pages.generate()` *and* `_notebooks.export()`, so a recipe named "export notebooks" also regenerates the API pages. The hook itself is honestly documented — its docstring reads "Generate API submodule pages and export marimo notebooks" — so it is only the recipe name that is narrow. The tighter call would be `from _notebooks import export; export(project_root)`.

Left as-is: it is a local file, it behaves correctly, and narrowing it is unrelated to this release.

---

# Second commit: the stale `pre-commit` docs, corrected

Verifying the `-f` change surfaced a real bug in this repo's curated how-tos, and the user authorised fixing it here.

**Two pages told contributors to run `uv run pre-commit install`.** That command cannot work: `pre-commit` is not a dependency (0 entries in `uv.lock`; the project depends on `prek`). And where it does find a stray `pre-commit` on `PATH`, it installs precisely the legacy shim that v0.28.4's `prek install -f` exists to overwrite — so the documentation steered contributors into the exact broken state the first commit clears.

These are curated local pages, so the edits are **minimal — tool names and commands only**. No page restructured, no steps renumbered.

| site | before | after |
|---|---|---|
| `contributing.md:35` | "Install pre-commit hooks:" | "Install the git hooks:" |
| `contributing.md:38` | `uv run pre-commit install` | `uv run prek install -f` |
| `contributing.md:102` | "commitizen pre-commit hooks" | "commitizen's commit-msg hook" |
| `contributing.md:240` | `uvx pre-commit run …` | `uv run prek run …` |
| `contributing.md:518` | "The pre-commit hook" | "The commit-msg hook" |
| `installation.md:80` | "+ pre-commit hooks" | "+ git hooks" |
| `installation.md:89` | `uv run pre-commit install` | `uv run prek install -f` |

Commands match the template's own wording at v0.28.4: `uv run prek install -f`, and `uv run prek run --all-files --show-diff-on-failure` — which is exactly what `just fix` runs.

**The two commit-message lines were wrong about the hook type, not just the tool.** commitizen is registered `stages: [commit-msg]`, which is why the config sets `default_install_hook_types: [pre-commit, commit-msg]`. So "the pre-commit hook will validate your commit messages" named the wrong tool *and* the wrong hook. Both now say commit-msg. This was flagged as a judgement call; the config settles it.

## Deliberately left alone

`pre-commit` is correct where it names the **config file**, the **git hook type**, or the **legacy hook path** — not the tool. Untouched: `.pre-commit-config.yaml` and its comments, `default_install_hook_types: [pre-commit, commit-msg]`, the `justfile`'s `.git/hooks/pre-commit.legacy` reference (template-owned), and the CHANGELOG's historical entries.

## Verification

- **Zero remaining invocations of the `pre-commit` tool** in tracked files, and zero in the rendered site.
- Swept rendered HTML with `get_text()`, not raw grep. This mattered: on the edited installation page, `prek install -f` is **not contiguous in raw source** — Pygments splits it across spans — so a raw grep would have reported the fix missing. Verified present via `get_text()`.
- Both sweeps carry controls and abort rather than report a clean pass: a positive control finds the 3 rendered `prek` invocations, and an injected `pre-commit install` was caught and then removed.
- `nox -s check_docs`: **0 warnings**, links resolve, `#commit-message-convention` target still exists, all three edited sentences confirmed in rendered output.
- Every prek hook passes, `rumdl` included.
- The v0.28.4 template changes in the first commit are **untouched** — `justfile`, `CONTRIBUTING.md` and `.copier-answers.yml` are unchanged by this commit.
