### PR TITLE
fix(ci): scope the token to the jobs that write

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -12,13 +12,18 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Least-privilege default: read-only token; the build job widens to contents:write
+# for the release upload.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      # Required to publish the rendered site to the `docs-site` release.
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,6 +12,11 @@ concurrency:
   group: examples-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
+# Without this, the job inherits the repository's default token scope, which can be
+# read-write. Running example notebooks needs neither.
+permissions:
+  contents: read
+
 jobs:
   examples:
     name: Run example notebooks

--- a/.github/workflows/export-notebooks.yml
+++ b/.github/workflows/export-notebooks.yml
@@ -12,13 +12,20 @@ on:
       - "src/yohou/**"
   workflow_dispatch:
 
+# Least-privilege default: read-only token; the export job widens to contents:write
+# for the release upload. A top-level write default applied to every job, including
+# the pull_request runs, which build untrusted branch content and never upload.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   export:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      # Required by the "Upload to release" step, which is itself skipped on
+      # pull_request events.
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/.github/workflows/regenerate-datasets.yml
+++ b/.github/workflows/regenerate-datasets.yml
@@ -3,13 +3,17 @@ name: Regenerate Dataset Files
 on:
   workflow_dispatch:
 
+# Least-privilege default: read-only token; the regenerate job widens to contents:write.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   regenerate:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      # Required to push the regenerated parquet files to the datasets branch.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Part of a fleet-wide security sweep of the org's Dependabot / malware / code-scanning alerts.

Scorecard reported six `TokenPermissionsID` findings on this repo. The two in `publish-release.yml` are template-generated and legitimate — creating a release needs `contents: write`. The other four are this repo's own workflows:

| File | Was | Now |
|---|---|---|
| `docs-deploy.yml` | top-level `contents: write` | top-level `contents: read`, job-level write |
| `export-notebooks.yml` | top-level `contents: write` | top-level `contents: read`, job-level write |
| `regenerate-datasets.yml` | top-level `contents: write` | top-level `contents: read`, job-level write |
| `examples.yml` | **no `permissions` at all** | `contents: read` |

`export-notebooks.yml` is the one that matters: it triggers on `pull_request`, so every fork PR run inherited a write-scoped default — while the only step that writes (`Upload to release`) is already guarded by `if: github.event_name != 'pull_request'`.

`examples.yml` inherited the repository default token scope, which can be read-write. Running notebooks reads.