### PR TITLE
feat(preprocessing): add DaylightSavingFeatureTransformer

### DIFF
--- a/docs/pages/api/preprocessing.md
+++ b/docs/pages/api/preprocessing.md
@@ -11,6 +11,7 @@ Preprocessing transformers for stationarization and feature engineering.
 | Name | Description |
 |------|-------------|
 | [`CalendarFeatureTransformer`](generated/yohou.preprocessing.CalendarFeatureTransformer.md) | Extract calendar-based features from the time column. |
+| [`DaylightSavingFeatureTransformer`](generated/yohou.preprocessing.DaylightSavingFeatureTransformer.md) | Deterministic daylight-saving-time features from the time column. |
 | [`HolidayFeatureTransformer`](generated/yohou.preprocessing.HolidayFeatureTransformer.md) | Extract holiday indicator features from a user-provided holiday calendar. |
 | [`FunctionTransformer`](generated/yohou.preprocessing.FunctionTransformer.md) | Constructs a transformer from an arbitrary callable. |
 | [`SeasonalImputer`](generated/yohou.preprocessing.SeasonalImputer.md) | Seasonal decomposition-based imputation for missing values. |

--- a/docs/pages/how-to/time-features.md
+++ b/docs/pages/how-to/time-features.md
@@ -83,7 +83,7 @@ X = transformer.fit_transform(y)
 # Output columns: dst_in_effect, dst_transition_day
 ```
 
-The `time_zone` parameter names the market/observing zone, not the input's zone. Pass `features=["in_effect", "transition_day", "transition_type"]` to also emit a signed flag (`+1` on a spring-forward date, `-1` on a fall-back date). `in_effect` requires sub-daily data and is dropped on daily-or-coarser frequencies; `transition_day`/`transition_type` apply at any frequency. The `"time"` column must be timezone-aware (a naive datetime or a `Date` is rejected at fit, since an offset needs both an instant and a zone).
+The `time_zone` parameter names the zone whose daylight-saving regime is evaluated, not the input's zone. Pass `features=["in_effect", "transition_day", "transition_type"]` to also emit a signed flag (`+1` on a spring-forward date, `-1` on a fall-back date). `in_effect` requires sub-daily data and is dropped on daily-or-coarser frequencies; `transition_day`/`transition_type` apply at any frequency. The `"time"` column must be timezone-aware (a naive datetime or a `Date` is rejected at fit, since an offset needs both an instant and a zone).
 
 ## Create a Trend Index
 

--- a/docs/pages/how-to/time-features.md
+++ b/docs/pages/how-to/time-features.md
@@ -69,6 +69,22 @@ X = transformer.fit_transform(y)
 
 Set `seasonality` to the period length in time steps (e.g., `24` for daily cycles in hourly data, `365.25` for yearly cycles in daily data). Use more harmonics for sharper seasonal shapes, fewer for smoother patterns. Harmonics must satisfy the Nyquist limit: each harmonic $k$ must be at most $S/2$ where $S$ is the seasonality.
 
+## Flag Daylight-Saving Transitions
+
+[`DaylightSavingFeatureTransformer`](/pages/api/generated/yohou.preprocessing.DaylightSavingFeatureTransformer/) captures the two daylight-saving effects a UTC-indexed frame cannot see: the summer/winter clock offset (which shifts the local diurnal cycle by an hour) and the 23- or 25-hour transition days:
+
+```python
+from yohou.preprocessing import DaylightSavingFeatureTransformer
+
+# The "time" column must be timezone-aware; time_zone is the zone whose
+# daylight-saving regime is evaluated (any input zone is converted into it).
+transformer = DaylightSavingFeatureTransformer(time_zone="America/Chicago")
+X = transformer.fit_transform(y)
+# Output columns: dst_in_effect, dst_transition_day
+```
+
+The `time_zone` parameter names the market/observing zone, not the input's zone. Pass `features=["in_effect", "transition_day", "transition_type"]` to also emit a signed flag (`+1` on a spring-forward date, `-1` on a fall-back date). `in_effect` requires sub-daily data and is dropped on daily-or-coarser frequencies; `transition_day`/`transition_type` apply at any frequency. The `"time"` column must be timezone-aware (a naive datetime or a `Date` is rejected at fit, since an offset needs both an instant and a zone).
+
 ## Create a Trend Index
 
 [`TimeIndexTransformer`](/pages/api/generated/yohou.preprocessing.TimeIndexTransformer/) converts timestamps to a numeric index, useful for capturing linear or polynomial trends:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "scikit-learn>=1.6.0",
     "sklearn-wrap",
     "scipy>=1.13",
-    "polars>=0.20",
+    "polars>=1.39.2",
     "pydantic>=2.6",
 ]
 

--- a/src/yohou/preprocessing/__init__.py
+++ b/src/yohou/preprocessing/__init__.py
@@ -1,6 +1,6 @@
 """Preprocessing transformers for stationarization and feature engineering."""
 
-from .calendar import CalendarFeatureTransformer, HolidayFeatureTransformer
+from .calendar import CalendarFeatureTransformer, DaylightSavingFeatureTransformer, HolidayFeatureTransformer
 from .function import FunctionTransformer
 from .imputation import (
     SeasonalImputer,
@@ -84,6 +84,7 @@ __all__ = [
     "OutlierPercentileHandler",
     # Calendar and time features
     "CalendarFeatureTransformer",
+    "DaylightSavingFeatureTransformer",
     "HolidayFeatureTransformer",
     "FourierFeatureTransformer",
     "TimeIndexTransformer",

--- a/src/yohou/preprocessing/calendar.py
+++ b/src/yohou/preprocessing/calendar.py
@@ -522,10 +522,10 @@ def _extract_dst_feature(feature: str, time_zone: str) -> pl.Expr:
 class DaylightSavingFeatureTransformer(BaseActualTransformer):
     r"""Deterministic daylight-saving-time features from the time column.
 
-    Markets that run on wall-clock time cross two kinds of daylight-saving boundary that a
+    A series whose local time observes daylight saving crosses two kinds of boundary that a
     UTC-indexed frame cannot see directly: the summer/winter clock offset, which shifts the
     UTC hour of the local diurnal cycle by one hour, and the two transition days a year,
-    which are 23- or 25-hour operating days with a skipped or repeated hour. Both are
+    which are 23- or 25-hour local days with a skipped or repeated hour. Both are
     deterministic and known for any future date, so they enter a model as unlagged,
     known-future features alongside the calendar terms. Output columns are prefixed with
     ``dst_``.

--- a/src/yohou/preprocessing/calendar.py
+++ b/src/yohou/preprocessing/calendar.py
@@ -1,10 +1,13 @@
 """Calendar and holiday feature transformers for time series."""
 
+from datetime import timedelta
+
 import numpy as np
 import polars as pl
 from sklearn.utils.validation import check_is_fitted
 
 from yohou.base import BaseActualTransformer
+from yohou.utils.validation import interval_to_timedelta
 
 ALL_FEATURES = (
     "year",
@@ -159,6 +162,7 @@ class CalendarFeatureTransformer(BaseActualTransformer):
     See Also
     --------
     - [`HolidayFeatureTransformer`][yohou.preprocessing.calendar.HolidayFeatureTransformer] : Binary holiday indicator from user-provided dates.
+    - [`DaylightSavingFeatureTransformer`][yohou.preprocessing.calendar.DaylightSavingFeatureTransformer] : Daylight-saving offset and transition-day features.
     - [`FourierFeatureTransformer`][yohou.preprocessing.time_features.FourierFeatureTransformer] : Sin/cos harmonics for cyclical encoding.
     - [`TimeIndexTransformer`][yohou.preprocessing.time_features.TimeIndexTransformer] : Numeric time index for trend features.
     - [`FunctionTransformer`][yohou.preprocessing.function.FunctionTransformer] : Custom function-based transforms.
@@ -299,6 +303,7 @@ class HolidayFeatureTransformer(BaseActualTransformer):
     See Also
     --------
     - [`CalendarFeatureTransformer`][yohou.preprocessing.calendar.CalendarFeatureTransformer] : Calendar features (month, day of week, etc.).
+    - [`DaylightSavingFeatureTransformer`][yohou.preprocessing.calendar.DaylightSavingFeatureTransformer] : Daylight-saving offset and transition-day features.
     - [`FourierFeatureTransformer`][yohou.preprocessing.time_features.FourierFeatureTransformer] : Sin/cos harmonics for cyclical encoding.
     - [`TimeIndexTransformer`][yohou.preprocessing.time_features.TimeIndexTransformer] : Numeric time index for trend features.
 
@@ -448,3 +453,203 @@ class HolidayFeatureTransformer(BaseActualTransformer):
         if self.days_since_last:
             generated.append(f"{self._PREFIX}_days_since_last")
         return generated
+
+
+DST_ALL_FEATURES = ("in_effect", "transition_day", "transition_type")
+DST_DEFAULT_FEATURES = ("in_effect", "transition_day")
+
+# ``in_effect`` reads the offset at an instant; on daily-or-coarser data there is no
+# single instant (it would be sampled at an arbitrary local midnight), so it is gated to
+# sub-daily data. ``transition_day``/``transition_type`` are date-level and apply at any
+# interval.
+DST_SUBDAILY_FEATURES = frozenset({"in_effect"})
+
+
+def _interval_is_subdaily(interval: str) -> bool:
+    """Return whether a detected time interval is finer than one day.
+
+    Parameters
+    ----------
+    interval : str
+        Detected time interval string (e.g., "1h", "1d", "1mo").
+
+    Returns
+    -------
+    bool
+        True for fixed sub-daily intervals; False for daily-or-coarser and for
+        variable intervals (e.g. "1mo", which has no fixed timedelta).
+
+    """
+    delta = interval_to_timedelta(interval)
+    return delta is not None and delta < timedelta(days=1)
+
+
+def _extract_dst_feature(feature: str, time_zone: str) -> pl.Expr:
+    """Build a polars expression for a daylight-saving feature in ``time_zone``.
+
+    Parameters
+    ----------
+    feature : str
+        Daylight-saving feature name.
+    time_zone : str
+        IANA zone in which the daylight-saving regime is evaluated. The ``"time"``
+        column is converted into it before the offset is read.
+
+    Returns
+    -------
+    pl.Expr
+        Expression that produces the ``dst_<feature>`` column.
+
+    """
+    local = pl.col("time").dt.convert_time_zone(time_zone)
+    if feature == "in_effect":
+        # Minutes of daylight-saving offset in effect: 0 in standard time, > 0 in DST.
+        return (local.dt.dst_offset().dt.total_minutes() != 0).cast(pl.Int32).alias("dst_in_effect")
+    # A local date is a transition date when its offset differs from the next date's,
+    # compared at each date's local midnight.
+    midnight = local.dt.truncate("1d")
+    dst_today = midnight.dt.dst_offset().dt.total_minutes()
+    dst_tomorrow = midnight.dt.offset_by("1d").dt.dst_offset().dt.total_minutes()
+    if feature == "transition_day":
+        return (dst_today != dst_tomorrow).cast(pl.Int32).alias("dst_transition_day")
+    if feature == "transition_type":
+        # Spring-forward gains the offset the next day (+1); fall-back loses it (-1).
+        return (dst_tomorrow - dst_today).sign().cast(pl.Int32).alias("dst_transition_type")
+    msg = f"Unknown feature: {feature}"
+    raise ValueError(msg)
+
+
+class DaylightSavingFeatureTransformer(BaseActualTransformer):
+    r"""Deterministic daylight-saving-time features from the time column.
+
+    Markets that run on wall-clock time cross two kinds of daylight-saving boundary that a
+    UTC-indexed frame cannot see directly: the summer/winter clock offset, which shifts the
+    UTC hour of the local diurnal cycle by one hour, and the two transition days a year,
+    which are 23- or 25-hour operating days with a skipped or repeated hour. Both are
+    deterministic and known for any future date, so they enter a model as unlagged,
+    known-future features alongside the calendar terms. Output columns are prefixed with
+    ``dst_``.
+
+    Daylight saving is evaluated in ``time_zone``: the ``"time"`` column (which must be
+    timezone-aware) is converted into that zone, then the offset is read there. The
+    parameter names the zone whose daylight-saving regime is evaluated, not an assertion
+    about the input's zone, so a UTC-indexed frame and a Central-indexed frame produce the
+    same features for the same instants.
+
+    For a timestamp $t$ with local daylight-saving offset $\delta(t)$ (in minutes, $0$ in
+    standard time), and $\delta_d$ the offset at the local midnight of date $d$:
+
+    $$\text{in\_effect}(t) = \mathbb{1}[\delta(t) \neq 0], \quad
+      \text{transition\_day}(d) = \mathbb{1}[\delta_d \neq \delta_{d+1}], \quad
+      \text{transition\_type}(d) = \operatorname{sign}(\delta_{d+1} - \delta_d)$$
+
+    Note that ``dst_transition_day`` is exactly ``dst_transition_type != 0``; both are
+    provided because a tree splits on them differently (the binary is a cleaner root split,
+    the signed carries the spring/fall direction).
+
+    Parameters
+    ----------
+    time_zone : str, default="America/Chicago"
+        IANA time zone in which daylight saving time is evaluated.
+    features : list of str or None, default=None
+        Which daylight-saving features to emit. If ``None``, emits every default feature
+        applicable to the detected time interval (``["in_effect", "transition_day"]``).
+        Valid options: ``"in_effect"``, ``"transition_day"``, ``"transition_type"``.
+
+    Attributes
+    ----------
+    applicable_features_ : list of str
+        The resolved feature list emitted during ``transform`` (after interval gating).
+
+    Raises
+    ------
+    ValueError
+        At fit time if the ``"time"`` column is not a timezone-aware ``pl.Datetime`` (a
+        timezone-naive datetime or a ``pl.Date`` has no well-defined offset); if any
+        requested feature name is unknown; if ``"in_effect"`` is explicitly requested on
+        data whose detected interval is daily or coarser; or if a generated ``dst_*``
+        column name conflicts with an existing column in ``X``.
+
+    See Also
+    --------
+    - [`CalendarFeatureTransformer`][yohou.preprocessing.calendar.CalendarFeatureTransformer] : Calendar features (month, day of week, etc.).
+    - [`HolidayFeatureTransformer`][yohou.preprocessing.calendar.HolidayFeatureTransformer] : Binary holiday indicator from user-provided dates.
+    - [`FourierFeatureTransformer`][yohou.preprocessing.time_features.FourierFeatureTransformer] : Sin/cos harmonics for cyclical encoding.
+
+    Examples
+    --------
+    >>> from datetime import datetime, timezone
+    >>> import polars as pl
+    >>> from yohou.preprocessing import DaylightSavingFeatureTransformer
+    >>> time = pl.datetime_range(
+    ...     datetime(2026, 3, 8, 6, tzinfo=timezone.utc),
+    ...     datetime(2026, 3, 8, 10, tzinfo=timezone.utc),
+    ...     interval="1h",
+    ...     eager=True,
+    ... )
+    >>> X = pl.DataFrame({"time": time})
+    >>> DaylightSavingFeatureTransformer().fit_transform(X)["dst_in_effect"].to_list()
+    [0, 0, 1, 1, 1]
+
+    """
+
+    _parameter_constraints: dict = {
+        "time_zone": [str],
+        "features": [list, None],
+    }
+
+    def __init__(self, time_zone: str = "America/Chicago", features: list[str] | None = None):
+        self.time_zone = time_zone
+        self.features = features
+
+    def _fit(self, X: pl.DataFrame, y: pl.DataFrame | None = None) -> None:
+        """Validate the input contract, resolve features (with interval gating), and check conflicts."""
+        dtype = X.schema["time"]
+        time_zone = dtype.time_zone if isinstance(dtype, pl.Datetime) else None
+        if time_zone is None:
+            raise ValueError(
+                "DaylightSavingFeatureTransformer requires a timezone-aware 'time' column "
+                "(a daylight-saving offset is undefined without an instant and a zone); "
+                f"got dtype {dtype}. Localize it first, e.g. dt.replace_time_zone('UTC')."
+            )
+
+        requested = list(self.features) if self.features is not None else list(DST_DEFAULT_FEATURES)
+        invalid = set(requested) - set(DST_ALL_FEATURES)
+        if invalid:
+            raise ValueError(f"Unknown DST features: {sorted(invalid)}. Valid features: {list(DST_ALL_FEATURES)}")
+
+        subdaily = _interval_is_subdaily(self.interval_)
+        gated = [f for f in requested if f in DST_SUBDAILY_FEATURES and not subdaily]
+        if self.features is not None and gated:
+            raise ValueError(
+                f"Features {gated} require sub-daily data, but the detected interval is "
+                f"'{self.interval_}'. These features need an instant, not just a date."
+            )
+        self.applicable_features_ = [f for f in requested if f not in gated]
+
+        generated = [f"dst_{f}" for f in self.applicable_features_]
+        conflicts = set(generated) & (set(X.columns) - {"time"})
+        if conflicts:
+            raise ValueError(f"Generated column names {sorted(conflicts)} conflict with existing columns in X.")
+
+    def _transform(self, X: pl.DataFrame) -> pl.DataFrame:
+        """Emit ``time`` plus the selected ``dst_*`` feature columns."""
+        exprs = [_extract_dst_feature(f, self.time_zone) for f in self.applicable_features_]
+        return X.select(pl.col("time"), *exprs)
+
+    def get_feature_names_out(self, input_features=None) -> list[str]:
+        """Return the selected ``dst_*`` feature-column names.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input feature names (unused, for API compatibility).
+
+        Returns
+        -------
+        list of str
+            Generated daylight-saving feature column names.
+
+        """
+        check_is_fitted(self, ["applicable_features_"])
+        return [f"dst_{f}" for f in self.applicable_features_]

--- a/src/yohou/preprocessing/time_features.py
+++ b/src/yohou/preprocessing/time_features.py
@@ -61,6 +61,7 @@ class FourierFeatureTransformer(BaseActualTransformer):
     --------
     - [`CalendarFeatureTransformer`][yohou.preprocessing.calendar.CalendarFeatureTransformer] : Calendar features (month, day of week, etc.).
     - [`HolidayFeatureTransformer`][yohou.preprocessing.calendar.HolidayFeatureTransformer] : Binary holiday indicator.
+    - [`DaylightSavingFeatureTransformer`][yohou.preprocessing.calendar.DaylightSavingFeatureTransformer] : Daylight-saving offset and transition-day features.
     - [`TimeIndexTransformer`][yohou.preprocessing.time_features.TimeIndexTransformer] : Numeric time index for trend features.
     - [`FourierSeasonalityForecaster`][yohou.stationarity.seasonality.FourierSeasonalityForecaster] : Forecaster-level Fourier seasonality.
 

--- a/tests/preprocessing/test_calendar.py
+++ b/tests/preprocessing/test_calendar.py
@@ -1,17 +1,22 @@
 """Tests for calendar and holiday feature transformers.
 
-Tests CalendarFeatureTransformer and HolidayFeatureTransformer using both
-the systematic check generator pattern and transformer-specific tests.
+Tests CalendarFeatureTransformer, HolidayFeatureTransformer, and
+DaylightSavingFeatureTransformer using both the systematic check generator
+pattern and transformer-specific tests.
 """
 
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 
 import polars as pl
 import pytest
 from sklearn.base import clone
 
 from conftest import run_checks
-from yohou.preprocessing.calendar import CalendarFeatureTransformer, HolidayFeatureTransformer
+from yohou.preprocessing.calendar import (
+    CalendarFeatureTransformer,
+    DaylightSavingFeatureTransformer,
+    HolidayFeatureTransformer,
+)
 from yohou.testing import _yield_yohou_transformer_checks
 
 
@@ -506,3 +511,177 @@ class TestHolidayFeatureTransformerEdgeCases:
 
         names = transformer.get_feature_names_out()
         assert names == ["holiday_indicator"]
+
+
+@pytest.fixture
+def spring_frame() -> pl.DataFrame:
+    """Hourly UTC frame spanning the 2026-03-08 US spring-forward (02:00 CST -> 03:00 CDT)."""
+    return pl.DataFrame({
+        "time": pl.datetime_range(
+            datetime(2026, 3, 6, tzinfo=UTC), datetime(2026, 3, 10, tzinfo=UTC), interval="1h", eager=True
+        )
+    })
+
+
+@pytest.fixture
+def fall_frame() -> pl.DataFrame:
+    """Hourly UTC frame spanning the 2026-11-01 US fall-back (02:00 CDT -> 01:00 CST)."""
+    return pl.DataFrame({
+        "time": pl.datetime_range(
+            datetime(2026, 10, 30, tzinfo=UTC), datetime(2026, 11, 3, tzinfo=UTC), interval="1h", eager=True
+        )
+    })
+
+
+def _row_at(out: pl.DataFrame, *cols: str, y: int, m: int, d: int, h: int) -> tuple:
+    return out.filter(pl.col("time") == datetime(y, m, d, h, tzinfo=UTC)).select(*cols).row(0)
+
+
+class TestDaylightSavingFeatureTransformerSystematic:
+    """Systematic check generator tests for DaylightSavingFeatureTransformer."""
+
+    @pytest.mark.parametrize(
+        "transformer,expected_failures",
+        [
+            (DaylightSavingFeatureTransformer(), []),
+            (DaylightSavingFeatureTransformer(features=["in_effect", "transition_day", "transition_type"]), []),
+        ],
+        ids=["default", "all_features"],
+    )
+    def test_systematic_checks(self, transformer, expected_failures, time_series_train_test_factory):
+        """Run all applicable checks for DaylightSavingFeatureTransformer."""
+        X_train, X_test = time_series_train_test_factory(train_length=60, test_length=30)
+        # The transformer requires a timezone-aware "time" column; the factory is tz-naive.
+        X_train = X_train.with_columns(pl.col("time").dt.replace_time_zone("UTC"))
+        X_test = X_test.with_columns(pl.col("time").dt.replace_time_zone("UTC"))
+
+        transformer_fitted = clone(transformer)
+        transformer_fitted.fit(X_train)
+
+        run_checks(
+            transformer_fitted,
+            _yield_yohou_transformer_checks(transformer_fitted, X_train, None, X_test),
+            expected_failures=set(expected_failures),
+        )
+
+
+class TestDaylightSavingFeatureTransformerFeatures:
+    """Feature-value tests for DaylightSavingFeatureTransformer."""
+
+    def test_in_effect_across_spring_forward(self):
+        """DST turns on at 03:00 CDT (08:00 UTC); the 02:00 local hour is skipped."""
+        times = pl.datetime_range(
+            datetime(2026, 3, 8, 6, tzinfo=UTC), datetime(2026, 3, 8, 10, tzinfo=UTC), interval="1h", eager=True
+        )
+        out = DaylightSavingFeatureTransformer(features=["in_effect"]).fit_transform(pl.DataFrame({"time": times}))
+        assert out["dst_in_effect"].to_list() == [0, 0, 1, 1, 1]
+
+    def test_transition_day_and_type_spring(self, spring_frame):
+        """The spring-forward local date is flagged (+1); neighbouring dates are not."""
+        out = DaylightSavingFeatureTransformer(features=["transition_day", "transition_type"]).fit_transform(
+            spring_frame
+        )
+        assert _row_at(out, "dst_transition_day", "dst_transition_type", y=2026, m=3, d=8, h=12) == (1, 1)
+        assert _row_at(out, "dst_transition_day", "dst_transition_type", y=2026, m=3, d=7, h=12) == (0, 0)
+        assert _row_at(out, "dst_transition_day", "dst_transition_type", y=2026, m=3, d=9, h=12) == (0, 0)
+
+    def test_transition_type_fall(self, fall_frame):
+        """The fall-back local date is flagged (-1); by noon UTC the clock has already fallen back to CST."""
+        out = DaylightSavingFeatureTransformer(
+            features=["in_effect", "transition_day", "transition_type"]
+        ).fit_transform(fall_frame)
+        assert _row_at(out, "dst_in_effect", "dst_transition_day", "dst_transition_type", y=2026, m=11, d=1, h=12) == (
+            0,
+            1,
+            -1,
+        )
+
+    def test_transition_day_equals_type_nonzero(self, spring_frame, fall_frame):
+        """dst_transition_day is exactly dst_transition_type != 0."""
+        for frame in (spring_frame, fall_frame):
+            out = DaylightSavingFeatureTransformer(features=["transition_day", "transition_type"]).fit_transform(frame)
+            expected = (out["dst_transition_type"] != 0).cast(pl.Int32)
+            assert out["dst_transition_day"].to_list() == expected.to_list()
+
+    def test_evaluation_zone_independent_of_input_zone(self):
+        """The same instants give the same features whether the input is UTC or Central."""
+        utc = pl.datetime_range(
+            datetime(2026, 3, 8, 6, tzinfo=UTC), datetime(2026, 3, 8, 10, tzinfo=UTC), interval="1h", eager=True
+        )
+        X_utc = pl.DataFrame({"time": utc})
+        X_central = pl.DataFrame({"time": utc.dt.convert_time_zone("America/Chicago")})
+        tx = DaylightSavingFeatureTransformer(features=["in_effect"])
+        assert (
+            tx.fit_transform(X_utc)["dst_in_effect"].to_list() == tx.fit_transform(X_central)["dst_in_effect"].to_list()
+        )
+
+    def test_default_features_and_contract(self, spring_frame):
+        """Default emits time + in_effect + transition_day, dropping input columns."""
+        tx = DaylightSavingFeatureTransformer()
+        out = tx.fit_transform(spring_frame)
+        assert out.columns == ["time", "dst_in_effect", "dst_transition_day"]
+        assert tx.applicable_features_ == ["in_effect", "transition_day"]
+        assert tx.get_feature_names_out() == ["dst_in_effect", "dst_transition_day"]
+
+
+class TestDaylightSavingFeatureTransformerContract:
+    """Input-contract and gating tests for DaylightSavingFeatureTransformer."""
+
+    def test_tz_naive_rejected(self):
+        """A timezone-naive time column raises at fit time."""
+        naive = pl.DataFrame({
+            "time": pl.datetime_range(datetime(2026, 3, 6), datetime(2026, 3, 10), interval="1h", eager=True)
+        })
+        with pytest.raises(ValueError, match="timezone-aware"):
+            DaylightSavingFeatureTransformer().fit(naive)
+
+    def test_date_dtype_rejected(self):
+        """A pl.Date time column raises at fit time (cannot be timezone-aware)."""
+        dates = pl.DataFrame({"time": pl.date_range(date(2026, 3, 1), date(2026, 3, 20), interval="1d", eager=True)})
+        with pytest.raises(ValueError, match="timezone-aware"):
+            DaylightSavingFeatureTransformer().fit(dates)
+
+    def test_in_effect_gated_on_daily_data(self):
+        """Explicit in_effect on daily data raises; the default drops it silently."""
+        daily = pl.DataFrame({
+            "time": pl.datetime_range(
+                datetime(2026, 3, 1, tzinfo=UTC), datetime(2026, 3, 20, tzinfo=UTC), interval="1d", eager=True
+            )
+        })
+        with pytest.raises(ValueError, match="sub-daily"):
+            DaylightSavingFeatureTransformer(features=["in_effect"]).fit(daily)
+
+        tx = DaylightSavingFeatureTransformer().fit(daily)
+        assert tx.applicable_features_ == ["transition_day"]
+        assert "dst_in_effect" not in tx.transform(daily).columns
+
+    def test_unknown_feature_raises(self, spring_frame):
+        """An unrecognized feature name raises at fit time."""
+        with pytest.raises(ValueError, match="Unknown DST features"):
+            DaylightSavingFeatureTransformer(features=["nope"]).fit(spring_frame)
+
+    def test_output_conflict_raises(self, spring_frame):
+        """A generated dst_* name colliding with an input column raises."""
+        clash = spring_frame.with_columns(pl.lit(0).alias("dst_in_effect"))
+        with pytest.raises(ValueError, match="conflict"):
+            DaylightSavingFeatureTransformer().fit(clash)
+
+    def test_feature_names_out_requires_fit(self):
+        """get_feature_names_out raises before fit."""
+        from sklearn.exceptions import NotFittedError
+
+        with pytest.raises(NotFittedError):
+            DaylightSavingFeatureTransformer().get_feature_names_out()
+
+    def test_composes_in_feature_union(self, spring_frame):
+        """The transformer composes inside a FeatureUnion alongside calendar features."""
+        from yohou.compose import FeatureUnion
+
+        union = FeatureUnion(
+            transformer_list=[
+                ("cal", CalendarFeatureTransformer(features=["hour"])),
+                ("dst", DaylightSavingFeatureTransformer(features=["in_effect"])),
+            ]
+        )
+        out = union.fit_transform(spring_frame)
+        assert any("dst_in_effect" in c for c in out.columns)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -55,6 +55,11 @@ _SKIP_COMMON = {
     "DistanceSimilarity",
     # Meta-forecasters requiring inner estimator (tested in tests/interval/)
     "SplitConformalForecaster",
+    # Requires a timezone-aware "time" column, which the common sweep's tz-naive
+    # fixture cannot provide (fit would just silently skip). The systematic
+    # check-generator sweep runs on tz-aware data in
+    # tests/preprocessing/test_calendar.py::TestDaylightSavingFeatureTransformerSystematic.
+    "DaylightSavingFeatureTransformer",
 }
 
 # Known check failures per estimator, covered by dedicated test files.

--- a/uv.lock
+++ b/uv.lock
@@ -3334,7 +3334,7 @@ requires-dist = [
     { name = "anywidget", marker = "extra == 'plotting'", specifier = ">=0.9" },
     { name = "plotly", marker = "extra == 'plotting'", specifier = ">=5.19" },
     { name = "plotly-resampler", marker = "extra == 'plotting'", specifier = ">=0.11" },
-    { name = "polars", specifier = ">=0.20" },
+    { name = "polars", specifier = ">=1.39.2" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pytz", marker = "extra == 'plotting'" },
     { name = "scikit-learn", specifier = ">=1.6.0" },


### PR DESCRIPTION
## Description

Add `DaylightSavingFeatureTransformer` to the calendar family
(`yohou.preprocessing.calendar`). It derives deterministic, known-future
daylight-saving features from the `time` column: `dst_in_effect`,
`dst_transition_day`, and `dst_transition_type` (23h/25h operating days).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Markets that run on wall-clock time cross two daylight-saving boundaries a
UTC-indexed frame cannot see directly: the summer/winter clock offset (which
shifts the UTC hour of the local diurnal cycle) and the two transition days a
year. Both are deterministic and known-future, so they belong beside the other
calendar-family feature transformers rather than in a downstream project.

Design highlights:

- Requires a timezone-aware `time` column; rejects tz-naive datetimes and
  `pl.Date` at fit time (a DST offset is undefined without an instant and a
  zone). The `time_zone` parameter is the **evaluation zone** whose DST regime
  is read, so input in any zone is converted into it.
- Gates `in_effect` to sub-daily data, mirroring how `CalendarFeatureTransformer`
  gates `hour`/`minute`; exposes `applicable_features_`.
- `dst_transition_day == (dst_transition_type != 0)`; both are emitted because a
  tree splits on them differently.
- Bumps the polars floor to `>=1.39.2` for `Expr.dt.dst_offset()`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Added to the `See Also` blocks of `CalendarFeatureTransformer`,
`HolidayFeatureTransformer`, and `FourierFeatureTransformer`, with a passing
doctest. Tests live in `tests/preprocessing/test_calendar.py` (behavior,
input-contract, gating, and systematic transformer checks).