### PR TITLE
ci(nightly): survive dataset-host outages, fix matrix python selection

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      # A nightly exists to report, not to fail fast: cancelling the other
+      # interpreters on the first failure once turned one dataset host's bad
+      # minute into a run that said nothing about 3.12, 3.13 or 3.14.
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     # Codecov upload authenticates via GitHub OIDC (tokenless) -- no stored CODECOV_TOKEN.
@@ -40,15 +44,26 @@ jobs:
         # renovate: datasource=pypi depName=nox
         run: uv tool install nox==2026.7.11
 
+      # `test_coverage` is a single-version session pinned to the minimum Python,
+      # so `nox -s test_coverage` runs 3.11 whatever the matrix entry says. Asking
+      # for it on every entry ran the same suite four times and tested no other
+      # interpreter; the split below mirrors `test-full` in tests.yml.
       - name: Run tests with coverage
+        if: matrix.python-version == '3.11'
         run: nox -s test_coverage
+
+      - name: Run tests
+        if: matrix.python-version != '3.11'
+        run: nox -s test --python ${{ matrix.python-version }}
 
       - name: Run docstring tests
         run: nox -s test_docstrings-${{ matrix.python-version }}
 
+      # Gated on the entry that produces the report. It was gated on 3.12, which
+      # uploaded a 3.11 run's coverage under a 3.12 label; now only 3.11 measures.
       - name: Upload coverage reports
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        if: ${{ matrix.python-version == '3.12' }}
+        if: ${{ matrix.python-version == '3.11' }}
         with:
           use_oidc: true
 

--- a/tests/datasets/test_fetchers.py
+++ b/tests/datasets/test_fetchers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import zipfile
 from datetime import datetime
+from urllib.error import HTTPError, URLError
 
 import polars as pl
 import pytest
@@ -36,6 +37,37 @@ ALL_FETCHERS = [
     fetch_hospital,
     fetch_kdd_cup,
 ]
+
+
+# Statuses that mean "the host is having a bad minute", not "the request was wrong":
+# request timeouts, rate limits, and the whole 5xx family Zenodo's gateway emits when
+# it is overloaded.
+_TRANSIENT_HTTP_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+# Zenodo's outages outlast sklearn's default 3 retries at 1s, so give the download a
+# wider window than a user's interactive call gets before deciding the host is down.
+_INTEGRATION_RETRIES = 5
+_INTEGRATION_DELAY = 5.0
+
+
+def _fetch_or_skip(fetcher, **kwargs):
+    """Call a real-download fetcher, skipping the test if the host is unavailable.
+
+    These tests assert that yohou downloads, parses and caches what Zenodo serves;
+    they are not a monitor for Zenodo's uptime. A gateway timeout there lasting the
+    length of a nightly run once failed the whole matrix and filed a failure issue
+    that no change to this repository could have closed. A transient upstream status
+    is therefore a skip, while a 404, a checksum mismatch or a parse error still
+    fails, because those are ours to fix.
+    """
+    try:
+        return fetcher(n_retries=_INTEGRATION_RETRIES, delay=_INTEGRATION_DELAY, **kwargs)
+    except HTTPError as exc:
+        if exc.code not in _TRANSIENT_HTTP_STATUS:
+            raise
+        pytest.skip(f"{fetcher.__name__}: upstream returned HTTP {exc.code} ({exc.reason})")
+    except (URLError, TimeoutError) as exc:
+        pytest.skip(f"{fetcher.__name__}: upstream unreachable ({exc})")
 
 
 def _make_fake_tsf_zip(directory: str, zip_name: str, tsf_name: str) -> None:
@@ -242,7 +274,7 @@ class TestFetchIntegration:
     )
     def test_real_download(self, fetcher, tmp_path):
         """Real download from Zenodo produces valid Bunch."""
-        bunch = fetcher(data_home=tmp_path)
+        bunch = _fetch_or_skip(fetcher, data_home=tmp_path)
         assert isinstance(bunch.frame, pl.DataFrame)
         assert "time" in bunch.frame.columns
         assert len(bunch.frame) > 0
@@ -252,7 +284,7 @@ class TestFetchIntegration:
     @pytest.mark.integration
     def test_real_download_dominick(self, tmp_path):
         """Real download of the large Dominick dataset (default subset)."""
-        bunch = fetch_dominick(data_home=tmp_path)
+        bunch = _fetch_or_skip(fetch_dominick, data_home=tmp_path)
         assert isinstance(bunch.frame, pl.DataFrame)
         assert "time" in bunch.frame.columns
         assert bunch.n_series == 50
@@ -261,13 +293,72 @@ class TestFetchIntegration:
     @pytest.mark.integration
     def test_real_download_kdd_cup(self, tmp_path):
         """Real download of the KDD Cup 2018 dataset (default subset)."""
-        bunch = fetch_kdd_cup(data_home=tmp_path)
+        bunch = _fetch_or_skip(fetch_kdd_cup, data_home=tmp_path)
         assert isinstance(bunch.frame, pl.DataFrame)
         assert "time" in bunch.frame.columns
         assert bunch.n_series == 30  # default n_groups=5 × 6 measurements
         for col in bunch.feature_names:
             assert "__" in col
             assert not col.endswith("__value")
+
+
+class TestFetchOrSkip:
+    """Tests for the transient-failure guard the integration tests download through."""
+
+    @pytest.mark.parametrize("status", sorted(_TRANSIENT_HTTP_STATUS))
+    def test_transient_status_skips(self, status):
+        """A status meaning the host is overloaded skips instead of failing."""
+
+        def fetcher(**_kwargs):
+            raise HTTPError("https://zenodo.org/x.zip", status, "Gateway Time-out", {}, None)
+
+        with pytest.raises(pytest.skip.Exception, match=f"HTTP {status}"):
+            _fetch_or_skip(fetcher)
+
+    @pytest.mark.parametrize("status", [400, 403, 404, 410])
+    def test_client_error_still_fails(self, status):
+        """A wrong URL or a withdrawn record is our bug, so it propagates."""
+
+        def fetcher(**_kwargs):
+            raise HTTPError("https://zenodo.org/x.zip", status, "Not Found", {}, None)
+
+        with pytest.raises(HTTPError):
+            _fetch_or_skip(fetcher)
+
+    def test_unreachable_host_skips(self):
+        """A connection that never opens skips: there is nothing to assert on."""
+
+        def fetcher(**_kwargs):
+            raise URLError("Name or service not known")
+
+        with pytest.raises(pytest.skip.Exception, match="unreachable"):
+            _fetch_or_skip(fetcher)
+
+    def test_parse_error_still_fails(self):
+        """A failure after the bytes arrive is ours, so it propagates."""
+
+        def fetcher(**_kwargs):
+            msg = "malformed TSF header"
+            raise ValueError(msg)
+
+        with pytest.raises(ValueError, match="malformed TSF header"):
+            _fetch_or_skip(fetcher)
+
+    def test_forwards_retry_settings_and_returns_bunch(self):
+        """The wider retry window reaches the fetcher and the Bunch passes through."""
+        captured = {}
+        expected = Bunch(frame=pl.DataFrame({"time": [datetime(2020, 1, 1)]}))
+
+        def fetcher(**kwargs):
+            captured.update(kwargs)
+            return expected
+
+        assert _fetch_or_skip(fetcher, data_home="/tmp/x") is expected
+        assert captured == {
+            "n_retries": _INTEGRATION_RETRIES,
+            "delay": _INTEGRATION_DELAY,
+            "data_home": "/tmp/x",
+        }
 
 
 class TestRestructureKddCup:


### PR DESCRIPTION
## Description

The nightly run of 2026-08-07 ([run 31147828129](https://github.com/stateful-y/yohou/actions/runs/31147828129)) failed on eight `urllib.error.HTTPError: HTTP Error 504: Gateway Time-out` responses from Zenodo. Investigating it turned up two further defects in `nightly.yml` that made the outage worse than it needed to be, so this fixes all three.

1. **Transient upstream failures skip instead of fail.** The real-download integration tests now go through `_fetch_or_skip`, which widens the retry window (5 retries at 5s, against sklearn's default 3 at 1s) and converts request timeouts, rate limits, the 5xx family, and an unreachable host into a skip. A 404, a checksum mismatch or a parse error still fails, because those are ours to fix.
2. **`fail-fast: false` on the nightly matrix.** The 3.11 failure cancelled 3.12, 3.13 and 3.14, so the run reported nothing about them. Every matrix in `tests.yml` already sets this; the nightly was the outlier.
3. **The matrix was not testing four Pythons.** `test_coverage` is a single-version nox session pinned to the minimum Python, so `nox -s test_coverage` with no `--python` ran the 3.11 suite on every matrix entry: the same work four times, and no coverage of the other three interpreters. Split as `test-full` in `tests.yml` does it, with the Codecov gate moved to the entry that actually measures (it was on 3.12, uploading a 3.11 run's report under a 3.12 label).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Zenodo's 504s lasted the whole run, so the existing retries never got through, and the nightly filed a failure issue that no change to this repository could have closed. The following night went green on its own. These tests assert that yohou downloads, parses and caches what Zenodo serves; they are not a monitor for Zenodo's uptime, and they should not be able to raise a false alarm.

Points 2 and 3 are why that single flake cost so much information: it cancelled three jobs, and those three jobs would not have told us anything about their own interpreter anyway.

Fixes #135

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Verification:

- All 199 `tests/datasets` tests pass, including the eight live Zenodo downloads.
- Outage simulated with a dead proxy: `SKIPPED [1] fetch_hospital: upstream unreachable (<urlopen error [Errno 111] Connection refused>)` after six attempts over 25s. A skip, not a failure.
- `TestFetchOrSkip` covers the discrimination directly: every transient status skips, 400/403/404/410 and a post-download `ValueError` still propagate, and the widened retry settings do reach the fetcher.

No documentation change: the behaviour is test-harness only and no public API moved.

One adjacent bug found but deliberately left out of scope: `tests.yml` points Codecov at `junit.3.11.xml` and `coverage.3.11.xml`, but `addopts` writes plain `coverage.xml`, and the coverage upload carries `fail_ci_if_error: true`. Worth a separate look.
