### PR TITLE
feat(interval): fail the fit when a calibration replay rewinds the forecaster

### DIFF
--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -219,6 +219,18 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         # `batch_invariant`; that path moves rolling-statistic columns by about one ULP,
         # so it is taken only on a declared stack. Anything undeclared keeps a
         # bit-identical path, which is what makes a missing declaration cost speed alone.
+        # Recorded as a fitted attribute, not just chosen. Which path ran decides what
+        # state the forecaster is left in, so a state defect is only attributable to a
+        # path if the fitted object can say which one it took. Establishing that for the
+        # 2026-08-08 regression cost a bisect across two submodule bumps.
+        if direct and bulk is not None and point._chains_are_batch_invariant():
+            replay_path = "bulk"
+        elif direct and batched is not None:
+            replay_path = "batched"
+        else:
+            replay_path = "rolling"
+        self.replay_path_ = replay_path
+
         if direct and bulk is not None and point._chains_are_batch_invariant():
             y_pred_calib = bulk(
                 y=y_calib,
@@ -290,7 +302,48 @@ class SplitConformalForecaster(BaseIntervalForecaster):
                 key = f"step_{step}"
                 self._fit_score_counts_[key] = conformity_scores.filter(pl.col("step") == step).height
 
+        self._check_replay_left_the_block_observed(y, replay_path)
+
         return self
+
+    def _check_replay_left_the_block_observed(self, y: pl.DataFrame, replay_path: str) -> None:
+        """Fail here if the replay did not leave the point forecaster where fit ends.
+
+        The replay consumes the calibration window to produce conformity scores, and
+        whatever it does internally the forecaster it leaves behind must have observed
+        that window. A path that does not is fitted but unpredictable: the first
+        ``predict`` assembles a frame with a ``calibration_size``-sized hole in it.
+
+        Without this check that defect surfaces several layers away, as an
+        inconsistent-interval error raised from whichever transformer inverts first, and
+        it describes the *input* as irregular when the input was regular and the gap was
+        introduced by the fit. Attributing it took a cloud step log and a bisect. One
+        timestamp comparison against a fit that costs minutes buys the attribution back.
+
+        Raises
+        ------
+        RuntimeError
+            If the wrapped point forecaster's observation state stops short of the data
+            the forecaster was fitted on.
+        """
+        observed = getattr(self.point_forecaster_, "observed_time_", None)
+        if observed is None:
+            return
+
+        # Under a panel strategy this is one timestamp per entity, not a scalar.
+        stamps = observed.values() if isinstance(observed, dict) else [observed]
+        expected = y["time"].max()
+        behind = sorted({stamp for stamp in stamps if stamp is not None and stamp != expected})
+        if not behind:
+            return
+
+        msg = (
+            f"The '{replay_path}' calibration replay left the point forecaster at {behind} "
+            f"but fit ended at {expected}, so it is fitted and not predictable: the next "
+            f"predict would assemble a frame with a {expected - behind[0]} hole in it. "
+            "The replay must leave the forecaster having observed the calibration block."
+        )
+        raise RuntimeError(msg)
 
     def _observe_conformity(
         self,

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -1723,3 +1723,57 @@ class TestBulkObserveReplay:
 
         predictions = forecaster.observe_predict_interval(y=later, forecasting_horizon=4, coverage_rates=[0.8])
         assert predictions.height > 0
+
+    def test_the_batched_path_also_leaves_the_block_observed(self):
+        """The third path, which the bulk-versus-rolling comparison does not reach.
+
+        `_observe_predict_batched_origins` captures its saved state inside `assemble`,
+        which runs as the `reduce_fn` after `_observe_predict_loop` has already rolled
+        through the origins, so what it restores is a post-observe state. That is why it
+        was never affected. Asserting it means the invariant covers all three paths
+        rather than the two a bulk-versus-rolling comparison happens to exercise.
+        """
+        y = self._panel()
+        forecaster = SplitConformalForecaster(point_forecaster=self._forecaster(), calibration_size=25)
+
+        # The batched path is chosen when the stack is not batch invariant but the
+        # forecaster still exposes batched origins, so deny the bulk guard to reach it.
+        cls = type(forecaster.point_forecaster)
+        saved = cls._chains_are_batch_invariant
+        cls._chains_are_batch_invariant = lambda self: False
+        try:
+            fitted = forecaster.fit(y, forecasting_horizon=4)
+        finally:
+            cls._chains_are_batch_invariant = saved
+
+        assert fitted.replay_path_ == "batched"
+        observed = fitted.point_forecaster_.observed_time_
+        stamps = set(observed.values()) if isinstance(observed, dict) else {observed}
+        assert stamps == {y["time"].max()}, (
+            "the batched replay left the forecaster short of the calibration block, so it "
+            "has the defect the bulk path had"
+        )
+
+    def test_a_replay_that_rewinds_the_forecaster_fails_at_fit(self):
+        """The invariant check fires where the state breaks, not four layers later.
+
+        Before this check, a replay that rewound the forecaster surfaced as an
+        inconsistent-interval error from whichever transformer inverted first, describing
+        regular input data as irregular. Attributing that took a cloud step log and a
+        bisect across two submodule bumps.
+        """
+        y = self._panel()
+        forecaster = SplitConformalForecaster(point_forecaster=self._forecaster(), calibration_size=25).fit(
+            y, forecasting_horizon=4
+        )
+
+        # Rewind the fitted point forecaster by the calibration block, which is exactly
+        # what restoring the pre-replay state used to do.
+        point = forecaster.point_forecaster_
+        rewound = y["time"].max() - timedelta(hours=25)
+        point.observed_time_ = (
+            dict.fromkeys(point.observed_time_, rewound) if isinstance(point.observed_time_, dict) else rewound
+        )
+
+        with pytest.raises(RuntimeError, match="fitted and not predictable"):
+            forecaster._check_replay_left_the_block_observed(y, "bulk")


### PR DESCRIPTION
Stacked on #141's fix (`0dbcfad`), which corrected the bulk calibration replay. This adds the guardrail that would have caught it in a minute rather than a day.

## Why

`0dbcfad` fixed the bulk replay leaving the point forecaster rewound by the whole calibration block. The fix is right, but the way the defect *presented* is the durable problem: an `inconsistent intervals` error raised from whichever transformer inverted first, describing regular input data as irregular, four layers away from the replay that caused it. Attributing it took a failing cloud run's step logs and a bisect across two submodule bumps.

Meanwhile the consequence downstream was silent. Every trial in the affected searches scored `-inf`, the trials were still marked `COMPLETE`, and the tuning step reported success while handing on hyperparameters that were never compared.

## What

- **`_check_replay_left_the_block_observed`** runs at the end of `SplitConformalForecaster.fit`. It compares the point forecaster's observed time against the end of the fitted data and raises naming the replay path, the observed timestamp and the expected one. One timestamp comparison against a fit that costs minutes.

  The comparison is **per entity**. Under a panel strategy `observed_time_` is a mapping of entity to timestamp rather than a scalar, so a scalar comparison silently passes on exactly the panel shapes this is meant to protect.

- **`replay_path_`** becomes a fitted attribute (`"bulk"` / `"batched"` / `"rolling"`). Which path ran decides what state the forecaster is left in, so a state defect is only attributable to a path if the fitted object can say which one it took.

- **Two tests.** One drives `_observe_predict_batched_origins`, which the existing bulk-versus-rolling comparison never reaches, and confirms it also leaves the block observed. That matches the finding that only the bulk path was ever affected: batched captures its saved state inside `assemble`, which runs as the `reduce_fn` after `_observe_predict_loop` has already rolled, so what it restores is a post-observe state. The other rewinds a fitted forecaster by the calibration block and asserts the check fires.

## Why an assertion and not only tests

`_chains_are_batch_invariant` makes path selection depend on the transformer stack, so a stack no test exercises can take an untested path. #141 shipped 620 lines of equivalence tests and they all passed, because they compared returned frames and the two paths returned equivalent frames while disagreeing about the state left behind. An assertion travels with the code; a test covers the stacks it happens to exercise.

## Verification

189 pass across `tests/interval/`, 76 in `test_split_conformal.py`. `prek run` clean on both files.

Also verified end to end against the real day-ahead panel: fit then predict immediately now reports the observed time landing at the end of the fitted data and returns 48 rows, where before the fix it raised with a 337 hour gap (`calibration_size + 1`).