### PR TITLE
chore(deps): update from template v0.29.5

### DIFF
--- a/.claude/skills/diataxis-reference-writer/SKILL.md
+++ b/.claude/skills/diataxis-reference-writer/SKILL.md
@@ -124,6 +124,25 @@ def process(data: list[float], *, normalize: bool = False) -> Result:
     """
 ```
 
+### References and Citations
+
+Write a `References` section as a **markdown ordered list with markdown links**, and cite it in prose with a plain `[1]`. Do **not** use reStructuredText/Sphinx citation syntax — `.. [1]` definitions or `[1]_` references. griffe hands the References section to mkdocstrings as raw text, so RST renders literally on the page (`.. [1]` appears verbatim) instead of as a citation. See `src/<package>/hello.py` for a worked example.
+
+```python
+def estimate(...):
+    """Estimate the thing.
+
+    The method follows the standard approach [1] with the correction from [2].
+
+    References
+    ----------
+    1. [Author, A. (2019). Title of the work.](https://doi.org/10.1000/xyz):
+        the method this implements.
+    2. [Author, B. (2023). A follow-up.](https://doi.org/10.1000/abc):
+        the correction applied here.
+    """
+```
+
 ### MkDocs Page Using mkdocstrings
 
 ```markdown

--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -48,6 +48,7 @@ docs_build/_markdown_export.py       # build step imported by build.py; same tie
 docs_build/_notebooks.py             # build step imported by build.py; examples-only
 docs_build/serve.py                  # live-preview supervisor; watches src/ and regenerates API pages
 docs_build/_see_also.py              # griffe extension; rewrites numpydoc See Also into cross-references
+docs_build/_references.py            # griffe extension; normalizes numpydoc References into a markdown ordered list
 docs_build/_source_links.py           # griffe extension; attaches View-on-GitHub URLs for the Source Code heading
 docs_build/_markers.py               # python-markdown extension; resolves the docs markers (API_TABLE, SUBPAGES, gallery, companion)
 docs_build/_glossary.py              # python-markdown extension; links glossary terms to their definitions at markdown level

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 37b2b10091e4c49ee0ff467f464eb705eb1325f2
+_commit: 92dbdabbfeb727659aae5777eaf26b755d07b1d9
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 92dbdabbfeb727659aae5777eaf26b755d07b1d9
+_commit: a327e3f6ffbbfd9c938e70dcd44d72dcdaf9272e
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,21 @@ repos:
         exclude: .*_version\.py$
         require_serial: true
 
+      # Ban reStructuredText citation syntax in docstrings. numpydoc "References"
+      # sections must use a markdown ordered list with plain `[1]` prose citations,
+      # never RST (`.. [1]` definitions or `[1]_` references) -- griffe hands the
+      # section to mkdocstrings as raw text, so RST renders literally on the API
+      # page. The docs build normalizes it anyway, but catching it at author time
+      # keeps the source clean. `pygrep` is built into prek, so this adds no
+      # dependency; it fails when either form matches.
+      - id: no-rst-citations
+        name: no reStructuredText citation syntax in docstrings
+        description: Use a markdown ordered list and plain `[1]` citations, not RST `.. [1]` / `[1]_`.
+        language: pygrep
+        entry: '(^\s*\.\. \[|\[[^]]+\]_)'
+        types: [python]
+        files: ^src/
+
       # Ruff linter (autofix)
       - id: ruff
         name: ruff

--- a/docs_build/_references.py
+++ b/docs_build/_references.py
@@ -1,0 +1,137 @@
+"""Griffe extension: normalize numpydoc "References" into a markdown list.
+
+This runs during Griffe collection, before mkdocstrings parses the docstring, so a
+References section written in any of the three styles seen across the fleet --
+reStructuredText citation definitions (`.. [1] ...`), bare-bracket entries
+(`[1] ...`), or an already-markdown ordered list (`1. ...`) -- renders as one
+clean markdown ordered list. It is the twin of `_see_also.py`: Griffe's numpy
+parser hands a References section to mkdocstrings as an unstructured *admonition*
+whose raw text is passed straight to `convert_markdown`, so RST citation syntax
+renders literally (`.. [1]` appears verbatim on the page) and a bare-bracket block
+collapses into one run-on paragraph. Rewriting the raw docstring here fixes both,
+independent of when and how the docstring is later parsed, and under any engine.
+
+Registered via `handlers.python.options.extensions` in mkdocs.yml, next to
+`_see_also`. Unlike See Also, References entries are freeform citations that name
+no project symbols, so this extension needs no name lookup -- it only reshapes
+text.
+
+The render target is a markdown ordered list, NOT markdown footnotes (`[^1]`):
+mkdocstrings pools footnotes at the *page* bottom and their numbers collide across
+the many objects rendered on one API page, so a list -- which stays inside each
+object's own section -- is the portable form. `hello.py` in the template models it.
+"""
+
+import logging
+import re
+
+from griffe import Extension
+
+# Warnings logged under the "mkdocs" logger tree are counted by mkdocs and turn a
+# --strict build red -- the same idiom `_markers` and `_api_pages` use. A References
+# section that still holds RST citation syntax after this pass would otherwise ship
+# as literal text on the page; warning here makes that a build failure instead.
+log = logging.getLogger("mkdocs.hooks")
+
+# The "References" section heading: a line, then an underline of dashes at the same
+# indent (numpydoc requires the underline to be at least as long as the title).
+_HEADING = re.compile(r"(?m)^(?P<indent>[ \t]*)References[ \t]*\n(?P=indent)-{3,}[ \t]*\n")
+
+# The start of the NEXT numpydoc section: a non-blank title line followed by a
+# dashes-only underline. This -- not the first blank line, which is where See Also
+# stops -- is where a References block ends, because references are routinely
+# separated by blank lines; stopping at the first one would drop every entry after
+# it. A reference entry's continuation lines are never a dashes-only line, so this
+# cannot mistake an entry for a section header.
+_NEXT_SECTION = re.compile(r"(?m)^[ \t]*\S.*\n[ \t]*-{3,}[ \t]*$")
+
+# A leading markdown list marker (`- `, `* `, `+ `, `1. `) on an entry line. Some
+# docstrings already write References as a list; stripping the marker before we
+# re-number stops `1. X` becoming `1. 1. X` (or `- X` a nested `1. - X`).
+_LIST_MARKER = re.compile(r"^(?:\d+\.|[-*+])\s+")
+
+# A leading citation label: the RST definition form (`.. [1] `, `.. [CIT2002] `) or
+# the bare-bracket form (`[1] `). The bare form requires whitespace after the `]` so
+# a markdown link at the start of an entry (`[Title](url)`) is left untouched -- its
+# `]` is followed by `(`, not a space.
+_CITATION = re.compile(r"^\.\. \[[^\]]+\]\s*|^\[[^\]]+\]\s+")
+
+# An inline citation *reference* in RST style: `[1]_`, `[CIT2002]_`. Rewritten to
+# plain `[1]` so no trailing-underscore reference survives into rendered prose.
+_BODY_CITE = re.compile(r"\[([^\]]+)\]_")
+
+# Whatever the RST citation-definition marker looks like after normalization has run.
+# If it survives, an entry could not be reshaped and the page would show it literally.
+_RESIDUAL_RST = ".. ["
+
+
+class ReferencesExtension(Extension):
+    """Rewrite numpydoc References blocks into a markdown ordered list at collection."""
+
+    def on_object(self, *, obj, **_kwargs) -> None:
+        """Rewrite the References block of any object whose docstring has one."""
+        docstring = obj.docstring
+        if docstring is None or "References" not in docstring.value:
+            return
+        rewritten = self._rewrite(docstring.value, obj.path)
+        # Inline `[1]_` references point at a References entry, so only rewrite them
+        # where a References section exists -- conservative, and there are none in
+        # the fleet today anyway.
+        rewritten = _BODY_CITE.sub(r"[\1]", rewritten)
+        if rewritten != docstring.value:
+            docstring.value = rewritten
+
+    def _rewrite(self, text: str, path: str) -> str:
+        """Replace a References block's entries with a markdown ordered list."""
+        heading = _HEADING.search(text)
+        if heading is None:
+            return text
+
+        body_start = heading.end()
+        rest = text[body_start:]
+        # The block runs to the next section header, or to the end of the docstring.
+        next_section = _NEXT_SECTION.search(rest)
+        body_end = body_start + (next_section.start() if next_section else len(rest))
+
+        entries = self._split_entries(text[body_start:body_end])
+        if not entries:
+            return text
+
+        block = "".join(f"{i}. {entry}\n" for i, entry in enumerate(entries, start=1))
+        if _RESIDUAL_RST in block:
+            # An entry held RST citation syntax the marker strip did not reach (a
+            # second directive, a directive on a continuation line). Left alone it
+            # renders verbatim; under --strict this warning fails the build.
+            log.warning("references: RST citation syntax survived normalization in %s", path)
+
+        return text[:body_start] + block + text[body_end:]
+
+    def _split_entries(self, body: str) -> list[str]:
+        """Group the block's lines into entries and strip each entry's marker.
+
+        numpydoc puts each reference at the section's base indent and indents any
+        wrapped continuation beneath it; entries may be separated by blank lines.
+        A line at (or below) the first entry's indent starts a new entry; a
+        more-indented line continues the one above. Each entry's leading list
+        marker and citation label are stripped, so the caller can re-number from 1
+        without doubling markers.
+        """
+        entries: list[list[str]] = []
+        base_indent: int | None = None
+        for line in body.splitlines():
+            if not line.strip():
+                continue
+            indent = len(line) - len(line.lstrip())
+            if base_indent is None:
+                base_indent = indent
+            stripped = line.strip()
+            if not entries or indent <= base_indent:
+                entries.append([self._strip_marker(stripped)])
+            else:
+                entries[-1].append(stripped)
+        return [" ".join(parts).strip() for parts in entries]
+
+    def _strip_marker(self, line: str) -> str:
+        """Remove a leading list marker and citation label from an entry's first line."""
+        line = _LIST_MARKER.sub("", line, count=1)
+        return _CITATION.sub("", line, count=1)

--- a/docs_build/_references.py
+++ b/docs_build/_references.py
@@ -109,27 +109,30 @@ class ReferencesExtension(Extension):
     def _split_entries(self, body: str) -> list[str]:
         """Group the block's lines into entries and strip each entry's marker.
 
-        numpydoc puts each reference at the section's base indent and indents any
-        wrapped continuation beneath it; entries may be separated by blank lines.
-        A line at (or below) the first entry's indent starts a new entry; a
-        more-indented line continues the one above. Each entry's leading list
-        marker and citation label are stripped, so the caller can re-number from 1
-        without doubling markers.
+        A new reference begins at a citation marker (`[1]`, `.. [1]`) or a list
+        marker (`1.`, `-`); every other line continues the entry above it. This is
+        keyed on the marker, NOT on indentation: numpydoc *recommends* indenting a
+        wrapped continuation, but many docstrings write the continuation flush with
+        the marker line, and splitting those by indent turned one citation into one
+        list item per physical line. Marker-keyed splitting folds a flush-left
+        multi-line citation into a single entry and still separates blank-line- or
+        indent-separated entries correctly. Each entry's leading marker is stripped
+        so the caller can re-number from 1 without doubling markers.
         """
         entries: list[list[str]] = []
-        base_indent: int | None = None
         for line in body.splitlines():
             if not line.strip():
                 continue
-            indent = len(line) - len(line.lstrip())
-            if base_indent is None:
-                base_indent = indent
             stripped = line.strip()
-            if not entries or indent <= base_indent:
+            if not entries or self._starts_entry(stripped):
                 entries.append([self._strip_marker(stripped)])
             else:
                 entries[-1].append(stripped)
         return [" ".join(parts).strip() for parts in entries]
+
+    def _starts_entry(self, line: str) -> bool:
+        """Whether a (stripped) line begins a new reference: it leads with a marker."""
+        return bool(_LIST_MARKER.match(line) or _CITATION.match(line))
 
     def _strip_marker(self, line: str) -> str:
         """Remove a leading list marker and citation label from an entry's first line."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -215,9 +215,13 @@ plugins:
             # Griffe extensions run during collection. `_see_also` rewrites
             # numpydoc "See Also" blocks into markdown cross-references before the
             # docstring is rendered, so autorefs links them -- replacing the HTML
-            # post-processing the docs hooks used to do.
+            # post-processing the docs hooks used to do. `_references` is its twin
+            # for the "References" section: it normalizes RST citation syntax
+            # (`.. [1]`) and bare-bracket entries into a markdown ordered list, so
+            # neither renders as literal text or a run-on paragraph.
             extensions:
               - docs_build/_see_also.py
+              - docs_build/_references.py
               - docs_build/_source_links.py
             docstring_style: numpy
             show_source: true


### PR DESCRIPTION
## Template sync: v0.29.3 → v0.29.4

Routine template update from `stateful-y/python-package-copier` **v0.29.3 → v0.29.4**. The headline of v0.29.4 is the **References-rendering fix**: a new griffe extension (`docs_build/_references.py`) normalizes numpydoc `References` sections (RST `.. [1]` citation syntax and bare-bracket entries) into a markdown ordered list, so they no longer render as literal text or a run-on paragraph. A companion `no-rst-citations` pre-commit hook bans RST citation syntax in `src/` docstrings at author time.

### Changed files (exactly the template delta — full-diff review requested)
- **NEW** `docs_build/_references.py` — griffe extension (Tier 1, template-owned; byte-identical to template source)
- `mkdocs.yml` — registers `- docs_build/_references.py` under mkdocstrings `python.options.extensions` (next to `_see_also.py`); no nav change
- `.pre-commit-config.yaml` — adds the `no-rst-citations` pygrep hook
- `.claude/skills/diataxis-reference-writer/SKILL.md` — adds a References/Citations section
- `.claude/skills/update-from-template/references/file-classification.md` — classifies the new extension file
- `.copier-answers.yml` — `_commit` bump

(The `.github/skills/*` Copilot mirrors are gitignored in this repo; copier refreshes them on disk but git does not track them — expected.)

### Verification
- `copier update`: no `.rej`, no conflicts; `docs/assets` untouched (`git diff --stat -- docs/assets` empty).
- Nav leaf counts unchanged (Tutorials 14, How-to 36, Explanation 21, Reference 22; Reference stays last).
- `uvx nox -s check_docs` (mkdocs `--strict`) passed with **0 warnings**.
- Rendered site: **0** literal `.. [` RST citations (detector falsified — an injected `.. [1]` is caught); all **19** `References` admonitions render as `<ol>` (e.g. `yohou.interval.DistanceSimilarity`, `yohou.weighting.ExponentialDecayWeighter`); **0** broken See Also autorefs.
- `ruff` (yohou's `D` docstring rules apply to `docs_build/`) passes on `_references.py`; full `prek run --all-files` green.
