### PR TITLE
fix(ci): pin exact uv version in setup-uv steps

### DIFF
--- a/.claude/skills/update-from-template/SKILL.md
+++ b/.claude/skills/update-from-template/SKILL.md
@@ -179,6 +179,26 @@ without it. Anyone who skips this keeps invoking a runner that can no longer par
 they get a confusing failure rather than a clean one. Tell every contributor, not just
 whoever ran the update.
 
+### Pin uv in workflows the template does not own
+
+`copier update` only touches files the template generates. The templated workflows
+(`tests.yml`, `changelog.yml`, `nightly.yml`, `commit-message.yml`) pin an exact uv
+version on every `astral-sh/setup-uv` step:
+
+```yaml
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.0"   # exact X.Y.Z, not "latest" or a range
+          # ...existing enable-cache / cache-dependency-glob stay as they are
+```
+
+An unpinned step resolves "latest" over the network on every run, and a transient
+blip there fails the job in a fraction of a second with `##[error]fetch failed`,
+before any real work. **Any workflow you added yourself** (anything not in the list
+above) keeps its own `astral-sh/setup-uv` steps, and the update leaves them untouched.
+After syncing, add the same exact `version:` pin to those steps by hand, matching the
+value the templated workflows now use, so the flake cannot reach your bespoke CI either.
+
 ```bash
 git add -A
 git commit -m "chore: update from template <version>"

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: a327e3f6ffbbfd9c938e70dcd44d72dcdaf9272e
+_commit: dbde7ae7632a1bb5a2018c882863ce35fcbd4a39
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin
@@ -15,3 +15,4 @@ min_python_version: '3.11'
 package_name: yohou
 project_name: Yohou
 project_slug: yohou
+uv_version: '0.10.0'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.0"
 
       - name: Run hooks on generated CHANGELOG
         run: |
@@ -103,6 +105,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.0"
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 

--- a/.github/workflows/export-notebooks.yml
+++ b/.github/workflows/export-notebooks.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.0"
 
       - name: Install dependencies
         run: uv sync --group docs --extra plotting

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 

--- a/.github/workflows/regenerate-datasets.yml
+++ b/.github/workflows/regenerate-datasets.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -69,6 +70,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -104,6 +106,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -149,6 +152,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -176,6 +180,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -202,6 +207,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -255,6 +261,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 


### PR DESCRIPTION
## Template update v0.29.5 -> v0.29.6

Pins an exact uv version on every `astral-sh/setup-uv` step so a transient
"latest" resolution flake cannot fail CI.

### Pins applied (`version: "0.10.0"`, 14 steps total)
**Copier-pinned (templated workflows, 11 steps):**
- `tests.yml` — 7 steps (test-fast, test-compat, test-full, lint, test_docstrings, check_docs, examples)
- `changelog.yml` — 2 steps (changelog, build)
- `commit-message.yml` — 1 step
- `nightly.yml` — 1 step

**Hand-pinned (bespoke workflows the template does not own, 3 steps):**
- `examples.yml` — 1 step
- `export-notebooks.yml` — 1 step (added `with:` block, previously bare)
- `regenerate-datasets.yml` — 1 step

### Bespoke-audit result
Walked every `.github/workflows/*.yml` with PyYAML: **14 setup-uv steps, 0 unpinned** after resolution.
`publish-release.yml` and `pr-title.yml` contain no setup-uv steps.

### Recorded
- `.copier-answers.yml`: `uv_version: '0.10.0'`, `_commit` -> `dbde7ae` (v0.29.6)
- `update-from-template/SKILL.md`: added "Pin uv in workflows the template does not own" section
- No changes to `docs/`, `mkdocs.yml`, `src/`, or binaries. No `.rej` conflicts.

**Held for review — do NOT merge.**
