### PR TITLE
perf(reduction): stop shipping the forecaster per predict task, batch panel groups

### DIFF
--- a/src/yohou/base/reduction.py
+++ b/src/yohou/base/reduction.py
@@ -28,6 +28,54 @@ from yohou.weighting.weighters import _combine_weight_vectors, _resolve_weighter
 __all__ = ["BaseReductionForecaster"]
 
 
+def _predict_direct_step(
+    estimator: BaseEstimator,
+    X_tab: pl.DataFrame,
+    n_targets: int,
+    row_ok: np.ndarray,
+) -> np.ndarray:
+    """Predict one horizon step for every observation row given.
+
+    Module level and free of any reference to the forecaster: a task dispatched to a
+    worker carries this function by name, the one estimator for its step, and the feature
+    rows, and nothing else.
+
+    One call covers every panel group. Under ``panel_strategy="global"`` all groups share
+    the estimator for a given step, so their feature rows stack into a single call rather
+    than one call per group.
+
+    Parameters
+    ----------
+    estimator : BaseEstimator
+        Fitted estimator for this horizon step.
+    X_tab : pl.DataFrame
+        Feature rows, one per observation unit (one per panel group, or a single row when
+        the data is not a panel).
+    n_targets : int
+        Target columns to take from the prediction.
+    row_ok : np.ndarray
+        Boolean mask, ``True`` for rows safe to feed to the estimator. Rows masked out
+        yield NaN. Resolved by the caller, so this function needs neither the
+        ``nan_handling`` mode nor the check itself.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape ``(n_rows, n_targets)``, NaN in the rows ``row_ok`` excluded.
+
+    """
+    out = np.full((X_tab.height, n_targets), np.nan)
+    if row_ok.all():
+        kept = X_tab
+    elif row_ok.any():
+        kept = X_tab.filter(pl.Series(row_ok))
+    else:
+        return out
+    pred = np.asarray(estimator.predict(kept))  # ty: ignore[unresolved-attribute]
+    out[row_ok] = pred.reshape(kept.height, -1)[:, :n_targets]
+    return out
+
+
 class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
     """Base class for forecasters using reduction to supervised learning.
 
@@ -82,11 +130,18 @@ class BaseReductionForecaster(BaseForecaster, metaclass=abc.ABCMeta):
         dropped rows. At predict time, returns NaN predictions for any
         time step whose features contain NaN.
     n_jobs : int or None, default=None
-        Number of jobs to run in parallel for the ``"direct"`` strategy
-        (fitting and predicting H independent models). ``None`` means 1
-        unless in a ``joblib.parallel_backend`` context. ``-1`` means
-        using all processors. Has no effect for ``"multi-output"`` or
-        ``"dir-rec"`` strategies.
+        Number of jobs to run in parallel over the H independent models of
+        the ``"direct"`` strategy, at fit and at predict. ``None`` means 1
+        unless in a ``joblib.parallel_backend`` context. ``-1`` means using
+        all processors. Has no effect for ``"multi-output"`` or ``"dir-rec"``
+        strategies.
+
+        Raising it above 1 pays at fit, where a task is a whole estimator
+        training. At predict whether it pays depends on the estimator: a task
+        is one call over the stacked observation rows, so a gradient-boosted
+        model on a wide feature matrix gains from the dispatch while a linear
+        model spends more on dispatch than the inference costs. Left at the
+        default, prediction runs serially and dispatches nothing.
     time_weighter : instance of `BaseWeighter` or None, default=None
         Weighter producing per-timestamp weights for the target time
         axis. Converted to sklearn ``sample_weight`` for training using
@@ -1261,32 +1316,56 @@ default="first_step"
         assert self.local_y_t_schema_ is not None
         y_cols = list(self.local_y_t_schema_.keys())
         n_targets = len(y_cols)
+        drop_nan = self.nan_handling == "drop"
 
-        def _predict_step(est: BaseEstimator, X_tab: pl.DataFrame) -> np.ndarray:
-            """Predict a single horizon step."""
-            if self.nan_handling == "drop" and self._features_have_nan(X_tab):
-                return np.full(n_targets, np.nan)
-            pred = est.predict(X_tab)  # ty: ignore[unresolved-attribute]
-            return np.atleast_1d(pred.ravel())[:n_targets]
+        # One feature row per observation unit: the single row for non-panel data, or one
+        # row per panel group stacked. Under panel_strategy="global" every group shares
+        # `estimators[step]`, so a step is one call over the stacked rows rather than one
+        # call per group. That is the same arithmetic with an order of magnitude fewer
+        # estimator calls, and it removes the per-call validation overhead that dominates
+        # cheap estimators.
+        # `groups_` is populated only under ``panel_strategy="global"``: `_pre_fit` routes
+        # ``"multivariate"`` to the standard path, which leaves it None. That is what makes
+        # one call per step sound, because every group then shares `estimators[step]`. A
+        # future panel strategy that populated `groups_` without that sharing would batch
+        # rows belonging to different models and be wrong in silence, so pin the invariant
+        # rather than leave it implicit.
+        assert self.groups_ is None or self.panel_strategy == "global", (
+            "batched prediction assumes every panel group shares the step's estimator, "
+            f"which panel_strategy={self.panel_strategy!r} does not guarantee"
+        )
 
-        if self.groups_ is None:
-            X_tab = self._get_predict_features()
-            rows: list[np.ndarray] = Parallel(n_jobs=self.n_jobs)(
-                delayed(_predict_step)(est, self._filter_step_features(X_tab, step + 1))
-                for step, est in enumerate(estimators)
-            )
-            y_pred_arr = np.vstack(rows)
-            y_pred = pl.DataFrame(y_pred_arr, schema=y_cols)
+        panel = self.groups_ is not None
+        X_tab = (
+            pl.concat([self._get_predict_features(g) for g in groups], how="vertical")
+            if panel
+            else self._get_predict_features()
+        )
+
+        # Step filtering depends only on column names, which are the local schema's and so
+        # shared across groups: filter once per step, not once per group per step.
+        step_frames = [self._filter_step_features(X_tab, step + 1) for step in range(len(estimators))]
+        row_masks = [
+            (self._compute_x_ok_mask(frame).to_numpy() if drop_nan else np.ones(frame.height, dtype=bool))
+            for frame in step_frames
+        ]
+
+        # `n_jobs` pays off only when a step's inference costs more than dispatching it,
+        # which depends on the estimator: a gradient-boosted model over a wide frame is
+        # milliseconds and gains, a linear model is well under and loses. It defaults to
+        # 1, so dispatch is opt-in.
+        step_preds: list[np.ndarray] = Parallel(n_jobs=self.n_jobs)(
+            delayed(_predict_direct_step)(est, frame, n_targets, mask)
+            for est, frame, mask in zip(estimators, step_frames, row_masks, strict=True)
+        )
+
+        if not panel:
+            y_pred = pl.DataFrame(np.vstack([p[0] for p in step_preds]), schema=y_cols)
             return cast(y_pred, self.local_y_t_schema_)
 
         y_pred_dict = {}
-        for panel_group_name in groups:
-            X_tab = self._get_predict_features(panel_group_name)
-            rows = Parallel(n_jobs=self.n_jobs)(
-                delayed(_predict_step)(est, self._filter_step_features(X_tab, step + 1))
-                for step, est in enumerate(estimators)
-            )
-            y_pred_arr = np.vstack(rows)
+        for row, panel_group_name in enumerate(groups):
+            y_pred_arr = np.vstack([step_pred[row] for step_pred in step_preds])
             y_pred_local = pl.DataFrame(y_pred_arr, schema=y_cols)
             y_pred_local = cast(y_pred_local, self.local_y_t_schema_)
             y_pred_local = y_pred_local.rename({col: f"{panel_group_name}__{col}" for col in y_cols})

--- a/src/yohou/interval/reduction.py
+++ b/src/yohou/interval/reduction.py
@@ -56,11 +56,18 @@ class IntervalReductionForecaster(BaseReductionForecaster, BaseIntervalForecaste
         dropped rows. At predict time, returns NaN predictions for any
         time step whose features contain NaN.
     n_jobs : int or None, default=None
-        Number of jobs to run in parallel for the ``"direct"`` strategy
-        (fitting and predicting H independent models). ``None`` means 1
-        unless in a ``joblib.parallel_backend`` context. ``-1`` means
-        using all processors. Has no effect for ``"multi-output"`` or
-        ``"dir-rec"`` strategies.
+        Number of jobs to run in parallel over the H independent models of
+        the ``"direct"`` strategy, at fit and at predict. ``None`` means 1
+        unless in a ``joblib.parallel_backend`` context. ``-1`` means using
+        all processors. Has no effect for ``"multi-output"`` or ``"dir-rec"``
+        strategies.
+
+        Raising it above 1 pays at fit, where a task is a whole estimator
+        training. At predict whether it pays depends on the estimator: a task
+        is one call over the stacked observation rows, so a gradient-boosted
+        model on a wide feature matrix gains from the dispatch while a linear
+        model spends more on dispatch than the inference costs. Left at the
+        default, prediction runs serially and dispatches nothing.
     step_feature_alignment : {"all", "matched", "cumulative"}, default="all"
         Controls which step-indexed feature columns each direct estimator
         sees. Only the ``"direct"`` strategy applies this parameter; a

--- a/src/yohou/point/reduction.py
+++ b/src/yohou/point/reduction.py
@@ -52,11 +52,18 @@ class PointReductionForecaster(BaseReductionForecaster, BasePointForecaster):
         dropped rows. At predict time, returns NaN predictions for any
         time step whose features contain NaN.
     n_jobs : int or None, default=None
-        Number of jobs to run in parallel for the ``"direct"`` strategy
-        (fitting and predicting H independent models). ``None`` means 1
-        unless in a ``joblib.parallel_backend`` context. ``-1`` means
-        using all processors. Has no effect for ``"multi-output"`` or
-        ``"dir-rec"`` strategies.
+        Number of jobs to run in parallel over the H independent models of
+        the ``"direct"`` strategy, at fit and at predict. ``None`` means 1
+        unless in a ``joblib.parallel_backend`` context. ``-1`` means using
+        all processors. Has no effect for ``"multi-output"`` or ``"dir-rec"``
+        strategies.
+
+        Raising it above 1 pays at fit, where a task is a whole estimator
+        training. At predict whether it pays depends on the estimator: a task
+        is one call over the stacked observation rows, so a gradient-boosted
+        model on a wide feature matrix gains from the dispatch while a linear
+        model spends more on dispatch than the inference costs. Left at the
+        default, prediction runs serially and dispatches nothing.
     step_feature_alignment : {"all", "matched", "cumulative"}, default="all"
         Controls which step-indexed feature columns each direct estimator
         sees. Only the ``"direct"`` strategy applies this parameter; a

--- a/tests/point/test_reduction.py
+++ b/tests/point/test_reduction.py
@@ -6,6 +6,7 @@ import polars as pl
 import polars.selectors as cs
 import pytest
 from sklearn.base import BaseEstimator, clone
+from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.linear_model import LinearRegression, Ridge
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
@@ -1181,6 +1182,236 @@ class TestNJobsParameter:
             y_seq.select(cs.numeric()).to_numpy(),
             y_par.select(cs.numeric()).to_numpy(),
         )
+
+    @pytest.mark.parametrize("panel", [False, True])
+    def test_predict_frames_are_identical_across_n_jobs(self, y_X_factory, panel):
+        """n_jobs selects an execution strategy, never a result.
+
+        Stronger than allclose: the frames must match exactly, including column
+        names, dtypes, row order and vintage_time.
+        """
+        y, X_actual = y_X_factory(length=60, n_targets=1, n_features=2, panel=panel, n_groups=3)
+
+        frames = []
+        for n_jobs in (1, 2):
+            forecaster = PointReductionForecaster(reduction_strategy="direct", n_jobs=n_jobs)
+            forecaster.fit(y=y, X_actual=X_actual, forecasting_horizon=4)
+            frames.append(forecaster.predict())
+
+        seq, par = frames
+        assert seq.columns == par.columns
+        assert seq.dtypes == par.dtypes
+        assert seq.equals(par)
+
+    @pytest.mark.parametrize("nan_handling", ["pass", "drop"])
+    def test_nan_handling_is_preserved_across_n_jobs(self, y_X_factory, nan_handling):
+        """Both NaN modes behave the same however the work is dispatched.
+
+        The estimator is NaN-tolerant because ``"pass"`` means exactly that: the nulls
+        reach it untouched, which a ``LinearRegression`` would reject.
+        """
+        from sklearn.ensemble import HistGradientBoostingRegressor
+
+        y, X_actual = y_X_factory(length=60, n_targets=1, n_features=2)
+        # Null the last observation so the predict-time feature row carries a null.
+        feature = [c for c in X_actual.columns if c != "time"][0]
+        X_actual = X_actual.with_columns(
+            pl
+            .when(pl.arange(0, X_actual.height) == X_actual.height - 1)
+            .then(None)
+            .otherwise(pl.col(feature))
+            .alias(feature)
+        )
+
+        frames = []
+        for n_jobs in (1, 2):
+            forecaster = PointReductionForecaster(
+                estimator=HistGradientBoostingRegressor(max_iter=5, min_samples_leaf=2, random_state=0),
+                reduction_strategy="direct",
+                n_jobs=n_jobs,
+                nan_handling=nan_handling,
+            )
+            forecaster.fit(y=y, X_actual=X_actual, forecasting_horizon=4)
+            frames.append(forecaster.predict())
+
+        seq, par = frames
+        assert seq.equals(par)
+
+        values = seq.select(cs.numeric()).to_numpy()
+        assert values.size > 0
+        if nan_handling == "drop":
+            # The null reaches the predict feature row, so every step returns NaN.
+            assert np.isnan(values).all()
+        else:
+            # A NaN-tolerant estimator sees the null and still predicts.
+            assert not np.isnan(values).any()
+
+    def test_dispatched_task_does_not_carry_the_forecaster(self, y_X_factory):
+        """Regression guard for the closure capture.
+
+        `_predict_direct_step` used to be nested inside `_estimator_predict_direct` and
+        to read `self`, so cloudpickle captured the whole fitted forecaster into every
+        dispatched task: for a 48 step horizon, all 48 models shipped to use one.
+
+        This pickles what joblib actually ships, through the same cloudpickle loky uses.
+        Pickling the module-level function directly would prove nothing, because it
+        serializes by name under any implementation.
+        """
+        from joblib.externals import cloudpickle
+        from sklearn.utils.parallel import delayed
+
+        from yohou.base.reduction import _predict_direct_step
+
+        # A re-nested function carries `<locals>` in its qualname and cells in its
+        # closure, and cloudpickle serializes whatever those cells reach.
+        assert "<locals>" not in _predict_direct_step.__qualname__
+        assert _predict_direct_step.__closure__ is None
+
+        y, X_actual = y_X_factory(length=120, n_targets=1, n_features=2)
+        forecaster = PointReductionForecaster(reduction_strategy="direct")
+        forecaster.fit(y=y, X_actual=X_actual, forecasting_horizon=24)
+
+        X_tab = forecaster._get_predict_features()
+        task = delayed(_predict_direct_step)(forecaster.estimator_[0], X_tab, 1, np.ones(X_tab.height, dtype=bool))
+        payload = len(cloudpickle.dumps(task))
+        one_model = len(cloudpickle.dumps(forecaster.estimator_[0]))
+        whole_forecaster = len(cloudpickle.dumps(forecaster))
+
+        # The task tracks the one model it needs, not the forecaster holding all 24.
+        assert payload < one_model + 8192
+        assert payload < whole_forecaster / 2
+
+
+def _assert_matches_per_group(batched, reference):
+    """Structure exactly, values to within floating-point reassociation.
+
+    Batching predicts every panel group in one call, so a linear model's inference is a
+    single ``(n_groups, n_features)`` matmul instead of ``n_groups`` separate
+    ``(1, n_features)`` ones. BLAS reassociates and the last bit can differ, measured at
+    1 ULP. Tree models come out bit-identical, but the assertion has to hold for both, so
+    this is the one place the batched path is not exactly the per-group path.
+
+    The small ``atol`` is not slack for the reassociation, which is relative. It covers a
+    reference value of exactly zero, where a relative tolerance admits nothing at all and
+    any nonzero batched value would fail.
+    """
+    assert batched.columns == reference.columns
+    assert batched.dtypes == reference.dtypes
+    np.testing.assert_allclose(batched.to_numpy(), reference.to_numpy(), rtol=1e-12, atol=1e-15)
+
+
+def _reference_predict_per_group(forecaster):
+    """Predict the pre-batching way: one estimator call per (group, step).
+
+    The batched path stacks every panel group's feature row into one call per step.
+    That is only sound if all groups share the step's estimator and see the same step
+    columns, so this reconstructs the per-group algorithm as the thing to match.
+    """
+    from yohou.utils import cast as _cast
+
+    y_cols = list(forecaster.local_y_t_schema_.keys())
+    n_targets = len(y_cols)
+    out = {}
+    for group in forecaster.groups_:
+        X_tab = forecaster._get_predict_features(group)
+        rows = []
+        for step, est in enumerate(forecaster.estimator_):
+            X_step = forecaster._filter_step_features(X_tab, step + 1)
+            if forecaster.nan_handling == "drop" and forecaster._features_have_nan(X_step):
+                rows.append(np.full(n_targets, np.nan))
+            else:
+                rows.append(np.atleast_1d(np.asarray(est.predict(X_step)).ravel())[:n_targets])
+        local = _cast(pl.DataFrame(np.vstack(rows), schema=y_cols), forecaster.local_y_t_schema_)
+        out[group] = local.rename({c: f"{group}__{c}" for c in y_cols})
+    return pl.concat(list(out.values()), how="horizontal")
+
+
+class TestPanelBatchedPredict:
+    """Stacking panel groups into one call per step must not change any number."""
+
+    @pytest.mark.parametrize("alignment", ["all", "matched", "cumulative"])
+    def test_batched_matches_per_group_with_forecast_step_columns(self, y_X_factory, alignment):
+        """Equivalence under every step alignment, with X_forecast step columns.
+
+        Vintage alignment is where a batching bug would hide: each step carries its own
+        `*_step_h` columns, and stacking the groups must keep every group on its own row
+        of the right step's frame.
+        """
+        y, X_actual, _X_future, X_forecast = y_X_factory(
+            length=90,
+            n_targets=1,
+            n_features=2,
+            panel=True,
+            n_groups=3,
+            n_forecast_features=2,
+            forecasting_horizon=4,
+            return_exogenous=True,
+        )
+
+        forecaster = PointReductionForecaster(reduction_strategy="direct", step_feature_alignment=alignment)
+        forecaster.fit(y=y, X_actual=X_actual, forecasting_horizon=4, X_forecast=X_forecast)
+
+        # Without step columns the alignment parameter is a no-op and this test would
+        # pass under any implementation, so pin that they exist.
+        assert forecaster._step_column_names_
+
+        batched = forecaster.predict().drop("vintage_time", strict=False)
+        reference = _reference_predict_per_group(forecaster)
+        _assert_matches_per_group(batched.drop("time", strict=False), reference)
+
+    def test_batched_matches_per_group_with_lags(self, y_X_factory):
+        """Equivalence when features come from a lag transformer.
+
+        Lags are rebuilt incrementally as observations arrive, so each group's feature
+        row is its own history. Stacking must not let one group read another's.
+        """
+        from yohou.preprocessing import LagTransformer as _LagTransformer
+
+        y, X_actual = y_X_factory(length=90, n_targets=1, n_features=2, panel=True, n_groups=3)
+
+        forecaster = PointReductionForecaster(
+            reduction_strategy="direct",
+            actual_transformer=_LagTransformer(lag=[1, 2, 3]),
+        )
+        forecaster.fit(y=y, X_actual=X_actual, forecasting_horizon=4)
+
+        batched = forecaster.predict().drop("vintage_time", strict=False)
+        reference = _reference_predict_per_group(forecaster)
+        _assert_matches_per_group(batched.drop("time", strict=False), reference)
+
+    def test_batched_isolates_a_single_group_with_null_features(self, y_X_factory):
+        """Under nan_handling="drop", one bad group must not poison the others.
+
+        The per-group path checked nulls a row at a time. Batched, the mask is per row of
+        the stacked frame, so this pins that a null in one group NaNs only that group.
+        """
+        y, X_actual = y_X_factory(length=90, n_targets=1, n_features=2, panel=True, n_groups=3)
+        victim = [c for c in X_actual.columns if c.startswith("group_0__")][0]
+        X_actual = X_actual.with_columns(
+            pl
+            .when(pl.arange(0, X_actual.height) == X_actual.height - 1)
+            .then(None)
+            .otherwise(pl.col(victim))
+            .alias(victim)
+        )
+
+        forecaster = PointReductionForecaster(
+            estimator=HistGradientBoostingRegressor(max_iter=5, min_samples_leaf=2, random_state=0),
+            reduction_strategy="direct",
+            nan_handling="drop",
+        )
+        forecaster.fit(y=y, X_actual=X_actual, forecasting_horizon=4)
+
+        batched = forecaster.predict()
+        _assert_matches_per_group(
+            batched.drop("time", "vintage_time", strict=False),
+            _reference_predict_per_group(forecaster),
+        )
+
+        poisoned = [c for c in batched.columns if c.startswith("group_0__")]
+        healthy = [c for c in batched.columns if c not in poisoned and c not in ("time", "vintage_time")]
+        assert np.isnan(batched.select(poisoned).to_numpy()).all()
+        assert not np.isnan(batched.select(healthy).to_numpy()).any()
 
 
 class TestPanelTimeWeight:


### PR DESCRIPTION
Two costs on the `direct` predict path, both paid per horizon step **per panel group**.

## 1. A closure capture

`_predict_step` was nested inside `_estimator_predict_direct` and read `self.nan_handling` and `self._features_have_nan`. cloudpickle captures a closure whole, so every task dispatched to a worker serialized the **entire fitted forecaster**, `estimator_` included:

```
bytes per joblib task: 4.61 MB
  one CatBoost model alone: 0.096 MB
  fitted forecaster (self): 4.61 MB
```

A 48x amplification at a 48 step horizon. And with `nan_handling` at its default of `"pass"`, the captured `_features_have_nan` is never called: the payload moves so a task can read one string.

`_predict_direct_step` is now module level and takes the NaN decision pre-resolved, so a task carries the function by name, one estimator, and the feature rows.

## 2. Granularity

Under `panel_strategy="global"` every group shares the estimator for a given step, so predicting each group separately made **480 single-row calls where 48 ten-row calls do**. Most of a single-row inference is fixed overhead (input validation, array conversion) paid once per call whatever the row count. The groups' feature rows are now stacked and predicted together, and step filtering happens once per step rather than once per group per step.

## Measurements

10 group panel, 48 step horizon, CatBoost at 80 iterations, real data, one `predict()`:

| | |
|---|---|
| original | 155.8s |
| closure fixed | 0.803s |
| + batched across groups | **0.114s** |

A `SplitConformalForecaster` fit replays one prediction per calibration row, so at the default `calibration_size=100` that is roughly **4.2 hours against about 15 seconds**.

## On `n_jobs`

It still governs both fit and predict, and the docstrings now say so rather than claiming otherwise. Whether it pays at predict depends on the estimator, because dispatch costs about a millisecond per task:

| estimator | alignment | parallel at `n_jobs=7` |
|---|---|---|
| CatBoost(80) | `all` | **+123%** |
| CatBoost(80) | `matched` | +25% |
| Impute+LinearRegression | `all` | -34% |
| Impute+LinearRegression | `matched` | -7% |

That crossover is a property of the caller's estimator, not something the library can decide, so the lever stays. `None` (the default) dispatches nothing, so a caller who has not asked for parallelism never pays for it.

## Correctness

**Dispatch is bit identical.** `n_jobs` selects where work runs, not what it computes.

**Batching is inert only up to floating point reassociation.** One `(n_groups, n_features)` matmul reassociates against `n_groups` separate `(1, n_features)` ones. Measured at **1 ULP** (1.7e-16 relative) for a linear estimator, and **exactly zero** for the CatBoost production configuration, whose inference is tree lookups. This is the one place the change is not bit-for-bit, and it is deliberate: the tests assert bit equality across `n_jobs` and a 1e-12 relative tolerance across batching.

Tests added to `TestNJobsParameter` and a new `TestPanelBatchedPredict`:

- exact frame equality across `n_jobs`, panel and non-panel
- both `nan_handling` modes, including a single group with null features NaN-ing only itself
- batched vs a per-group reference under every `step_feature_alignment`, with lag-derived features and with `X_forecast` step columns
- a payload guard that cloudpickles the **real** `delayed(...)` task, with a byte ceiling and a `<locals>` qualname check

The equivalence tests were checked against three deliberate mutations (wrong group row, wrong step columns, ignored NaN mask) and each is caught.

Full suite green: 5792 passed. Three example-notebook timeouts under `-n auto` on a 14-core box all pass in 60s standalone.

## Note

`IntervalReductionForecaster` inherits the same `_estimator_predict_direct` and calls it twice per prediction, once per bound, so it was paying both costs at double rate and benefits without a separate change.
