### PR TITLE
fix(security): update from template v0.40.1

### DIFF
--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -99,6 +99,9 @@ docs/pages/explanation/security.md
 .github/workflows/commit-message.yml   # conditional: include_actions
 .github/workflows/codeql.yml       # conditional: include_actions + public repo_visibility
 .github/workflows/scorecard.yml    # conditional: include_actions + public repo_visibility
+.github/codeql/codeql-config.yml   # conditional: include_actions + public repo_visibility.
+                                   # Scopes the CodeQL scan; a project may add its own
+                                   # exclusions, so merge rather than overwrite.
 CODEOWNERS
 ```
 

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: e61fdc1b9d718318344f6e9b2406b92810f12b08
+_commit: c1343c6c8cf8ac01e92a81e7565e26590319af02
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,24 @@
+# CodeQL scans the package, not the harness that exercises it.
+#
+# Without this file, `init` runs the default query suite over the whole checkout. The
+# security queries then read test assertions and example notebooks as if they were
+# production code paths, and report on them: `py/incomplete-url-substring-sanitization`
+# fires on `assert "docs.python.org" in url` (an assertion that config content is
+# present, not a trust decision), and `py/clear-text-logging-sensitive-data` fires on any
+# variable whose name contains "secret" or "trusted" -- including an allowlist of public
+# package names printed by an example.
+#
+# Every such alert is a false positive, and dismissing them one by one does not hold:
+# the shapes recur every time a test asserts on a URL. Excluding the directories is the
+# fix that stays fixed.
+#
+# The cost is real and deliberate: CodeQL no longer analyses test or example code. That
+# code does not run in production, has no untrusted input, and is already covered by
+# ruff's flake8-bandit (`S`) ruleset, which runs over the whole repository on every
+# change. `src/` and `docs_build/` -- the code that ships and the code that builds the
+# site -- stay in scope.
+name: "yohou (source only)"
+
+paths-ignore:
+  - tests
+  - examples

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,10 @@ jobs:
         uses: github/codeql-action/init@a2983b8bed1923f44751c5c43237f479442827b3 # v3
         with:
           languages: python
+          # Scopes the scan to shipped code. Without it the default suite reads test
+          # assertions and example notebooks as production code paths; see the config
+          # file for which queries that trips and why excluding beats dismissing.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@a2983b8bed1923f44751c5c43237f479442827b3 # v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,10 +28,15 @@ jobs:
     steps:
       - name: Find release tag
         id: find_tag
+        # The PR title reaches the shell through the environment, never through
+        # an expression inside `run:`. An expression is substituted into the
+        # script before bash parses it, so a title carrying shell metacharacters
+        # would execute here -- in a job that goes on to publish. An env var is data.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0" or "v0.1.0-alpha.1")
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
+          VERSION=$(printf '%s' "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
 
           if [ -z "$VERSION" ]; then
             echo "No version found in PR title"
@@ -179,7 +184,6 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        # renovate: datasource=github-releases depName=pypa/gh-action-pypi-publish
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           attestations: true

--- a/docs/pages/explanation/security.md
+++ b/docs/pages/explanation/security.md
@@ -47,6 +47,14 @@ rewrite the repository.
 **A single merge gate.** No change lands on the main branch until the full test suite and
 the security checks above all pass, enforced as one required status check.
 
+**Untrusted input never becomes code.** Values an outsider controls -- a pull request
+title, an issue body, a fork's branch name -- reach a workflow's shell only as environment
+variables. Workflow expressions are substituted into a script *before* the shell parses
+it, so interpolating one directly turns a crafted pull request title into commands that
+run with the release job's privileges. Quoting does not help; passing the value through
+`env:` does, because the runner then hands it over as data. A test asserts no workflow
+interpolates such a value into a `run:` or `script:` body.
+
 **Scoped automation identity.** Release automation authenticates with a short-lived,
 narrowly-scoped GitHub App token rather than a broad personal access token, so there is no
 long-lived automation credential to leak.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,12 +97,18 @@ docs = [
     # package. `mkdocs`/`mkdocs-material` above are kept so CI can still run a
     # MkDocs build as a comparison during the engine transition.
     "zensical>=0.0.51",
-    # Floor matches Zensical's own requirement (pymdown-extensions>=10.21.3).
-    # Do NOT pin to >=11: the examples group's notebook runtime caps
-    # pymdown-extensions at <11, so a project with examples must resolve it in
-    # [10.21.3, 11). Zensical works with either major; forcing 11 makes the
-    # docs-plus-examples sync unsatisfiable.
-    "pymdown-extensions>=10.21.3",
+    # Floor is a security floor: 10.x carries a path traversal in the b64 extension
+    # (GHSA-9xwg-3r6f-jcx2, fixed in 11.0.0) and 11.0.0 carries a ReDoS in four inline
+    # processors (GHSA-gm37-52c6-37mw, fixed in 11.0.1). Zensical works with either
+    # major, so nothing here argues for staying on 10.
+    #
+    # This floor used to read >=10.21.3 with a comment forbidding >=11, because the
+    # examples group's notebook runtime capped it at <11 and a project with examples
+    # could not resolve otherwise. That is what let a known-vulnerable version sit in
+    # five repositories: the cap was real, the CVEs landed behind it, and nothing
+    # rechecked the cap afterwards. That runtime has since relaxed its cap, and the
+    # examples group floors at the first release that did -- the two must move together.
+    "pymdown-extensions>=11.0.1",
     # Also a direct import of docs_build/_api_pages.py, which reads mkdocstrings'
     # `preload_modules` out of mkdocs.yml so that list has one definition rather
     # than two. Same argument as griffe above: it arrives via mkdocs anyway, but
@@ -124,7 +130,11 @@ fix = [
   "prek>=0.4.10",
 ]
 examples = [
-    "marimo>=0.19.0",
+    # Floor is set by the docs group, not by anything marimo does. marimo caps
+    # pymdown-extensions, and every release before 0.23.16 capped it at <11 -- below
+    # the version that fixes two published advisories. Lowering this floor puts those
+    # CVEs back in the lockfile of every project that generates examples.
+    "marimo>=0.23.16",
     "catboost>=1.2",
     "statsmodels>=0.14",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1148,7 +1148,7 @@ wheels = [
 
 [[package]]
 name = "marimo"
-version = "0.23.14"
+version = "0.23.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "sys_platform != 'emscripten'" },
@@ -1168,12 +1168,13 @@ dependencies = [
     { name = "pyzmq", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
     { name = "starlette", marker = "sys_platform != 'emscripten'" },
     { name = "tomlkit" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
     { name = "websockets", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/33/b60febb3f7e44658fc0c4b59e04ba9071e01f4186235d9dd1864e7efba72/marimo-0.23.14.tar.gz", hash = "sha256:f33f17abb5106edabf6921d016d91a6d8f02b4d1b0ed599039957b8f7f5b9489", size = 38705304, upload-time = "2026-07-10T20:01:01.646Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/c0/b6b7101dc9d3760c51d67714d4547047cb2c29c11f26691bed6a64d8a995/marimo-0.23.16.tar.gz", hash = "sha256:378c892f0e1bc3985bc0b5b61109078e09fc767438b95234bfec9faa45858c98", size = 38789959, upload-time = "2026-07-31T20:04:47.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/ea/898058b213ed79555cf4fde8f59fcb2c257c888dcbc351e0670d3a0b632d/marimo-0.23.14-py3-none-any.whl", hash = "sha256:c93a25ab3ae928f06d2d9855c8b582836485ad9af4d038de2eac8d028af837ee", size = 39160204, upload-time = "2026-07-10T20:00:58.325Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7a/db0583b21d1f03403fc26800cb4638f59e95a33efd333f7a4d45ac348b82/marimo-0.23.16-py3-none-any.whl", hash = "sha256:e0bba0a44b395d402072c65d686fb459bd8955c9ab8b0d6135a22f729c989373", size = 39241287, upload-time = "2026-07-31T20:04:43.678Z" },
 ]
 
 [[package]]
@@ -2285,15 +2286,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]
@@ -3364,13 +3365,13 @@ dev = [
     { name = "griffe", specifier = ">=1.0" },
     { name = "hypothesis", specifier = ">=6.100" },
     { name = "interrogate", specifier = ">=1.7.0" },
-    { name = "marimo", specifier = ">=0.19.0" },
+    { name = "marimo", specifier = ">=0.23.16" },
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-autorefs", specifier = ">=1.0" },
     { name = "mkdocs-material", specifier = ">=9.7" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26.0" },
     { name = "prek", specifier = ">=0.4.10" },
-    { name = "pymdown-extensions", specifier = ">=10.21.3" },
+    { name = "pymdown-extensions", specifier = ">=11.0.1" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-cov", specifier = ">=7.0" },
     { name = "pytest-mock", specifier = ">=3.14" },
@@ -3386,12 +3387,12 @@ dev = [
 docs = [
     { name = "catboost", specifier = ">=1.2" },
     { name = "griffe", specifier = ">=1.0" },
-    { name = "marimo", specifier = ">=0.19.0" },
+    { name = "marimo", specifier = ">=0.23.16" },
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-autorefs", specifier = ">=1.0" },
     { name = "mkdocs-material", specifier = ">=9.7" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26.0" },
-    { name = "pymdown-extensions", specifier = ">=10.21.3" },
+    { name = "pymdown-extensions", specifier = ">=11.0.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "statsmodels", specifier = ">=0.14" },
     { name = "watchdog", specifier = ">=4.0" },
@@ -3399,7 +3400,7 @@ docs = [
 ]
 examples = [
     { name = "catboost", specifier = ">=1.2" },
-    { name = "marimo", specifier = ">=0.19.0" },
+    { name = "marimo", specifier = ">=0.23.16" },
     { name = "statsmodels", specifier = ">=0.14" },
 ]
 fix = [{ name = "prek", specifier = ">=0.4.10" }]


### PR DESCRIPTION
Updates yohou from python-package-copier **v0.40.0** (`e61fdc1`) to **v0.40.1**
(`c1343c6`).

**Held for review — do not merge.** Part of a fleet-wide fan-out; please review
the digest-pin resolutions below before merging.

## What this delivers

**The point of the release: a shell-injection fix in the publish job.**
`publish-release.yml`'s *Find release tag* step interpolated
`${{ github.event.pull_request.title }}` straight into its `run:` body. Actions
substitutes an expression *before* bash parses the script, so a title carrying
shell metacharacters ran as commands — in the job that holds `contents: write`
and gates PyPI publication. The title now reaches the shell through
`env: PR_TITLE`, and `echo` becomes `printf '%s'`.

**CodeQL is scoped to shipped code.** New `.github/codeql/codeql-config.yml`
(`paths-ignore: tests, examples` — both, because this project has
`include_examples: True`), wired in via `config-file:` on `codeql.yml`'s `init`
step.

**Two CVE floors, raised together.** `pymdown-extensions>=10.21.3` → `>=11.0.1`
and `marimo>=0.19.0` → `>=0.23.16`. marimo below 0.23.16 caps
pymdown-extensions at `<11`, below the fix for **GHSA-9xwg-3r6f-jcx2** (path
traversal in the b64 extension) and **GHSA-gm37-52c6-37mw** (ReDoS in four
inline processors). `uv.lock` now resolves `pymdown-extensions 11.0.1` and
`marimo 0.23.16`, which closes both open Dependabot alerts and supersedes #138.

**Docs.** `docs/pages/explanation/security.md` gains one paragraph, *"Untrusted
input never becomes code."*

**Riding along** (template PRs #269/#270/#271): the now-redundant `# renovate:`
annotation above the PyPI publish step is dropped — Renovate reads `uses:`
natively.

## Digest pins were deliberately kept

The template moved `actions/checkout@v7` → `@v7.0.1` and
`actions/upload-artifact@v7` → `@v7.0.1`. This repository is **digest-pinned by
Renovate**, so every one of those lines conflicted. **All 20 conflicts were
resolved by keeping the local digest** and discarding the template's tag.
Resolving toward the template would un-pin the repo and reopen OpenSSF
Scorecard's `PinnedDependenciesID` findings. No new digests were added — that
stays Renovate's job.

Result: **59 `uses:` lines across all 12 workflows, 59 digest-pinned, 0 lost.**
`changelog.yml`, `commit-message.yml`, `nightly.yml`, `scorecard.yml` and
`tests.yml` therefore have a **zero-line net diff** — their only template delta
was the tag bump.

## Verification

- `git diff --stat -- docs/assets` — **empty**.
- `mkdocs.yml` untouched; nav leaves **96 → 96, byte-identical** (parsed YAML,
  per-section: Home 1 / Tutorials 14 / How-to 36 / Examples 1 / Explanation 22 /
  Reference 22).
- Whole-file pre→post diffs on all 8 touched files: only the template's intended
  hunks. Local content preserved — `test-compat` on `scikit-learn==1.6.0`,
  `test_docstrings-3.11`, nightly's `fail-fast: false` and 3.11/non-3.11 split,
  changelog's `GIT_LFS_SKIP_SMUDGE`, `uv 0.12.1`, examples' `catboost` and
  `statsmodels`.
- The four bespoke setup-uv workflows (`examples.yml`, `regenerate-datasets.yml`,
  `export-notebooks.yml`, `docs-deploy.yml`) are **byte-identical** — the
  `permissions:` scoping from #139 survived intact.
- 8 `UU` conflicts, **0 `.rej`**; 0 conflict markers remain (checked with
  `^(<<<<<<<|>>>>>>>|=======)( |$)`, falsified against injected markers).
- No `${{ github.event.* }}` remains in any `run:` or `script:` body across all
  12 workflows (audit falsified: it finds the old form on `main`).
- `nox -s check_docs` — **"No issues found", 0 warnings, 465 pages**, run in a
  clean container and falsified with an injected broken link (exit 1). On the
  host it is vacuous (empty `site/`, 0.16s) for both this branch and `main`;
  that is a local inotify-exhaustion artifact, not a repo change.
- `prek run --all-files` — all 13 hooks pass.
- `uv lock --locked` passes under the CI-pinned `uv 0.12.1`; the lock diff is 23
  lines, only the two packages.
