### PR TITLE
docs(api): regenerate stale testing.md API summary

### DIFF
--- a/docs/pages/api/testing.md
+++ b/docs/pages/api/testing.md
@@ -37,6 +37,7 @@ Testing utilities for Yohou estimators.
 | [`check_forecaster_tags_match_capabilities`](generated/yohou.testing.check_forecaster_tags_match_capabilities.md) | Check forecaster tags accurately reflect capabilities. |
 | [`check_forecaster_tags_static_after_fit`](generated/yohou.testing.check_forecaster_tags_static_after_fit.md) | Check forecaster tags remain static after fit(). |
 | [`check_forecasting_horizon_validation`](generated/yohou.testing.check_forecasting_horizon_validation.md) | Check forecasting_horizon < 1 raises ValueError. |
+| [`check_mixed_cadence_X_forecast_resolves`](generated/yohou.testing.check_mixed_cadence_X_forecast_resolves.md) | Check that a channel on a slower schedule survives step-column derivation. |
 | [`check_observe_auto_rederives_step_columns`](generated/yohou.testing.check_observe_auto_rederives_step_columns.md) | Check observe() re-derives step columns from stored raws. |
 | [`check_observe_extends_observations`](generated/yohou.testing.check_observe_extends_observations.md) | Check observe() extends observation buffers correctly. |
 | [`check_observe_predict_interval_with_step_columns`](generated/yohou.testing.check_observe_predict_interval_with_step_columns.md) | Check observe_predict_interval works with step columns (lightweight). |


### PR DESCRIPTION
yohou's committed `docs/pages/api/testing.md` was stale: `check_mixed_cadence_X_forecast_resolves` exists in `src/yohou/testing/forecaster.py` but was missing from the generated summary. Regenerated via `docs_build/build.py prebuild` — only this one file changed (no SHA churn). Surfaced by the v0.36.0 fan-out; unrelated to that release.