### PR TITLE
fix(ci): export notebooks via docs_build/_notebooks.py, not the removed hooks module

### DIFF
--- a/.github/workflows/export-notebooks.yml
+++ b/.github/workflows/export-notebooks.yml
@@ -31,12 +31,7 @@ jobs:
         run: timeout 120 uv run python docs/precache_datasets.py || echo "Dataset precache timed out"
 
       - name: Export notebooks
-        run: |
-          uv run python -c "
-          import sys; sys.path.insert(0, 'docs')
-          from hooks import on_pre_build
-          on_pre_build(None)
-          "
+        run: uv run python docs_build/_notebooks.py
 
       - name: Package notebook cache
         run: tar czf notebook-exports.tar.gz -C docs/examples .


### PR DESCRIPTION
## Problem

The **Export Notebooks** workflow (`.github/workflows/export-notebooks.yml`) still ran:

```
uv run python -c "
import sys; sys.path.insert(0, 'docs')
from hooks import on_pre_build
on_pre_build(None)
"
```

`docs/hooks.py` was removed when the build tooling moved to `docs_build/` (template v0.20.0), so this step fails with `ModuleNotFoundError: No module named 'hooks'` on every run — e.g. [run 30078080988](https://github.com/stateful-y/yohou/actions/runs/30078080988/job/89433183004). It triggers on any PR/push touching `src/yohou/**` or `examples/**`.

This is pre-existing local drift: `export-notebooks.yml` is yohou-specific (not shipped by the template — verified), so no `copier update` ever touched it, and it was never updated when the hooks module was retired.

## Fix

Call the current notebook-export entry point — `docs_build/_notebooks.py`, whose `main()` runs `export(repo_root)` into `docs/examples/`, exactly what the old `on_pre_build(None)` did. Same invocation `noxfile.py` uses. One line; it's the only stale `hooks` reference in the repo (swept).