### PR TITLE
chore(template): sync to v0.36.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: e748f5c10c0fdd611bbbdae3783c130a82da87bd
+_commit: 804bc6947a8671392eb93470bb7fe0b8874722ee
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,8 +16,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    # Codecov upload authenticates via GitHub OIDC (tokenless) -- no stored CODECOV_TOKEN.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -46,9 +48,9 @@ jobs:
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v7
-        if: ${{ matrix.python-version == '3.12' && env.CODECOV_TOKEN != '' }}
+        if: ${{ matrix.python-version == '3.12' }}
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          use_oidc: true
 
   create-issue-on-failure:
     needs: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,8 +102,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    # Codecov upload authenticates via GitHub OIDC (tokenless) -- no stored CODECOV_TOKEN.
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -135,17 +137,17 @@ jobs:
         run: nox -s test --python ${{ matrix.python-version }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && matrix.python-version == '3.11' && env.CODECOV_TOKEN != '' }}
+        if: ${{ !cancelled() && matrix.python-version == '3.11' }}
         uses: codecov/test-results-action@v1
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          use_oidc: true
           file: '${{ github.workspace }}/junit.${{ matrix.python-version }}.xml'
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v7
-        if: ${{ matrix.python-version == '3.11' && env.CODECOV_TOKEN != '' }}
+        if: ${{ matrix.python-version == '3.11' }}
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          use_oidc: true
           files: '${{ github.workspace }}/coverage.${{ matrix.python-version }}.xml'
           env_vars: OS,PYTHON
           fail_ci_if_error: true


### PR DESCRIPTION
Syncs yohou to python-package-copier template **v0.36.0** (`_commit` e748f5c -> 804bc69).

## Changes (workflow-YAML only)
- **Codecov -> tokenless GitHub OIDC** in `tests.yml` and `nightly.yml`:
  - Coverage/test-results steps now use `use_oidc: true` (no `token:` input).
  - Job gains `permissions: { contents: read, id-token: write }`.
  - Removed the `CODECOV_TOKEN` env, `token:` inputs, and `env.CODECOV_TOKEN != ''` guards (yohou is public).
- **scorecard.yml**: reconciles cleanly to `ossf/scorecard-action@v2.4.4` (yohou was already hotfixed to v2.4.4 on main, so no change was produced).

## Verification
- Only 3 files changed: `.copier-answers.yml`, `.github/workflows/tests.yml`, `.github/workflows/nightly.yml`. No nav/docs changes; `docs/assets` untouched.
- No `.rej` files, no merge conflicts.
- yohou-local drift preserved (e.g. `GIT_LFS_SKIP_SMUDGE` in `changelog.yml`).
- prek (lint/format/secrets) clean.
- The `CODECOV_TOKEN` repo secret is intentionally left untouched (retired fleet-wide only after all sync PRs merge).

Held for review; do not merge.