### PR TITLE
chore(template): sync to v0.37.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 804bc6947a8671392eb93470bb7fe0b8874722ee
+_commit: 3b9107a65f86f0e52e8a03fd704b033ccdbcf7a2
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin


### PR DESCRIPTION
Syncs yohou to python-package-copier template **v0.37.0**.

The v0.36.0 → v0.37.0 delta is **docs-only**: it adds a gitsign tag-signing section to the template's `docs/pages/how-to/contribute.md` (Release Process now uses `git tag -s` plus a one-time gitsign config block). It touches no nav, workflows, or config.

**This update is inert for yohou.** yohou deleted its `docs/pages/how-to/contribute.md` (curated how-to set), and that file is not `_skip_if_exists`-listed, so copier does not recreate a locally-deleted file. The only resulting change is the `_commit` bump in `.copier-answers.yml`.

- No `.rej` files, no merge conflicts.
- `contribute.md` was **not** recreated.
- `docs/assets` untouched.
- prek clean.

Held for review; do not merge.