### PR TITLE
feat(interval): add optional adaptive conformal inference adapter

### DIFF
--- a/.claude/skills/create-yohou-conformal-adapter/SKILL.md
+++ b/.claude/skills/create-yohou-conformal-adapter/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: create-yohou-conformal-adapter
+description: "Step-by-step guide for implementing new conformal adapters in Yohou, the estimator family that SplitConformalForecaster uses for adaptive conformal inference (online miscoverage-level adjustment). Covers the stateful BaseConformalAdapter lifecycle (fit/observe/predict/rewind), the (coverage_rate, tail) keying, the symmetric-vs-asymmetric level split, epsilon clipping, _parameter_constraints, and wiring into _yield_yohou_conformal_adapter_checks. Use when creating, extending, or testing any conformal adapter class."
+---
+
+# Creating New Conformal Adapters
+
+A conformal adapter maintains a time-varying effective miscoverage level and
+updates it online from realized coverage, so `SplitConformalForecaster`
+restores its target coverage under drift. It is an optional add-on: with
+`adapter=None` the forecaster uses the static calibrated level. An adapter is a
+stateful lifecycle estimator that mirrors the forecaster lifecycle: `fit`,
+`observe`, `predict`, `rewind`.
+
+The adapter is the level-recursion state machine only. It never sees the
+calibration scores or similarity weights; the forecaster holds those, computes
+the per-row miscoverage indicators, and feeds them in. This separation is what
+lets the adapter compose with `similarity` (the similarity sets the weights,
+the adapter sets the level).
+
+## Quick Decision Tree
+
+- **Vanilla single-rate online adjustment** -> use the shipped
+  `AdaptiveConformalInference`; do not write a new class.
+- **A genuinely new level-adaptation rule** (e.g. DtACI expert aggregation,
+  AgACI) -> extend `BaseConformalAdapter` in `src/yohou/interval/adapter.py`.
+
+Composition first, subclassing only for a novel rule.
+
+## The keying model (read this first)
+
+The forecaster clones **one adapter per horizon step** into a per-step dict
+`adapters_` (mirroring `similarities_`). Each clone owns one step. Inside its
+step the adapter is keyed by `(coverage_rate, tail)`:
+
+- **coverage rate**: one effective level per tracked rate, seeded at fit from
+  `1 - coverage_rate`. A rate depends on the requested interval, unlike a
+  similarity weight, so the rate dimension lives *inside* the adapter.
+- **tail**: for a **symmetric** conformity scorer, one level per rate (a float);
+  for an **asymmetric** scorer, two levels per rate (a `(lower, upper)` tuple),
+  each targeting `alpha/2`.
+
+`predict()` returns `{coverage_rate: level}` where `level` is a float
+(symmetric) or a `(lower, upper)` tuple (asymmetric). The forecaster reads the
+scorer's `symmetric` tag and passes it to `fit`.
+
+## The lifecycle contract
+
+- `fit(coverage_rates, *, symmetric)` -> seed one level per key; initialize a
+  bounded per-key history stack for rewind. Set fitted attributes ending in `_`.
+- `observe(errors)` -> `errors` is a **list of per-row dicts**; each dict maps a
+  coverage rate to its miscoverage signal (a float for symmetric, a
+  `(lower, upper)` tuple for asymmetric). Apply one update and push one history
+  entry **per row**, so rewind is row-exact. A row a step could not score
+  arrives as the zero-update sentinel (err equal to the target), which the
+  forecaster supplies; your update must be a no-op for it.
+- `predict()` -> current levels; call `check_is_fitted` first.
+- `rewind(n_rows)` -> pop `n_rows` history entries per key, never below the seed.
+
+## Read First (ground truth)
+
+- `src/yohou/interval/base.py` -> `BaseConformalAdapter`: the abstract methods
+  and the `estimator_type="conformal_adapter"` tags.
+- `src/yohou/interval/adapter.py` -> `AdaptiveConformalInference`: the full
+  Gibbs-Candes update, `alpha_pooling`, `epsilon` clipping, per-tail logic.
+- `src/yohou/interval/split_conformal.py` -> `_observe_adapter`,
+  `_rewind_adapter`, `_adapter_step_errors`, `_pool_adapter_errors`,
+  `_adapter_inverse_score`, and the `predict_interval` adapter branch: how the
+  forecaster drives the adapter and computes the indicators.
+- `tests/test_common.py` (`_conformal_adapter_instances`,
+  `TestConformalAdapterCommon`) and `tests/interval/test_adapter.py` for the
+  fixture and behavioral shapes.
+
+## Templates
+
+- [Adapter class template](./adapter_template.py): `MyAdapter(BaseConformalAdapter)`
+  with the full `fit`/`observe`/`predict`/`rewind` lifecycle and one tunable param.
+- [Test file template](./test_adapter_template.py): behavioral tests plus the
+  `_yield_yohou_conformal_adapter_checks` systematic-checks wiring.
+
+## Wiring checklist
+
+1. Class in `src/yohou/interval/adapter.py` extending `BaseConformalAdapter`,
+   with `_parameter_constraints` and a runnable docstring example.
+2. Export from `src/yohou/interval/__init__.py` (`__all__` and the import).
+3. Register a working instance in `tests/test_common.py`
+   `_conformal_adapter_instances()` and add the class name to `_SKIP_COMMON` so
+   the generic sweep defers to `TestConformalAdapterCommon`.
+4. Behavioral and integration tests in `tests/interval/test_adapter.py`.
+5. If the adapter needs a new tag, extend `ConformalAdapterTags` in
+   `src/yohou/utils/tags.py`.
+
+## Invariants the systematic checks enforce
+
+- `predict` returns one level per tracked rate, each in `[0, 1]` (per tail).
+- `observe` then `rewind` of the same rows restores the levels exactly.
+- A miscovered observation lowers the level; a covered one raises it.
+- A positive `epsilon` keeps the level within `[epsilon, 1 - epsilon]`.
+- `predict`, `observe`, and `rewind` raise `NotFittedError` before `fit`.
+
+Run `just test-fast` and `just lint` before opening a PR.

--- a/.claude/skills/create-yohou-conformal-adapter/adapter_template.py
+++ b/.claude/skills/create-yohou-conformal-adapter/adapter_template.py
@@ -1,0 +1,110 @@
+"""Template for a new conformal adapter.
+
+Copy into ``src/yohou/interval/adapter.py`` and rename. This template shows the
+full ``BaseConformalAdapter`` lifecycle with one tunable parameter. Delete the
+comments and adapt the update rule to your method.
+"""
+
+import numbers
+
+from sklearn.utils.validation import check_is_fitted
+
+from yohou.utils._compat import Interval, _fit_context
+
+from .base import BaseConformalAdapter
+
+__all__ = ["MyAdapter"]
+
+
+class MyAdapter(BaseConformalAdapter):
+    """One-line summary of the level-adaptation rule.
+
+    Longer description: what signal it reacts to and how the effective level
+    moves. Cite the method's reference.
+
+    Parameters
+    ----------
+    step_size : float, default=0.05
+        Learning rate of the online update.
+
+    Attributes
+    ----------
+    levels_ : dict
+        Current effective level per coverage rate (float for symmetric
+        scorers, ``(lower, upper)`` tuple for asymmetric).
+    coverage_rates_ : list of float
+        The coverage rates seeded at fit time.
+    symmetric_ : bool
+        Whether the tracked scorer is symmetric.
+
+    Examples
+    --------
+    >>> from yohou.interval.adapter import MyAdapter  # doctest: +SKIP
+    >>> adapter = MyAdapter().fit([0.9], symmetric=True)  # doctest: +SKIP
+    >>> round(adapter.predict()[0.9], 4)  # doctest: +SKIP
+    0.1
+
+    """
+
+    _parameter_constraints: dict = {
+        "step_size": [Interval(numbers.Real, 0, None, closed="neither")],
+    }
+
+    def __init__(self, step_size: float = 0.05) -> None:
+        # Only assign constructor args here, verbatim (sklearn contract).
+        self.step_size = step_size
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, coverage_rates: list[float], *, symmetric: bool) -> "MyAdapter":
+        """Seed one effective level per coverage rate."""
+        self.symmetric_ = symmetric
+        self.coverage_rates_ = list(coverage_rates)
+
+        self.levels_: dict[float, object] = {}
+        self._level_history: dict[float, list] = {}
+        for coverage_rate in self.coverage_rates_:
+            alpha_target = 1.0 - coverage_rate
+            seed = alpha_target if symmetric else (alpha_target / 2.0, alpha_target / 2.0)
+            self.levels_[coverage_rate] = seed
+            self._level_history[coverage_rate] = [seed]
+        return self
+
+    def observe(self, errors: list[dict[float, object]]) -> "MyAdapter":
+        """Advance each level by one update per observed row."""
+        check_is_fitted(self, "levels_")
+        for row_errors in errors:
+            for coverage_rate in self.coverage_rates_:
+                alpha_target = 1.0 - coverage_rate
+                err = row_errors[coverage_rate]
+                if self.symmetric_:
+                    current = float(self.levels_[coverage_rate])  # type: ignore[arg-type]
+                    # Replace with your rule. A row's zero-update sentinel has
+                    # err == alpha_target, so this must be a no-op for it.
+                    updated: object = current + self.step_size * (alpha_target - float(err))
+                else:
+                    lower, upper = self.levels_[coverage_rate]  # type: ignore[misc]
+                    err_lower, err_upper = err  # type: ignore[misc]
+                    target = alpha_target / 2.0
+                    updated = (
+                        lower + self.step_size * (target - float(err_lower)),
+                        upper + self.step_size * (target - float(err_upper)),
+                    )
+                self.levels_[coverage_rate] = updated
+                self._level_history[coverage_rate].append(updated)
+        return self
+
+    def predict(self) -> dict[float, object]:
+        """Return the current effective level per coverage rate."""
+        check_is_fitted(self, "levels_")
+        return dict(self.levels_)
+
+    def rewind(self, n_rows: int) -> "MyAdapter":
+        """Undo the last ``n_rows`` updates, never below the seed."""
+        check_is_fitted(self, "levels_")
+        for coverage_rate in self.coverage_rates_:
+            history = self._level_history[coverage_rate]
+            for _ in range(n_rows):
+                if len(history) > 1:
+                    history.pop()
+            self.levels_[coverage_rate] = history[-1]
+        return self

--- a/.claude/skills/create-yohou-conformal-adapter/test_adapter_template.py
+++ b/.claude/skills/create-yohou-conformal-adapter/test_adapter_template.py
@@ -1,0 +1,70 @@
+"""Template for testing a new conformal adapter.
+
+Two layers:
+1. The systematic checks via ``_yield_yohou_conformal_adapter_checks`` (wired
+   in ``tests/test_common.py`` ``_conformal_adapter_instances`` +
+   ``TestConformalAdapterCommon``); register your instance there.
+2. Behavioral / integration tests below, in ``tests/interval/test_adapter.py``.
+"""
+
+import pytest
+from sklearn.exceptions import NotFittedError
+
+from yohou.interval import SplitConformalForecaster
+from yohou.interval.adapter import MyAdapter  # rename to your class
+from yohou.point import SeasonalNaive
+
+
+class TestMyAdapterUnit:
+    """The adapter in isolation."""
+
+    def test_fit_seeds_target_level(self):
+        """Seed one level per rate at 1 - coverage_rate."""
+        adapter = MyAdapter().fit([0.9], symmetric=True)
+        assert adapter.predict()[0.9] == pytest.approx(0.1)
+
+    def test_observe_rewind_round_trip(self):
+        """Observe then rewind restores the levels exactly."""
+        adapter = MyAdapter().fit([0.9, 0.8], symmetric=True)
+        before = adapter.predict()
+        adapter.observe([{0.9: 1.0, 0.8: 0.0}, {0.9: 0.0, 0.8: 1.0}])
+        assert adapter.predict() != before
+        adapter.rewind(2)
+        assert adapter.predict() == before
+
+    def test_asymmetric_two_tails(self):
+        """Asymmetric scorers seed a (lower, upper) level per rate."""
+        adapter = MyAdapter().fit([0.9], symmetric=False)
+        lower, upper = adapter.predict()[0.9]
+        assert lower == pytest.approx(0.05)
+        assert upper == pytest.approx(0.05)
+
+    def test_unfitted_methods_raise(self):
+        """predict/observe/rewind raise NotFittedError before fit."""
+        adapter = MyAdapter()
+        with pytest.raises(NotFittedError):
+            adapter.predict()
+        with pytest.raises(NotFittedError):
+            adapter.observe([{0.9: 1.0}])
+        with pytest.raises(NotFittedError):
+            adapter.rewind(1)
+
+
+class TestMyAdapterInForecaster:
+    """The adapter wired into SplitConformalForecaster."""
+
+    def test_lifecycle_end_to_end(self):
+        """The adapter adapts and predicts through the forecaster lifecycle."""
+        # Build ~200 rows of your representative series here.
+        y = ...  # pl.DataFrame with "time" + value column
+        forecaster = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            adapter=MyAdapter(),
+        )
+        forecaster.fit(y[:180], forecasting_horizon=3, coverage_rates=[0.9])
+        before = forecaster.adapters_["step_1"].predict()
+        forecaster.observe(y[180:188])
+        assert forecaster.adapters_["step_1"].predict() != before
+        intervals = forecaster.predict_interval()
+        assert "value_lower_0.9" in intervals.columns

--- a/docs/pages/explanation/interval-forecasting.md
+++ b/docs/pages/explanation/interval-forecasting.md
@@ -241,6 +241,41 @@ a few nearby calibration points reduces variance but can increase bias if the lo
 neighborhood is too small. Larger calibration sets help by providing more data points
 in each local region.
 
+## Adaptive Conformal Inference
+
+Similarity weighting adapts *which* residuals count. Adaptive conformal
+inference adapts something orthogonal: the *quantile level* itself. A static
+calibration set fixes the miscoverage level once, so if the series drifts, the
+realized coverage drifts away from the target and never corrects. The adaptive
+conformal inference update (Gibbs and Candes, 2021) closes that loop. After each
+observation it compares the target miscoverage to the realized miscoverage and
+shifts the effective level accordingly:
+
+$$\alpha_{t+1} = \alpha_t + \gamma\,(\alpha^{*} - \mathrm{err}_t)$$
+
+where $\alpha^{*} = 1 - \text{coverage rate}$ is the target, $\mathrm{err}_t$ is 1
+when the truth fell outside the interval, and $\gamma$ (the `step_size`) sets how
+fast the level reacts. A run of misses lowers $\alpha_t$ and widens the interval;
+a run of covers raises it and narrows the interval.
+
+In Yohou this is an optional
+[`AdaptiveConformalInference`](/pages/api/generated/yohou.interval.AdaptiveConformalInference/)
+adapter passed to `SplitConformalForecaster`. It lives in the same
+`observe` / `predict_interval` / `rewind` lifecycle as the rest of the library,
+so a backtest and a production stream restore coverage identically. Because the
+two mechanisms are orthogonal, the adapter composes with similarity weighting:
+the similarity sets the weights, the adapter sets the level. The two axes are
+summarized below.
+
+| Mechanism | What it adapts | Set by |
+| --- | --- | --- |
+| Similarity weighting | which residuals count | `similarity` |
+| Adaptive conformal inference | how far into their tail to reach | `adapter` |
+
+The adapter tracks one level per horizon step (or a single shared level with
+`alpha_pooling="shared"`), and one level per tail for asymmetric conformity
+scorers so a lopsided error distribution corrects each side separately.
+
 ## Quantile Reduction Intervals
 
 [`IntervalReductionForecaster`](/pages/api/generated/yohou.interval.IntervalReductionForecaster/)

--- a/docs/pages/how-to/interval-forecasting.md
+++ b/docs/pages/how-to/interval-forecasting.md
@@ -108,6 +108,38 @@ interval columns using the same `{component}_lower_{rate}` /
 `{component}_upper_{rate}` naming as the conformal path. Use this route when
 the estimator's own quantile loss is preferable to post-hoc calibration.
 
+## 5. Adapt Coverage Online Under Drift
+
+A static calibration set fixes the interval width once. When the series
+drifts, realized coverage drifts with it and the intervals become too wide or
+too narrow. Pass an
+[`AdaptiveConformalInference`](/pages/api/generated/yohou.interval.AdaptiveConformalInference/)
+adapter to nudge the effective miscoverage level up or down from the coverage
+actually observed, restoring the target rate as you walk forward:
+
+```python
+from yohou.interval import AdaptiveConformalInference, SplitConformalForecaster
+from yohou.point import SeasonalNaive
+
+forecaster = SplitConformalForecaster(
+    point_forecaster=SeasonalNaive(seasonality=7),
+    calibration_size=100,
+    adapter=AdaptiveConformalInference(step_size=0.05),
+)
+forecaster.fit(y_train, forecasting_horizon=3, coverage_rates=[0.9])
+
+# Walk forward: each observe() updates the level, each predict reflects it.
+y_pred = forecaster.observe_predict_interval(y_stream, stride=1, coverage_rates=[0.9])
+```
+
+The output columns keep their nominal labels (`..._lower_0.9`), so a "90%
+interval" stays a 90% interval; only its width is adapted. `step_size` is the
+learning rate: larger values react faster but track more noisily. Leave
+`adapter=None` (the default) for the static behavior. The adapter composes
+with `similarity`: the similarity sets which residuals count, the adapter sets
+how far into their tail to reach. A coverage rate the adapter never tracked
+falls back to the static level with a warning.
+
 ## See Also
 
 - [About Interval Forecasting](../explanation/interval-forecasting.md): conformal theory, coverage guarantees, and when to prefer quantile regression over conformal wrapping

--- a/docs/pages/reference/tags.md
+++ b/docs/pages/reference/tags.md
@@ -79,6 +79,14 @@ These apply to all estimator types.
 | `requires_predictions` | `bool` | `True` | Whether predictions (`y_pred`) are needed in addition to actuals |
 | `produces_weights` | `bool` | `True` | Whether the measure produces weights for conformity scores |
 
+## Conformal Adapter Tags (`conformal_adapter_tags`)
+
+| Tag | Type | Default | Description |
+|-----|------|---------|-------------|
+| `online` | `bool` | `True` | Whether the adapter updates its effective level online via `observe()` |
+| `requires_coverage_rates` | `bool` | `True` | Whether `fit()` must be told the tracked coverage rates |
+| `tail_aware` | `bool` | `True` | Whether the adapter tracks one level for symmetric scorers and two (lower, upper) for asymmetric ones |
+
 ## Dynamic Tags
 
 Some tags are computed at runtime rather than declared in `_tags`. Override

--- a/src/yohou/interval/__init__.py
+++ b/src/yohou/interval/__init__.py
@@ -1,12 +1,15 @@
 """Interval forecasters for prediction uncertainty quantification."""
 
-from .base import BaseIntervalForecaster, BaseSimilarity
+from .adapter import AdaptiveConformalInference
+from .base import BaseConformalAdapter, BaseIntervalForecaster, BaseSimilarity
 from .reduction import IntervalReductionForecaster
 from .similarity import CompositeSimilarity, DistanceSimilarity, SeasonalSimilarity
 from .split_conformal import SplitConformalForecaster
 from .utils import weighted_quantile
 
 __all__ = [
+    "AdaptiveConformalInference",
+    "BaseConformalAdapter",
     "BaseIntervalForecaster",
     "BaseSimilarity",
     "CompositeSimilarity",

--- a/src/yohou/interval/adapter.py
+++ b/src/yohou/interval/adapter.py
@@ -1,0 +1,219 @@
+"""Adaptive conformal inference adapters for interval forecasting."""
+
+import numbers
+from typing import Literal
+
+from sklearn.utils.validation import check_is_fitted
+
+from yohou.utils._compat import Interval, StrOptions, _fit_context
+
+from .base import BaseConformalAdapter
+
+__all__ = ["AdaptiveConformalInference"]
+
+
+class AdaptiveConformalInference(BaseConformalAdapter):
+    r"""Online miscoverage-level adjustment (Gibbs and Candes, 2021).
+
+    Maintains a time-varying effective miscoverage level and updates it
+    from the coverage realized on newly observed data, so a conformal
+    forecaster restores its target coverage under distribution shift. For
+    each tracked coverage rate the update is
+
+    $$\alpha_{t+1} = \mathrm{clip}\big(\alpha_t + \gamma\,(\alpha^{*} -
+    \mathrm{err}_t),\; \epsilon,\; 1 - \epsilon\big)$$
+
+    where $\gamma$ is ``step_size``, $\alpha^{*} = 1 - \text{coverage rate}$
+    is the target miscoverage, and $\mathrm{err}_t \in [0, 1]$ is the
+    realized miscoverage of the interval that was in force. When the
+    conformity scorer is asymmetric, a lower and an upper level are tracked
+    separately, each targeting $\alpha^{*}/2$.
+
+    This adapter owns one horizon step; ``SplitConformalForecaster`` clones
+    one per step and supplies the miscoverage indicators (it holds the
+    calibration scores and any similarity weights). The adapter is the
+    level-recursion state machine only.
+
+    Parameters
+    ----------
+    step_size : float, default=0.05
+        Learning rate $\gamma$ of the online update. Larger values react
+        faster to coverage drift but track more noisily.
+    alpha_pooling : {"per_step", "shared"}, default="per_step"
+        How the enclosing forecaster pools miscoverage across horizon steps
+        before updating. ``"per_step"`` lets each step's level evolve
+        independently; ``"shared"`` makes the forecaster pool the per-step
+        indicators and feed every step the same update, yielding one shared
+        trajectory. The adapter stores this so the forecaster can read it;
+        the update itself is identical either way.
+    epsilon : float, default=0.0
+        Clips the effective level to ``[epsilon, 1 - epsilon]``. The default
+        ``0.0`` reproduces the paper-exact ``[0, 1]`` clipping; a positive
+        value prevents fully degenerate intervals in production.
+
+    Attributes
+    ----------
+    levels_ : dict
+        Current effective level per coverage rate: a float for symmetric
+        scorers, or a ``(lower, upper)`` tuple for asymmetric ones.
+    coverage_rates_ : list of float
+        The coverage rates seeded at fit time.
+    symmetric_ : bool
+        Whether the tracked scorer is symmetric.
+
+    References
+    ----------
+    [1] Gibbs, I., & Candes, E. (2021). "Adaptive conformal inference under
+        distribution shift." Advances in Neural Information Processing
+        Systems, 34, 1660-1672.
+
+    See Also
+    --------
+    - [`BaseConformalAdapter`][yohou.interval.base.BaseConformalAdapter] : Abstract adapter base class.
+    - [`SplitConformalForecaster`][yohou.interval.split_conformal.SplitConformalForecaster] :
+        Conformal forecaster that consumes an adapter.
+
+    Examples
+    --------
+    >>> from yohou.interval.adapter import AdaptiveConformalInference
+    >>> adapter = AdaptiveConformalInference(step_size=0.1).fit([0.9], symmetric=True)
+    >>> round(adapter.predict()[0.9], 4)
+    0.1
+    >>> # A miscovered observation (err=1) lowers the level, widening the interval.
+    >>> _ = adapter.observe([{0.9: 1.0}])
+    >>> round(adapter.predict()[0.9], 4)
+    0.01
+    >>> # Rewinding restores the seeded level.
+    >>> _ = adapter.rewind(1)
+    >>> round(adapter.predict()[0.9], 4)
+    0.1
+
+    """
+
+    _parameter_constraints: dict = {
+        "step_size": [Interval(numbers.Real, 0, None, closed="neither")],
+        "alpha_pooling": [StrOptions({"per_step", "shared"})],
+        "epsilon": [Interval(numbers.Real, 0, 0.5, closed="left")],
+    }
+
+    def __init__(
+        self,
+        step_size: float = 0.05,
+        alpha_pooling: Literal["per_step", "shared"] = "per_step",
+        epsilon: float = 0.0,
+    ) -> None:
+        self.step_size = step_size
+        self.alpha_pooling = alpha_pooling
+        self.epsilon = epsilon
+
+    def _clip(self, level: float) -> float:
+        """Clamp a level to ``[epsilon, 1 - epsilon]``."""
+        return min(max(level, self.epsilon), 1.0 - self.epsilon)
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, coverage_rates: list[float], *, symmetric: bool) -> "AdaptiveConformalInference":
+        """Seed one effective level per coverage rate.
+
+        Parameters
+        ----------
+        coverage_rates : list of float
+            Nominal coverage rates to track. Each is seeded at its target
+            miscoverage ``1 - coverage_rate`` (halved per tail for
+            asymmetric scorers).
+        symmetric : bool
+            Whether the conformity scorer is symmetric.
+
+        Returns
+        -------
+        self
+
+        """
+        self.symmetric_ = symmetric
+        self.coverage_rates_ = list(coverage_rates)
+
+        self.levels_: dict[float, object] = {}
+        self._level_history: dict[float, list] = {}
+        for coverage_rate in self.coverage_rates_:
+            alpha_target = 1.0 - coverage_rate
+            seed = alpha_target if symmetric else (alpha_target / 2.0, alpha_target / 2.0)
+            self.levels_[coverage_rate] = seed
+            self._level_history[coverage_rate] = [seed]
+
+        return self
+
+    def observe(self, errors: list[dict[float, object]]) -> "AdaptiveConformalInference":
+        """Advance each level by one update per observed row.
+
+        Parameters
+        ----------
+        errors : list of dict
+            One entry per newly observed row, mapping each tracked coverage
+            rate to its miscoverage signal (a float for symmetric scorers, a
+            ``(lower, upper)`` tuple for asymmetric ones).
+
+        Returns
+        -------
+        self
+
+        """
+        check_is_fitted(self, "levels_")
+
+        for row_errors in errors:
+            for coverage_rate in self.coverage_rates_:
+                alpha_target = 1.0 - coverage_rate
+                err = row_errors[coverage_rate]
+
+                if self.symmetric_:
+                    current = self.levels_[coverage_rate]
+                    assert isinstance(current, float)
+                    updated: object = self._clip(current + self.step_size * (alpha_target - float(err)))  # ty: ignore[invalid-argument-type]
+                else:
+                    lower, upper = self.levels_[coverage_rate]  # ty: ignore[not-iterable]
+                    err_lower, err_upper = err  # ty: ignore[not-iterable]
+                    target = alpha_target / 2.0
+                    updated = (
+                        self._clip(lower + self.step_size * (target - float(err_lower))),
+                        self._clip(upper + self.step_size * (target - float(err_upper))),
+                    )
+
+                self.levels_[coverage_rate] = updated
+                self._level_history[coverage_rate].append(updated)
+
+        return self
+
+    def predict(self) -> dict[float, object]:
+        """Return the current effective level per coverage rate.
+
+        Returns
+        -------
+        dict
+            Maps each tracked coverage rate to its current effective level.
+
+        """
+        check_is_fitted(self, "levels_")
+        return dict(self.levels_)
+
+    def rewind(self, n_rows: int) -> "AdaptiveConformalInference":
+        """Undo the level updates from the last ``n_rows`` observations.
+
+        Parameters
+        ----------
+        n_rows : int
+            Number of most-recently observed rows to roll back, never
+            dropping below the fit-time seed.
+
+        Returns
+        -------
+        self
+
+        """
+        check_is_fitted(self, "levels_")
+
+        for coverage_rate in self.coverage_rates_:
+            history = self._level_history[coverage_rate]
+            for _ in range(n_rows):
+                if len(history) > 1:
+                    history.pop()
+            self.levels_[coverage_rate] = history[-1]
+
+        return self

--- a/src/yohou/interval/base.py
+++ b/src/yohou/interval/base.py
@@ -14,7 +14,7 @@ from yohou.base import BaseActualTransformer, BaseForecaster, BaseForecastTransf
 from yohou.utils import INTERVAL, Tags, cast, validate_forecaster_data
 from yohou.utils._compat import _fit_context
 
-__all__ = ["BaseIntervalForecaster", "BaseSimilarity"]
+__all__ = ["BaseConformalAdapter", "BaseIntervalForecaster", "BaseSimilarity"]
 
 
 class BaseSimilarity(BaseEstimator, metaclass=abc.ABCMeta):
@@ -222,6 +222,130 @@ class BaseSimilarity(BaseEstimator, metaclass=abc.ABCMeta):
 
         """
         return self
+
+
+class BaseConformalAdapter(BaseEstimator, metaclass=abc.ABCMeta):
+    """Base class for adaptive conformal inference adapters.
+
+    A conformal adapter maintains a time-varying effective miscoverage
+    level and updates it online from the coverage realized on newly
+    observed data. It is an optional, pluggable add-on for
+    ``SplitConformalForecaster``: when ``adapter=None`` the forecaster uses
+    the static calibrated level, and when an adapter is supplied the
+    forecaster feeds it per-row miscoverage indicators and reads back the
+    effective level to use when constructing intervals.
+
+    The adapter owns a single horizon step. The forecaster clones one
+    adapter per step into a ``adapters_`` dict (mirroring ``similarities_``)
+    and drives the per-step lifecycle. Inside its step the adapter tracks
+    one effective level per coverage rate for symmetric conformity scorers,
+    and two (lower and upper) for asymmetric ones. The forecaster, which
+    holds the calibration scores and any similarity weights, computes the
+    miscoverage indicators; the adapter is the level-recursion state
+    machine only.
+
+    Notes
+    -----
+    The lifecycle mirrors the rest of the library: ``fit`` seeds the level
+    from the target coverage, ``observe`` advances it per newly observed
+    row, ``predict`` returns the current level, and ``rewind`` rolls it
+    back so backtests and production replay share one code path.
+
+    See Also
+    --------
+    - [`AdaptiveConformalInference`][yohou.interval.adapter.AdaptiveConformalInference] :
+        Concrete Gibbs-Candes online level adjustment.
+    - [`SplitConformalForecaster`][yohou.interval.split_conformal.SplitConformalForecaster] :
+        Conformal forecaster that consumes an adapter.
+
+    """
+
+    _parameter_constraints: dict = {}
+
+    def __sklearn_tags__(self) -> Tags:
+        """Get estimator tags.
+
+        Returns
+        -------
+        Tags
+            Estimator tags with conformal-adapter-specific attributes.
+
+        """
+        tags = Tags(estimator_type="conformal_adapter", requires_fit=True)
+
+        assert tags.conformal_adapter_tags is not None
+        tags.conformal_adapter_tags.online = True
+        tags.conformal_adapter_tags.requires_coverage_rates = True
+        tags.conformal_adapter_tags.tail_aware = True
+
+        return tags
+
+    @abc.abstractmethod
+    def fit(self, coverage_rates: list[float], *, symmetric: bool) -> "BaseConformalAdapter":
+        """Seed the effective level(s) from the target coverage rates.
+
+        Parameters
+        ----------
+        coverage_rates : list of float
+            The nominal coverage rates to track, one effective level seeded
+            per rate at ``1 - coverage_rate``.
+        symmetric : bool
+            Whether the conformity scorer is symmetric. Symmetric scorers
+            use one level per rate; asymmetric scorers use two (lower and
+            upper), each targeting half the miscoverage.
+
+        Returns
+        -------
+        self
+
+        """
+
+    @abc.abstractmethod
+    def observe(self, errors: list[dict[float, Any]]) -> "BaseConformalAdapter":
+        """Advance the effective level(s) from per-row miscoverage.
+
+        Parameters
+        ----------
+        errors : list of dict
+            One entry per newly observed row. Each entry maps a tracked
+            coverage rate to its miscoverage signal: a float in ``[0, 1]``
+            for symmetric scorers, or a ``(lower, upper)`` tuple of such
+            floats for asymmetric scorers.
+
+        Returns
+        -------
+        self
+
+        """
+
+    @abc.abstractmethod
+    def predict(self) -> dict[float, Any]:
+        """Return the current effective level(s).
+
+        Returns
+        -------
+        dict
+            Maps each tracked coverage rate to its current effective level:
+            a float for symmetric scorers, or a ``(lower, upper)`` tuple for
+            asymmetric scorers.
+
+        """
+
+    @abc.abstractmethod
+    def rewind(self, n_rows: int) -> "BaseConformalAdapter":
+        """Roll the effective level(s) back by ``n_rows`` observations.
+
+        Parameters
+        ----------
+        n_rows : int
+            Number of most-recently observed rows to undo, never dropping
+            below the fit-time seed.
+
+        Returns
+        -------
+        self
+
+        """
 
 
 class BaseIntervalForecaster(BaseForecaster, metaclass=abc.ABCMeta):

--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -1,6 +1,7 @@
 """Implementation of conformal forecasters."""
 
 import numbers
+import warnings
 from typing import Literal
 
 import numpy as np
@@ -16,7 +17,7 @@ from yohou.point import BasePointForecaster, SeasonalNaive
 from yohou.utils import POINT_INTERVAL, Tags, validate_forecaster_data
 from yohou.utils._compat import Interval, _fit_context
 
-from .base import BaseIntervalForecaster, BaseSimilarity
+from .base import BaseConformalAdapter, BaseIntervalForecaster, BaseSimilarity
 from .utils import weighted_quantile
 
 __all__ = ["SplitConformalForecaster"]
@@ -39,6 +40,13 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         Scorer used to compute conformity scores.
     similarity : BaseSimilarity or None, default=None
         Similarity measure used to weight conformity scores.
+    adapter : BaseConformalAdapter or None, default=None
+        Adaptive conformal inference adapter. When ``None`` (the default),
+        intervals use the static calibrated level. When supplied, the
+        forecaster tracks a time-varying effective miscoverage level per
+        coverage rate and horizon step, updating it online from realized
+        coverage. Composes with ``similarity``: the adapter sets the level,
+        the similarity sets the weights.
     panel_strategy : {"global", "multivariate"}, default="global"
         How to handle panel data. See `BaseForecaster` for details.
 
@@ -69,6 +77,7 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         "calibration_size": [Interval(numbers.Integral, 1, None, closed="left")],
         "conformity_scorer": [BaseConformityScorer],
         "similarity": [BaseSimilarity, None],
+        "adapter": [BaseConformalAdapter, None],
     }
 
     def __sklearn_tags__(self) -> Tags:
@@ -93,6 +102,7 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         calibration_size: StrictInt = 100,
         conformity_scorer: BaseConformityScorer = Residual(),
         similarity: BaseSimilarity | None = None,
+        adapter: BaseConformalAdapter | None = None,
         panel_strategy: Literal["global", "multivariate"] = "global",
     ):
         BaseIntervalForecaster.__init__(self, panel_strategy=panel_strategy)
@@ -100,6 +110,7 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         self.point_forecaster = point_forecaster
         self.conformity_scorer = conformity_scorer
         self.similarity = similarity
+        self.adapter = adapter
         self.calibration_size = calibration_size
 
     @_fit_context(prefer_skip_nested_validation=True)
@@ -304,6 +315,20 @@ class SplitConformalForecaster(BaseIntervalForecaster):
 
         self._check_replay_left_the_block_observed(y, replay_path)
 
+        if self.adapter is not None:
+            # One cloned adapter per horizon step, mirroring similarities_.
+            # Each clone is told the tracked coverage rates and the scorer's
+            # symmetry so it can seed one effective level per (rate, tail).
+            scorer_tags = self.conformity_scorer.__sklearn_tags__()
+            assert scorer_tags.scorer_tags is not None
+            self._adapter_symmetric_ = scorer_tags.scorer_tags.symmetric
+            self.adapters_ = {}
+            for step in range(1, 1 + forecasting_horizon):
+                key = f"step_{step}"
+                self.adapters_[key] = clone(self.adapter).fit(
+                    self.fit_coverage_rates_, symmetric=self._adapter_symmetric_
+                )
+
         return self
 
     def _check_replay_left_the_block_observed(self, y: pl.DataFrame, replay_path: str) -> None:
@@ -460,6 +485,247 @@ class SplitConformalForecaster(BaseIntervalForecaster):
                 y_rewind = y.head(n_remove)
                 similarity_step.rewind(y=y_rewind, y_pred=y_rewind, X_actual=X_actual)
 
+    @staticmethod
+    def _adapter_thresholds(
+        calib_col: np.ndarray,
+        weights: np.ndarray,
+        level: object,
+        symmetric: bool,
+    ) -> object:
+        """Compute score-space interval thresholds at an effective level.
+
+        Parameters
+        ----------
+        calib_col : np.ndarray
+            Calibration conformity scores for one value column.
+        weights : np.ndarray
+            Per-calibration weights (uniform when no similarity is used).
+        level : float or tuple of float
+            Effective level: a single miscoverage ``alpha`` for symmetric
+            scorers, or ``(beta_lower, beta_upper)`` per-tail miscoverage for
+            asymmetric scorers.
+        symmetric : bool
+            Whether the conformity scorer is symmetric.
+
+        Returns
+        -------
+        float or tuple of float
+            For symmetric scorers, the half-width quantile ``q`` (a truth is
+            covered when its score is ``<= q``). For asymmetric scorers, the
+            ``(lower_q, upper_q)`` score bounds (a truth is covered when its
+            score lies within them).
+
+        """
+        if symmetric:
+            alpha_eff = float(level)  # ty: ignore[invalid-argument-type]
+            return weighted_quantile(calib_col, alpha_eff, weights)
+
+        beta_lower, beta_upper = level  # ty: ignore[not-iterable]
+        lower_q = weighted_quantile(calib_col, 1.0 - float(beta_lower), weights)
+        upper_q = weighted_quantile(calib_col, float(beta_upper), weights)
+        return (lower_q, upper_q)
+
+    def _adapter_step_errors(
+        self,
+        y: pl.DataFrame,
+        scores_new: pl.DataFrame,
+        calib: pl.DataFrame,
+        y_pred_step: pl.DataFrame,
+        step_key: str,
+        coverage_rates: list[float],
+        symmetric: bool,
+        n_rows: int,
+    ) -> list[dict[float, object]]:
+        """Build one per-row miscoverage dict per observed row for a step.
+
+        Rows this step could not score (its prediction reached past the
+        observed truth) receive a zero-update sentinel so every step advances
+        exactly ``n_rows`` times, keeping the rewind arithmetic exact.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            The newly observed batch (defines row order and count).
+        scores_new : pl.DataFrame
+            New conformity scores for this step (``"time"`` plus value cols).
+        calib : pl.DataFrame
+            Pre-observe calibration scores for this step.
+        y_pred_step : pl.DataFrame
+            Pre-observe point predictions for this step.
+        step_key : str
+            The ``"step_k"`` key into ``similarities_``.
+        coverage_rates : list of float
+            Tracked coverage rates.
+        symmetric : bool
+            Whether the conformity scorer is symmetric.
+        n_rows : int
+            Number of rows in ``y``.
+
+        Returns
+        -------
+        list of dict
+            Length ``n_rows``; each dict maps a coverage rate to its
+            miscoverage signal.
+
+        """
+        value_cols = [c for c in calib.columns if c != "time"]
+        calib_cols = {c: calib[c].to_numpy().astype(np.float64) for c in value_cols}
+        n_calib = calib.height
+        levels = self.adapters_[step_key].predict()
+
+        def sentinel(coverage_rate: float) -> object:
+            """Return the zero-update error for a row this step could not score."""
+            alpha_target = 1.0 - coverage_rate
+            return alpha_target if symmetric else (alpha_target / 2.0, alpha_target / 2.0)
+
+        # Default every row to the zero-update sentinel, then fill scored rows.
+        errors: list[dict[float, object]] = [{cr: sentinel(cr) for cr in coverage_rates} for _ in range(n_rows)]
+
+        if scores_new.height == 0:
+            return errors
+
+        # Weights per scored row (uniform when no similarity is configured).
+        scored_pred = y_pred_step.join(scores_new.select("time"), on="time", how="semi")
+        if self.similarity is not None and hasattr(self, "similarities_"):
+            weight_matrix = self.similarities_[step_key].predict(y_pred=scored_pred).astype(np.float64)
+        else:
+            weight_matrix = np.ones((scores_new.height, n_calib), dtype=np.float64)
+
+        row_index = {t: i for i, t in enumerate(y["time"].to_list())}
+        scored_values = {c: scores_new[c].to_numpy().astype(np.float64) for c in value_cols}
+
+        for j, t in enumerate(scores_new["time"].to_list()):
+            i = row_index[t]
+            weights = weight_matrix[j]
+            for coverage_rate in coverage_rates:
+                level = levels[coverage_rate]
+                if symmetric:
+                    misses = []
+                    for c in value_cols:
+                        q = float(self._adapter_thresholds(calib_cols[c], weights, level, True))  # ty: ignore[invalid-argument-type]
+                        misses.append(1.0 if scored_values[c][j] > q else 0.0)
+                    errors[i][coverage_rate] = float(np.mean(misses))
+                else:
+                    lower_misses, upper_misses = [], []
+                    for c in value_cols:
+                        lower_q, upper_q = self._adapter_thresholds(calib_cols[c], weights, level, False)  # ty: ignore[not-iterable]
+                        s = scored_values[c][j]
+                        lower_misses.append(1.0 if s < lower_q else 0.0)
+                        upper_misses.append(1.0 if s > upper_q else 0.0)
+                    errors[i][coverage_rate] = (float(np.mean(lower_misses)), float(np.mean(upper_misses)))
+
+        return errors
+
+    @staticmethod
+    def _pool_adapter_errors(
+        per_step_errors: dict[str, list[dict[float, object]]],
+        coverage_rates: list[float],
+        symmetric: bool,
+        n_rows: int,
+    ) -> list[dict[float, object]]:
+        """Average per-step miscoverage into one shared per-row trajectory.
+
+        Used for ``alpha_pooling="shared"``: a single pooled update is fed to
+        every step's adapter, so the per-step dict alone (which cannot see
+        across steps) still yields one shared level.
+
+        Parameters
+        ----------
+        per_step_errors : dict
+            Maps each ``"step_k"`` key to its length-``n_rows`` error list.
+        coverage_rates : list of float
+            Tracked coverage rates.
+        symmetric : bool
+            Whether the conformity scorer is symmetric.
+        n_rows : int
+            Number of observed rows.
+
+        Returns
+        -------
+        list of dict
+            Length ``n_rows`` pooled error list.
+
+        """
+        keys = list(per_step_errors)
+        pooled: list[dict[float, object]] = []
+        for i in range(n_rows):
+            row: dict[float, object] = {}
+            for coverage_rate in coverage_rates:
+                if symmetric:
+                    row[coverage_rate] = float(np.mean([per_step_errors[k][i][coverage_rate] for k in keys]))
+                else:
+                    lowers = [per_step_errors[k][i][coverage_rate][0] for k in keys]  # ty: ignore[not-subscriptable]
+                    uppers = [per_step_errors[k][i][coverage_rate][1] for k in keys]  # ty: ignore[not-subscriptable]
+                    row[coverage_rate] = (float(np.mean(lowers)), float(np.mean(uppers)))
+            pooled.append(row)
+        return pooled
+
+    def _observe_adapter(self, y: pl.DataFrame) -> None:
+        """Advance the per-step adapters from newly observed coverage.
+
+        Runs before ``_observe_conformity`` (and before the point forecaster
+        absorbs ``y``) so the effective level is updated against the
+        calibration set and similarity state as they stood pre-observe.
+        Panel-agnostic, like ``_observe_conformity``.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            New target observations.
+
+        """
+        if not hasattr(self, "adapters_"):
+            return
+
+        fh = self.fit_forecasting_horizon_
+        n_rows = len(y)
+        symmetric = self._adapter_symmetric_
+        coverage_rates = self.fit_coverage_rates_
+
+        y_pred = self.point_forecaster_.predict(forecasting_horizon=fh)
+
+        per_step_errors: dict[str, list[dict[float, object]]] = {}
+        for step in range(1, 1 + fh):
+            key = f"step_{step}"
+            scorer = self.conformity_scorers_[key]
+            y_pred_step = y_pred[step - 1 :: fh].drop("vintage_time", strict=False)
+            scores_new = scorer.score(y, y_pred_step)
+            calib = self.conformity_scores_.filter(pl.col("step") == step).drop("step")
+            per_step_errors[key] = self._adapter_step_errors(
+                y=y,
+                scores_new=scores_new,
+                calib=calib,
+                y_pred_step=y_pred_step,
+                step_key=key,
+                coverage_rates=coverage_rates,
+                symmetric=symmetric,
+                n_rows=n_rows,
+            )
+
+        if getattr(self.adapter, "alpha_pooling", "per_step") == "shared":
+            pooled = self._pool_adapter_errors(per_step_errors, coverage_rates, symmetric, n_rows)
+            for key in per_step_errors:
+                self.adapters_[key].observe(pooled)
+        else:
+            for key, errors in per_step_errors.items():
+                self.adapters_[key].observe(errors)
+
+    def _rewind_adapter(self, y: pl.DataFrame) -> None:
+        """Roll each per-step adapter back by ``len(y)`` observations.
+
+        Parameters
+        ----------
+        y : pl.DataFrame
+            Target observations to rewind (used only for the row count).
+
+        """
+        if not hasattr(self, "adapters_"):
+            return
+
+        n_rewind = len(y)
+        for adapter in self.adapters_.values():
+            adapter.rewind(n_rewind)
+
     def observe(
         self,
         y: pl.DataFrame,
@@ -516,6 +782,11 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         # runs unconditionally ahead of the panel/standard branch; routing it
         # through the standard branch alone would silently skip it on panel
         # data.
+        #
+        # The adapter runs *before* _observe_conformity so its realized-coverage
+        # check sees the calibration scores and similarity weights as they stood
+        # pre-observe, before this batch is appended.
+        self._observe_adapter(y)
         self._observe_conformity(y)
 
         if self.groups_ is None:
@@ -576,6 +847,7 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         # rolls back, mirroring the order used by observe() so both methods
         # maintain the same state invariant. As in observe(), this rollback is
         # panel-agnostic and runs unconditionally ahead of the branch.
+        self._rewind_adapter(y)
         self._rewind_conformity(y, X_actual=X_actual)
 
         if self.groups_ is None:
@@ -925,6 +1197,79 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         upper_bound = pl.DataFrame(upper_data)
         return conformity_scorer_step._format_y_pred_interval(lower_bound, upper_bound, coverage_rate)
 
+    def _adapter_inverse_score(
+        self,
+        y_pred_step: pl.DataFrame,
+        conformity_scores_step: pl.DataFrame,
+        coverage_rate: float,
+        level: object,
+        weights: np.ndarray,
+        conformity_scorer_step: BaseConformityScorer,
+    ) -> pl.DataFrame:
+        """Build an interval at the adapter's effective level.
+
+        Constructs the interval from the effective miscoverage level the
+        adapter currently tracks, then labels the output columns with the
+        *nominal* ``coverage_rate`` so callers still read a "90% interval"
+        even though its width was adapted. Uses similarity weights when
+        supplied and uniform weights otherwise, mirroring
+        ``_weighted_inverse_score``.
+
+        Parameters
+        ----------
+        y_pred_step : pl.DataFrame
+            Point predictions for one step (single row) with ``"time"``.
+        conformity_scores_step : pl.DataFrame
+            Conformity scores for this step with ``"time"``.
+        coverage_rate : float
+            Nominal coverage rate used only to label the output columns.
+        level : float or tuple of float
+            Effective level from the adapter: ``alpha`` for symmetric
+            scorers, ``(beta_lower, beta_upper)`` for asymmetric ones.
+        weights : np.ndarray
+            Per-calibration weights (similarity weights, or uniform).
+        conformity_scorer_step : BaseConformityScorer
+            Fitted conformity scorer (for tags and formatting).
+
+        Returns
+        -------
+        pl.DataFrame
+            Interval columns (no ``"time"`` column), labeled with the
+            nominal ``coverage_rate``.
+
+        """
+        value_cols = [c for c in conformity_scores_step.columns if c != "time"]
+        scores_no_time = conformity_scores_step.drop("time", strict=False)
+        y_pred_values = y_pred_step.drop("time")
+
+        tags = conformity_scorer_step.__sklearn_tags__()
+        assert tags.scorer_tags is not None
+        symmetric = tags.scorer_tags.symmetric
+        multiplicative = tags.scorer_tags.multiplicative
+        epsilon = conformity_scorer_step.get_params().get("epsilon", 0.0)
+
+        lower_data: dict[str, list[float]] = {}
+        upper_data: dict[str, list[float]] = {}
+
+        for col in value_cols:
+            scores_col = scores_no_time[col].to_numpy().astype(np.float64)
+            pred_val = float(y_pred_values[col][0])
+            scale = (pred_val + epsilon) if multiplicative else 1.0
+
+            thresholds = self._adapter_thresholds(scores_col, weights, level, symmetric)
+            if symmetric:
+                q = float(thresholds)  # ty: ignore[invalid-argument-type]
+                lower_data[col] = [pred_val - q * scale]
+                upper_data[col] = [pred_val + q * scale]
+            else:
+                lower_q, upper_q = thresholds  # ty: ignore[not-iterable]
+                lower_data[col] = [pred_val + lower_q * scale]
+                upper_data[col] = [pred_val + upper_q * scale]
+
+        lower_bound = pl.DataFrame(lower_data)
+        upper_bound = pl.DataFrame(upper_data)
+        return conformity_scorer_step._format_y_pred_interval(lower_bound, upper_bound, coverage_rate)
+
     def predict_interval(  # ty: ignore[invalid-method-override]
         self,
         forecasting_horizon: StrictInt | None = None,
@@ -1001,6 +1346,22 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         y_pred_time = y_pred.select("time")
         y_pred_values = y_pred.drop("time")
 
+        # An adapter only adapts the coverage rates it seeded at fit time.
+        # Rates it never tracked fall back to the static level, with a warning
+        # so the fallback is never silent.
+        tracked_rates: set[float] = set()
+        if hasattr(self, "adapters_"):
+            tracked_rates = set(self.adapters_["step_1"].predict().keys())
+            for coverage_rate in coverage_rates:
+                if coverage_rate not in tracked_rates:
+                    warnings.warn(
+                        f"Coverage rate {coverage_rate} was not tracked by the adaptive conformal "
+                        f"adapter (tracked rates: {sorted(tracked_rates)}); falling back to the static "
+                        f"calibrated level for it.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+
         y_pred_intervals_list: list[pl.DataFrame] = []
         for step in range(1, 1 + forecasting_horizon):
             # Get step predictions
@@ -1015,16 +1376,39 @@ class SplitConformalForecaster(BaseIntervalForecaster):
 
             rate_parts: list[pl.DataFrame] = []
             for coverage_rate in coverage_rates:
+                adapter_active = hasattr(self, "adapters_") and coverage_rate in tracked_rates
+                effective_level = self.adapters_[f"step_{step}"].predict()[coverage_rate] if adapter_active else None
+
                 if self.similarity is not None and hasattr(self, "similarities_"):
                     similarity_step = self.similarities_[f"step_{step}"]
                     weights_array = similarity_step.predict(y_pred=y_pred_step)
                     step_weights = weights_array[0].astype(np.float64)
 
-                    y_pred_interval_rate_step = self._weighted_inverse_score(
+                    if adapter_active:
+                        y_pred_interval_rate_step = self._adapter_inverse_score(
+                            y_pred_step=y_pred_step,
+                            conformity_scores_step=conformity_scores_step,
+                            coverage_rate=coverage_rate,
+                            level=effective_level,
+                            weights=step_weights,
+                            conformity_scorer_step=conformity_scorer_step,
+                        )
+                    else:
+                        y_pred_interval_rate_step = self._weighted_inverse_score(
+                            y_pred_step=y_pred_step,
+                            conformity_scores_step=conformity_scores_step,
+                            coverage_rate=coverage_rate,
+                            weights=step_weights,
+                            conformity_scorer_step=conformity_scorer_step,
+                        )
+                elif adapter_active:
+                    uniform_weights = np.ones(conformity_scores_step.height, dtype=np.float64)
+                    y_pred_interval_rate_step = self._adapter_inverse_score(
                         y_pred_step=y_pred_step,
                         conformity_scores_step=conformity_scores_step,
                         coverage_rate=coverage_rate,
-                        weights=step_weights,
+                        level=effective_level,
+                        weights=uniform_weights,
                         conformity_scorer_step=conformity_scorer_step,
                     )
                 else:

--- a/src/yohou/testing/__init__.py
+++ b/src/yohou/testing/__init__.py
@@ -100,6 +100,9 @@ from .forecaster import (
     check_step_feature_alignment_filters,
 )
 from .generators import (
+    _yield_yohou_conformal_adapter_checks as _yield_yohou_conformal_adapter_checks,
+)
+from .generators import (
     _yield_yohou_forecaster_checks as _yield_yohou_forecaster_checks,
 )
 from .generators import (

--- a/src/yohou/testing/conformal_adapter.py
+++ b/src/yohou/testing/conformal_adapter.py
@@ -1,0 +1,198 @@
+"""Check functions for yohou conformal adapters.
+
+Systematic validation functions for the ``BaseConformalAdapter`` estimator
+family (adaptive conformal inference adapters). All check functions raise
+AssertionError on failure.
+"""
+
+from sklearn.base import clone
+from sklearn.exceptions import NotFittedError
+
+__all__ = [
+    "check_conformal_adapter_clipping",
+    "check_conformal_adapter_methods_call_check_is_fitted",
+    "check_conformal_adapter_observe_rewind_round_trip",
+    "check_conformal_adapter_predict_returns_levels",
+    "check_conformal_adapter_update_direction",
+]
+
+_RATES = [0.9, 0.8]
+
+
+def _symmetric_errors(n: int) -> list[dict[float, object]]:
+    """Build ``n`` per-row symmetric miscoverage dicts over ``_RATES``."""
+    pattern = [1.0, 0.0]
+    return [{rate: pattern[(i + j) % 2] for j, rate in enumerate(_RATES)} for i in range(n)]
+
+
+def _asymmetric_errors(n: int) -> list[dict[float, object]]:
+    """Build ``n`` per-row asymmetric ``(lower, upper)`` miscoverage dicts."""
+    pattern = [(1.0, 0.0), (0.0, 1.0)]
+    return [{rate: pattern[(i + j) % 2] for j, rate in enumerate(_RATES)} for i in range(n)]
+
+
+def check_conformal_adapter_predict_returns_levels(adapter) -> None:
+    """Check ``predict`` returns one effective level per tracked coverage rate.
+
+    Parameters
+    ----------
+    adapter : BaseConformalAdapter
+        Adapter instance.
+
+    Raises
+    ------
+    AssertionError
+        If ``predict`` omits a tracked rate or returns a level outside
+        ``[0, 1]`` (per tail for asymmetric scorers).
+
+    """
+    name = type(adapter).__name__
+
+    fitted = clone(adapter).fit(_RATES, symmetric=True)
+    levels = fitted.predict()
+    assert set(levels) == set(_RATES), f"{name}.predict keys {set(levels)} != tracked rates {set(_RATES)}"
+    for rate, level in levels.items():
+        assert 0.0 <= float(level) <= 1.0, f"{name}.predict level {level} for rate {rate} outside [0, 1]"
+
+    fitted_asym = clone(adapter).fit(_RATES, symmetric=False)
+    levels_asym = fitted_asym.predict()
+    for rate, level in levels_asym.items():
+        lower, upper = level
+        assert 0.0 <= float(lower) <= 1.0 and 0.0 <= float(upper) <= 1.0, (
+            f"{name}.predict asymmetric level {level} for rate {rate} outside [0, 1]"
+        )
+
+
+def check_conformal_adapter_observe_rewind_round_trip(adapter) -> None:
+    """Check ``observe`` then ``rewind`` of the same rows restores the levels.
+
+    This is the core lifecycle invariant: a backtest that rolls forward then
+    rewinds must land exactly on its pre-observe state.
+
+    Parameters
+    ----------
+    adapter : BaseConformalAdapter
+        Adapter instance.
+
+    Raises
+    ------
+    AssertionError
+        If observing then rewinding does not restore the effective levels, or
+        if ``observe`` did not move them in the first place.
+
+    """
+    name = type(adapter).__name__
+
+    for symmetric, errors in ((True, _symmetric_errors(4)), (False, _asymmetric_errors(4))):
+        fitted = clone(adapter).fit(_RATES, symmetric=symmetric)
+        before = fitted.predict()
+
+        fitted.observe(errors)
+        moved = fitted.predict()
+        assert moved != before, f"{name}.observe (symmetric={symmetric}) did not change any level"
+
+        fitted.rewind(len(errors))
+        after = fitted.predict()
+        assert after == before, (
+            f"{name}: observe+rewind (symmetric={symmetric}) did not restore levels: {before} != {after}"
+        )
+
+
+def check_conformal_adapter_update_direction(adapter) -> None:
+    """Check miscoverage lowers the level and coverage raises it (symmetric).
+
+    Parameters
+    ----------
+    adapter : BaseConformalAdapter
+        Adapter instance.
+
+    Raises
+    ------
+    AssertionError
+        If a fully-miscovered update does not decrease the level, or a
+        fully-covered update does not increase it.
+
+    """
+    name = type(adapter).__name__
+    rate = _RATES[0]
+
+    miscover = clone(adapter).fit([rate], symmetric=True)
+    seed = float(miscover.predict()[rate])
+    miscover.observe([{rate: 1.0}])
+    assert float(miscover.predict()[rate]) < seed, (
+        f"{name}: a miscovered observation must lower the level (widen the interval)"
+    )
+
+    cover = clone(adapter).fit([rate], symmetric=True)
+    cover.observe([{rate: 0.0}])
+    assert float(cover.predict()[rate]) > seed, (
+        f"{name}: a covered observation must raise the level (narrow the interval)"
+    )
+
+
+def check_conformal_adapter_clipping(adapter) -> None:
+    """Check a positive ``epsilon`` keeps the level within ``[epsilon, 1 - epsilon]``.
+
+    Skipped for adapters without an ``epsilon`` parameter.
+
+    Parameters
+    ----------
+    adapter : BaseConformalAdapter
+        Adapter instance.
+
+    Raises
+    ------
+    AssertionError
+        If a sustained miscoverage streak drives the level below ``epsilon``.
+
+    """
+    name = type(adapter).__name__
+    if "epsilon" not in adapter.get_params(deep=False):
+        return
+
+    rate = _RATES[0]
+    epsilon = 0.1
+    clipped = clone(adapter).set_params(epsilon=epsilon).fit([rate], symmetric=True)
+    clipped.observe([{rate: 1.0}] * 200)
+    level = float(clipped.predict()[rate])
+    assert level >= epsilon - 1e-9, f"{name}: level {level} fell below epsilon={epsilon} despite clipping"
+    assert level <= 1.0 - epsilon + 1e-9, f"{name}: level {level} rose above 1 - epsilon={1 - epsilon}"
+
+
+def check_conformal_adapter_methods_call_check_is_fitted(adapter) -> None:
+    """Check ``predict``, ``observe``, and ``rewind`` raise ``NotFittedError`` before ``fit``.
+
+    Parameters
+    ----------
+    adapter : BaseConformalAdapter
+        Adapter instance.
+
+    Raises
+    ------
+    AssertionError
+        If any of ``predict``, ``observe``, or ``rewind`` does not raise
+        ``NotFittedError`` when unfitted.
+
+    """
+    name = type(adapter).__name__
+
+    unfitted = clone(adapter)
+    try:
+        unfitted.predict()
+        raise AssertionError(f"{name}.predict() must raise NotFittedError when unfitted")
+    except NotFittedError:
+        pass
+
+    unfitted2 = clone(adapter)
+    try:
+        unfitted2.observe([{_RATES[0]: 1.0}])
+        raise AssertionError(f"{name}.observe() must raise NotFittedError when unfitted")
+    except NotFittedError:
+        pass
+
+    unfitted3 = clone(adapter)
+    try:
+        unfitted3.rewind(1)
+        raise AssertionError(f"{name}.rewind() must raise NotFittedError when unfitted")
+    except NotFittedError:
+        pass

--- a/src/yohou/testing/generators.py
+++ b/src/yohou/testing/generators.py
@@ -28,6 +28,13 @@ from .common import (
     check_metadata_routing_get_metadata_routing,
 )
 from .composite import _yield_composite_reducer_checks
+from .conformal_adapter import (
+    check_conformal_adapter_clipping,
+    check_conformal_adapter_methods_call_check_is_fitted,
+    check_conformal_adapter_observe_rewind_round_trip,
+    check_conformal_adapter_predict_returns_levels,
+    check_conformal_adapter_update_direction,
+)
 from .contract import _yield_estimator_contract_checks
 from .forecaster import (
     check_clone_preserves_forecaster_params,
@@ -1513,3 +1520,40 @@ def _yield_yohou_similarity_checks(
         yield from _yield_composite_reducer_checks(
             similarity, descriptor, operate=lambda c: c.fit(y_calib, y_pred_calib)
         )
+
+
+def _yield_yohou_conformal_adapter_checks(
+    adapter,
+) -> Generator[tuple[str, Callable, dict], None, None]:
+    """Generate applicable checks for a conformal adapter.
+
+    Yields the conformal-adapter-family lifecycle checks (predict shape,
+    observe/rewind round-trip, update direction, clipping, and unfitted
+    guards) followed by the shared sklearn estimator-contract checks.
+
+    Parameters
+    ----------
+    adapter : BaseConformalAdapter
+        Adapter instance.
+
+    Yields
+    ------
+    tuple of (str, callable, dict)
+        ``(check_name, check_func, check_kwargs)`` consumable by ``run_checks``.
+
+    """
+    yield "check_conformal_adapter_predict_returns_levels", check_conformal_adapter_predict_returns_levels, {}
+    yield (
+        "check_conformal_adapter_observe_rewind_round_trip",
+        check_conformal_adapter_observe_rewind_round_trip,
+        {},
+    )
+    yield "check_conformal_adapter_update_direction", check_conformal_adapter_update_direction, {}
+    yield "check_conformal_adapter_clipping", check_conformal_adapter_clipping, {}
+    yield (
+        "check_conformal_adapter_methods_call_check_is_fitted",
+        check_conformal_adapter_methods_call_check_is_fitted,
+        {},
+    )
+
+    yield from _yield_estimator_contract_checks(adapter)

--- a/src/yohou/utils/tags.py
+++ b/src/yohou/utils/tags.py
@@ -10,6 +10,7 @@ from typing import ClassVar, Literal
 
 __all__ = [
     "CLASS_PROBA",
+    "ConformalAdapterTags",
     "ForecasterTags",
     "INTERVAL",
     "InputTags",
@@ -291,6 +292,30 @@ class SimilarityTags:
 
 
 @dataclass
+class ConformalAdapterTags:
+    """Tags specific to conformal adapters for adaptive conformal inference.
+
+    Parameters
+    ----------
+    online : bool, default=True
+        Whether the adapter updates its effective miscoverage level online
+        as new observations arrive (via ``observe``).
+    requires_coverage_rates : bool, default=True
+        Whether the adapter must be told the tracked coverage rates at fit
+        time in order to seed one effective level per rate.
+    tail_aware : bool, default=True
+        Whether the adapter respects the conformity scorer's ``symmetric``
+        tag, tracking one level for symmetric scorers and two (lower and
+        upper) for asymmetric ones.
+
+    """
+
+    online: bool = True
+    requires_coverage_rates: bool = True
+    tail_aware: bool = True
+
+
+@dataclass
 class SplitterTags:
     """Tags specific to cross-validation splitters.
 
@@ -359,7 +384,9 @@ class Tags:
 
     """
 
-    estimator_type: Literal["transformer", "forecaster", "scorer", "similarity", "splitter"] | None = None
+    estimator_type: (
+        Literal["transformer", "forecaster", "scorer", "similarity", "splitter", "conformal_adapter"] | None
+    ) = None
     requires_fit: bool = True
     non_deterministic: bool = False
     input_tags: InputTags | None = None
@@ -369,6 +396,7 @@ class Tags:
     forecaster_tags: ForecasterTags | None = None
     scorer_tags: ScorerTags | None = None
     similarity_tags: SimilarityTags | None = None
+    conformal_adapter_tags: ConformalAdapterTags | None = None
 
     def __post_init__(self):
         """Initialize nested tags after dataclass initialization."""
@@ -387,5 +415,7 @@ class Tags:
             self.scorer_tags = ScorerTags()
         elif self.estimator_type == "similarity" and self.similarity_tags is None:
             self.similarity_tags = SimilarityTags()
+        elif self.estimator_type == "conformal_adapter" and self.conformal_adapter_tags is None:
+            self.conformal_adapter_tags = ConformalAdapterTags()
         elif self.estimator_type == "splitter" and self.splitter_tags is None:
             self.splitter_tags = SplitterTags()

--- a/tests/interval/test_adapter.py
+++ b/tests/interval/test_adapter.py
@@ -1,0 +1,220 @@
+"""Tests for adaptive conformal inference adapters."""
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+from sklearn.base import clone
+from sklearn.exceptions import NotFittedError
+
+from yohou.interval import AdaptiveConformalInference, SplitConformalForecaster
+from yohou.interval.similarity import SeasonalSimilarity
+from yohou.metrics.conformity import AbsoluteResidual, Residual
+from yohou.point import SeasonalNaive
+
+
+def _series(n: int = 200, seed: int = 42) -> pl.DataFrame:
+    """A seasonal daily series with noise."""
+    dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+    rng = np.random.default_rng(seed)
+    values = [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + rng.normal(0, 0.5) for i in range(n)]
+    return pl.DataFrame({"time": dates, "value": values})
+
+
+def _fit(adapter=None, scorer=None, similarity=None, horizon=3, calib=50):
+    """Fit a SplitConformalForecaster on the first 180 rows of ``_series``."""
+    y = _series()
+    forecaster = SplitConformalForecaster(
+        point_forecaster=SeasonalNaive(seasonality=7),
+        calibration_size=calib,
+        conformity_scorer=scorer if scorer is not None else Residual(),
+        similarity=similarity,
+        adapter=adapter,
+    )
+    forecaster.fit(y[:180], forecasting_horizon=horizon, coverage_rates=[0.9])
+    return forecaster, y
+
+
+def _width(intervals: pl.DataFrame, rate: float = 0.9) -> list[float]:
+    """Interval widths for the given coverage rate."""
+    return (intervals[f"value_upper_{rate}"] - intervals[f"value_lower_{rate}"]).to_list()
+
+
+class TestAdaptiveConformalInferenceUnit:
+    """The adapter estimator in isolation."""
+
+    def test_fit_seeds_target_level_symmetric(self):
+        adapter = AdaptiveConformalInference(step_size=0.1).fit([0.9, 0.8], symmetric=True)
+        assert adapter.predict() == {0.9: pytest.approx(0.1), 0.8: pytest.approx(0.2)}
+
+    def test_fit_seeds_half_target_per_tail_asymmetric(self):
+        adapter = AdaptiveConformalInference().fit([0.9], symmetric=False)
+        lower, upper = adapter.predict()[0.9]
+        assert lower == pytest.approx(0.05)
+        assert upper == pytest.approx(0.05)
+
+    def test_miscoverage_lowers_level(self):
+        adapter = AdaptiveConformalInference(step_size=0.1).fit([0.9], symmetric=True)
+        adapter.observe([{0.9: 1.0}])
+        assert adapter.predict()[0.9] < 0.1
+
+    def test_coverage_raises_level(self):
+        adapter = AdaptiveConformalInference(step_size=0.1).fit([0.9], symmetric=True)
+        adapter.observe([{0.9: 0.0}])
+        assert adapter.predict()[0.9] > 0.1
+
+    def test_observe_rewind_round_trip(self):
+        adapter = AdaptiveConformalInference(step_size=0.1).fit([0.9, 0.8], symmetric=True)
+        before = adapter.predict()
+        adapter.observe([{0.9: 1.0, 0.8: 0.0}, {0.9: 0.0, 0.8: 1.0}, {0.9: 1.0, 0.8: 1.0}])
+        assert adapter.predict() != before
+        adapter.rewind(3)
+        assert adapter.predict() == before
+
+    def test_rewind_never_drops_below_seed(self):
+        adapter = AdaptiveConformalInference(step_size=0.1).fit([0.9], symmetric=True)
+        seed = adapter.predict()
+        adapter.observe([{0.9: 1.0}])
+        adapter.rewind(10)  # more than observed
+        assert adapter.predict() == seed
+
+    def test_epsilon_clips_level_floor(self):
+        adapter = AdaptiveConformalInference(step_size=0.2, epsilon=0.1).fit([0.9], symmetric=True)
+        adapter.observe([{0.9: 1.0}] * 100)
+        assert adapter.predict()[0.9] >= 0.1 - 1e-9
+
+    def test_default_epsilon_reaches_zero(self):
+        adapter = AdaptiveConformalInference(step_size=0.5).fit([0.9], symmetric=True)
+        adapter.observe([{0.9: 1.0}] * 100)
+        assert adapter.predict()[0.9] == pytest.approx(0.0)
+
+    def test_asymmetric_tails_adapt_independently(self):
+        adapter = AdaptiveConformalInference(step_size=0.1).fit([0.9], symmetric=False)
+        # Miss low only: lower level drops, upper level rises.
+        adapter.observe([{0.9: (1.0, 0.0)}])
+        lower, upper = adapter.predict()[0.9]
+        assert lower < 0.05
+        assert upper > 0.05
+
+    def test_unfitted_methods_raise(self):
+        adapter = AdaptiveConformalInference()
+        with pytest.raises(NotFittedError):
+            adapter.predict()
+        with pytest.raises(NotFittedError):
+            adapter.observe([{0.9: 1.0}])
+        with pytest.raises(NotFittedError):
+            adapter.rewind(1)
+
+    def test_clone_preserves_params(self):
+        adapter = AdaptiveConformalInference(step_size=0.2, alpha_pooling="shared", epsilon=0.05)
+        assert clone(adapter).get_params() == adapter.get_params()
+
+
+class TestAdapterInForecaster:
+    """The adapter wired into SplitConformalForecaster."""
+
+    def test_adapter_none_is_default(self):
+        forecaster, _ = _fit(adapter=None)
+        assert not hasattr(forecaster, "adapters_")
+
+    def test_adapter_none_deterministic(self):
+        # adapter=None must not perturb the static path.
+        f_a, _ = _fit(adapter=None)
+        f_b, _ = _fit(adapter=None)
+        assert_frame_equal(f_a.predict_interval(), f_b.predict_interval())
+
+    def test_adapter_fits_one_per_step(self):
+        forecaster, _ = _fit(adapter=AdaptiveConformalInference(), horizon=3)
+        assert set(forecaster.adapters_) == {"step_1", "step_2", "step_3"}
+
+    def test_seeded_adapter_labels_columns_nominally(self):
+        forecaster, _ = _fit(adapter=AdaptiveConformalInference())
+        cols = forecaster.predict_interval().columns
+        assert any(c == "value_lower_0.9" for c in cols)
+        assert any(c == "value_upper_0.9" for c in cols)
+
+    def test_observe_adapts_then_rewind_restores(self):
+        forecaster, y = _fit(adapter=AdaptiveConformalInference(step_size=0.1))
+        new = y[180:188]
+        before = forecaster.adapters_["step_1"].predict()
+        forecaster.observe(new)
+        assert forecaster.adapters_["step_1"].predict() != before
+        forecaster.rewind(new)
+        assert forecaster.adapters_["step_1"].predict() == before
+
+    def test_untracked_rate_warns_and_falls_back(self):
+        forecaster, _ = _fit(adapter=AdaptiveConformalInference())
+        with pytest.warns(UserWarning, match="not tracked"):
+            intervals = forecaster.predict_interval(coverage_rates=[0.8])
+        assert "value_lower_0.8" in intervals.columns
+
+    def test_tracked_rate_does_not_warn(self):
+        forecaster, _ = _fit(adapter=AdaptiveConformalInference())
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            forecaster.predict_interval(coverage_rates=[0.9])
+
+    def test_symmetric_scorer_single_level(self):
+        forecaster, y = _fit(adapter=AdaptiveConformalInference(), scorer=AbsoluteResidual())
+        level = forecaster.adapters_["step_1"].predict()[0.9]
+        assert isinstance(level, float)
+
+    def test_asymmetric_scorer_two_tails(self):
+        forecaster, y = _fit(adapter=AdaptiveConformalInference(), scorer=Residual())
+        level = forecaster.adapters_["step_1"].predict()[0.9]
+        assert isinstance(level, tuple) and len(level) == 2
+
+    def test_composes_with_similarity(self):
+        forecaster, y = _fit(
+            adapter=AdaptiveConformalInference(step_size=0.1),
+            scorer=AbsoluteResidual(),
+            similarity=SeasonalSimilarity(seasonality=[7.0]),
+        )
+        # Both add-ons active and the lifecycle runs end to end.
+        forecaster.observe(y[180:188])
+        intervals = forecaster.predict_interval()
+        assert len(intervals) == 3
+        assert forecaster.adapters_["step_1"].predict()[0.9] != 0.1
+
+    def test_shared_pooling_ties_steps_together(self):
+        forecaster, y = _fit(
+            adapter=AdaptiveConformalInference(step_size=0.1, alpha_pooling="shared"),
+            scorer=AbsoluteResidual(),
+        )
+        forecaster.observe(y[180:188])
+        levels = [forecaster.adapters_[f"step_{s}"].predict()[0.9] for s in (1, 2, 3)]
+        assert levels[0] == pytest.approx(levels[1]) == pytest.approx(levels[2])
+
+    def test_shared_pooling_with_asymmetric_scorer(self):
+        # Shared pooling must pool each tail across steps for asymmetric scorers.
+        forecaster, y = _fit(
+            adapter=AdaptiveConformalInference(step_size=0.1, alpha_pooling="shared"),
+            scorer=Residual(),
+        )
+        forecaster.observe(y[180:188])
+        levels = [forecaster.adapters_[f"step_{s}"].predict()[0.9] for s in (1, 2, 3)]
+        # Every step shares one (lower, upper) trajectory.
+        assert all(isinstance(level, tuple) for level in levels)
+        assert levels[0] == pytest.approx(levels[1])
+        assert levels[1] == pytest.approx(levels[2])
+
+    def test_per_step_pooling_allows_divergence(self):
+        forecaster, y = _fit(
+            adapter=AdaptiveConformalInference(step_size=0.1, alpha_pooling="per_step"),
+            scorer=AbsoluteResidual(),
+        )
+        forecaster.observe(y[180:190])
+        levels = {s: forecaster.adapters_[f"step_{s}"].predict()[0.9] for s in (1, 2, 3)}
+        # Different horizons generally realize different coverage, so at least
+        # one step's level should differ from another.
+        assert len({round(v, 6) for v in levels.values()}) > 1
+
+    def test_observe_predict_interval_loop_runs(self):
+        forecaster, y = _fit(adapter=AdaptiveConformalInference(step_size=0.1), scorer=AbsoluteResidual())
+        out = forecaster.observe_predict_interval(y[180:190], stride=1, coverage_rates=[0.9])
+        assert "value_lower_0.9" in out.columns
+        assert len(out) > 0

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -14,11 +14,12 @@ from sklearn.base import clone
 
 from conftest import run_checks
 from yohou.base import BaseActualTransformer, BaseForecaster
-from yohou.interval.base import BaseSimilarity
+from yohou.interval.base import BaseConformalAdapter, BaseSimilarity
 from yohou.metrics.base import BaseScorer
 from yohou.model_selection.split import BaseSplitter
 from yohou.testing import (
     _yield_composition_contract_checks,
+    _yield_yohou_conformal_adapter_checks,
     _yield_yohou_forecaster_checks,
     _yield_yohou_scorer_checks,
     _yield_yohou_similarity_checks,
@@ -54,6 +55,8 @@ _SKIP_COMMON = {
     "SklearnScaler",
     # Similarity (not a standard estimator type)
     "DistanceSimilarity",
+    # Conformal adapter (not a standard estimator type; tested by TestConformalAdapterCommon)
+    "AdaptiveConformalInference",
     # Meta-forecasters requiring inner estimator (tested in tests/interval/)
     "SplitConformalForecaster",
     # Requires a timezone-aware "time" column, which the common sweep's tz-naive
@@ -482,6 +485,35 @@ class TestSimilarityCommon:
         similarity = instances[name]
         y_calib, y_pred_calib = _similarity_calibration()
         run_checks(similarity, _yield_yohou_similarity_checks(similarity, y_calib, y_pred_calib))
+
+
+def _conformal_adapter_instances() -> dict[str, object]:
+    """Representative *working* conformal adapter instances keyed by class name."""
+    from yohou.interval.adapter import AdaptiveConformalInference
+
+    return {
+        "AdaptiveConformalInference": AdaptiveConformalInference(),
+    }
+
+
+class TestConformalAdapterCommon:
+    """Run systematic checks on all discovered conformal adapters."""
+
+    @pytest.mark.parametrize(
+        "name,cls",
+        [(n, c) for n, c in all_estimators() if issubclass(c, BaseConformalAdapter)],
+        ids=[n for n, c in all_estimators() if issubclass(c, BaseConformalAdapter)],
+    )
+    def test_conformal_adapter_checks(self, name, cls):
+        """Run all applicable check-generator checks for a conformal adapter."""
+        instances = _conformal_adapter_instances()
+        if name not in instances:
+            pytest.fail(
+                f"{name} is not registered in _conformal_adapter_instances(). Add a representative "
+                "instance there following the create-yohou-conformal-adapter skill pattern."
+            )
+        adapter = instances[name]
+        run_checks(adapter, _yield_yohou_conformal_adapter_checks(adapter))
 
 
 def _composition_descriptors() -> dict[str, dict]:


### PR DESCRIPTION
## Description

Adds an optional, pluggable adaptive conformal inference add-on to `SplitConformalForecaster`. A new `BaseConformalAdapter` estimator family and a concrete `AdaptiveConformalInference` (Gibbs and Candes, 2021) track a time-varying effective miscoverage level online, restoring target coverage under distribution shift. With `adapter=None` (the default), the static calibration path is byte-for-byte unchanged.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

A static calibration set fixes interval width once, so under drift the realized coverage drifts and never corrects. The adapter closes that loop inside the existing `observe` / `predict_interval` / `rewind` lifecycle, so backtests and production replay share one code path. It follows the precedent set by the optional `similarity` add-on and composes with it: the similarity sets the weights, the adapter sets the level.

Design and decisions were captured in the OpenSpec change `add-adaptive-conformal-inference` (local `openspec/`, gitignored) and passed an `openspec-review` gate.

Fixes #

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Design decisions baked in:

- **Pluggable adapter** (not a scalar param), mirroring the `similarity` family, so variants like DtACI drop in later.
- **Per-step dict of clones** (`adapters_`), each keyed internally by `(coverage_rate, tail)`; `fit` receives the coverage rates and the scorer's `symmetric` tag.
- **`alpha_pooling`** `per_step` (default) or `shared`; **`epsilon`** clipping defaulting to `0.0` (paper-exact); **tag-driven** one level for symmetric scorers, two per-tail levels for asymmetric.
- **Untracked coverage rate** falls back to the static level with a warning.

Verification: `just lint` (ruff + ty) passes; the full `just test-fast` shows **4929 passed** with new-code coverage of 98%+ (adapter module 100%). The only red in the local full run was three example-notebook timeouts from running suites concurrently; the affected notebook completes in ~173s idle and does not exercise the adapter path (`adapter=None`).
