### PR TITLE
chore(template): update from python-package-copier v0.38.0

### DIFF
--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -109,6 +109,14 @@ CODEOWNERS
 Project-specific files where the template only provides initial scaffolding. Never overwrite with template content after initial generation.
 
 ```text
+CLAUDE.md                          # Project instructions for AI assistants. Seeded
+                                   # once, then owned entirely by the project: it
+                                   # records what is true about *this* project, so
+                                   # the template's version survives nowhere.
+                                   # Enforced by _skip_if_exists in copier.yml, not
+                                   # by this classification -- copier ignores tiers,
+                                   # and a page it keeps re-delivering gets reverted
+                                   # by one shifted line (v0.22.0, five projects).
 src/<package_name>/**              # All source code
 tests/**                           # All test files
 examples/**                        # conditional: include_examples

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 3b9107a65f86f0e52e8a03fd704b033ccdbcf7a2
+_commit: 80ca9f8f495a141f90bb5ff7b980c5b25d63a922
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.gitignore
+++ b/.gitignore
@@ -97,13 +97,13 @@ docs/pages/api/generated/
 # Worktrees
 .worktrees/
 
-# AI Assistant Instructions
-CLAUDE.md
-CLAUDE_INSTRUCTIONS.md
-.claude.md
-claude-instructions.md
-claude-config.md
-claude-prompt.md
+# AI assistant instructions are NOT ignored. CLAUDE.md is project content: it is
+# where a project records what a newcomer cannot derive from the code, and ignoring
+# it meant no generated project could keep that anywhere the repo could see. The
+# template seeds it once (see _skip_if_exists in copier.yml) and never overwrites it.
+
+# Local review scratch space (this project's own entry, kept across the update: it
+# shared a block with the AI-instructions entries the template removed).
 reviews/
 
 # GitHub Copilot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# Yohou
+
+A time series forecasting package based on Scikit-Learn and Polars
+
+Instructions for AI coding assistants working in this repository.
+
+**This file is yours.** It is seeded once when the project is generated and never
+delivered again: a template update will not overwrite your edits, and there is no
+merge to lose. Rewrite it freely. What follows is a starting point, not a contract.
+
+## Project overview
+
+A Python package generated from [python-package-copier](https://github.com/stateful-y/python-package-copier).
+Source lives in `src/yohou/`, tests in `tests/`.
+
+## Critical workflows
+
+- **Package management**: `uv` exclusively. No `pip`, no `venv`.
+- **Task running**: `just` (see `just --list`), or `uvx nox` for the CI sessions.
+- **Setup**: `just install` creates the lockfile and installs the git hooks.
+  The `-f` matters: without it an existing pre-commit shim is chained rather than
+  replaced, and both run on every commit.
+- **Testing**: `just test-fast` for quick feedback, `just test` for everything.
+- **Lint and format**: `just fix`. Tools are pinned by `uv.lock`, so `--locked`
+  failures mean the lockfile is stale, not that the tool changed.
+- **Docs**: `just serve` to preview, `just build` to build.
+
+## Conventions
+
+- Conventional commits are enforced at commit time and on pull request titles.
+- `uv.lock` is tracked and CI runs with `--locked`; commit it with dependency changes.
+- Docstrings follow numpydoc. In `References` sections use a markdown ordered list
+  with plain `[1]` citations, never reStructuredText (`.. [1]` or `[1]_`), which
+  renders literally on the generated API pages.
+
+## What to record here
+
+The things a newcomer cannot derive from the code: why a dependency is pinned, which
+assumptions this project breaks relative to the template, what a failing check
+actually means. Keep it short enough that it stays true.


### PR DESCRIPTION
Template update to **v0.38.0**.

## What changes

- **`CLAUDE.md` is seeded** — a project-instructions file for AI coding assistants, rendered with this project's own name and description.
- **The generated `.gitignore` stops excluding it.** Until now the template ignored six `CLAUDE*` filename variants and shipped no replacement, so no generated project could record what a newcomer cannot derive from the code anywhere the repository could see it.

## The file is yours

Registered in the template's `_skip_if_exists`, so it is delivered **once** and never again. Rewrite it freely; template updates will leave it alone.

## One conflict, resolved

This project had added `reviews/` to the same ignore block the template removed, so the block conflicted. **`reviews/` is kept**, moved to its own section since it has nothing to do with AI instructions.

Worth flagging how that presented, because it is the fleet's silent-failure shape: `copier update` **exited 0**, produced no `.rej`, and `git status` did **not** list `CLAUDE.md` — because the unresolved `.gitignore` still contained `CLAUDE.md`, so git treated the newly-delivered file as ignored. The file was on disk the whole time. A sweep reading only exit codes, `.rej` files, or `git status` would have reported this repo clean and the file undelivered, both wrong.

Note `.github/skills/` is gitignored in generated projects, so the Copilot mirror of the update-skill reference is not refreshed here. Known, separately tracked.