### PR TITLE
fix(ci): stop the nightly coverage upload relying on a fallback search

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 2ef4acdac177596054e95a53c88406f215bc038a
+_commit: 10e9f41542bbcf96855ec8049cb1e0802572a610
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,6 +66,13 @@ jobs:
         if: ${{ matrix.python-version == '3.11' }}
         with:
           use_oidc: true
+          # Named explicitly, with the uploader's search off. This step had
+          # neither for several releases: it uploaded whatever the fallback happened to
+          # find, which is the exact pattern the tests.yml upload was fixed to remove --
+          # and it survived that fix because the check only looked at tests.yml.
+          files: '${{ github.workspace }}/.artifacts/coverage.xml'
+          disable_search: true
+          fail_ci_if_error: true
 
   # The release path's tools, exercised where a failure is cheap.
   #

--- a/.gitignore
+++ b/.gitignore
@@ -78,11 +78,13 @@ examples/**/__marimo__/
 # database, which the generated conftest.py points under `.artifacts/`.
 #
 # Recent Hypothesis drops a self-ignoring `.gitignore` inside it, and this entry was
-# removed on the strength of that. It is version-dependent: 6.165.2 writes the file,
-# 6.151.9 does not, and the project floors at `hypothesis>=6.100`. A repo resolving
-# below the cutoff gets ~26 untracked files at its root -- the exact mess the
-# `.artifacts/` layout exists to prevent, reintroduced by trusting a library's
-# internal behaviour across a range it does not promise.
+# removed on the strength of that. It is version-dependent, and the project floors at
+# `hypothesis>=6.100`. Measured across the fleet: 6.151.9 does NOT write the file;
+# 6.156.9, 6.158.0, 6.161.2 and 6.165.2 all do -- so the cutoff sits between 6.151.9
+# and 6.156.9, and every repo measured happened to resolve above it. One did not, and
+# got ~26 untracked files at its root: the exact mess the `.artifacts/` layout exists to
+# prevent, reintroduced by trusting a library's internal behaviour across a range it
+# does not promise. Nothing pins the resolution, so the entry stays.
 .hypothesis/
 
 # Markdown linter cache. rumdl has no cache-path option, so unlike the caches

--- a/tests/test_artifact_paths.py
+++ b/tests/test_artifact_paths.py
@@ -208,36 +208,61 @@ def test_every_reader_of_the_built_site_agrees_with_mkdocs():
         assert site_dir in text, f"{name} reads the built site but not at {site_dir!r} from mkdocs.yml `site_dir`"
 
 
-def test_coverage_upload_names_the_file_coverage_writes():
-    """The Codecov `files:` input must name the file the coverage config produces.
+def _workflows_uploading_coverage():
+    """Every workflow file containing a Codecov upload step.
+
+    Deliberately discovered, not listed. The first version of these checks named
+    `tests.yml` and nothing else, so a second upload in `nightly.yml` -- with no
+    `files:` and no `disable_search:`, relying entirely on the fallback -- sat
+    unnoticed through the release that removed exactly that pattern from `tests.yml`.
+    A check that names its own scope cannot see the instance it was not told about.
+    """
+    workflows = _PROJECT / ".github/workflows"
+    if not workflows.is_dir():
+        return []
+
+    return [
+        path for path in sorted(workflows.glob("*.yml")) if "codecov/codecov-action" in path.read_text(encoding="utf-8")
+    ]
+
+
+def test_a_coverage_upload_exists_to_check():
+    """Guard the input set, so the two checks below cannot pass over nothing."""
+    assert _workflows_uploading_coverage(), (
+        "no workflow uploads coverage, so the assertions about upload paths measure nothing"
+    )
+
+
+def test_every_coverage_upload_names_the_file_coverage_writes():
+    """Each Codecov `files:` input must name the file the coverage config produces.
 
     These drifted apart once before and nothing noticed, because the uploader's
-    fallback search found the real report and reported success.
+    fallback search found the real report and reported success anyway.
     """
     pyproject = (_PROJECT / "pyproject.toml").read_text(encoding="utf-8")
     written = re.search(r"\[tool\.coverage\.xml\][^\[]*?output\s*=\s*\"([^\"]+)\"", pyproject, re.S)
     assert written, "pyproject.toml does not set [tool.coverage.xml] output; the report path is undefined"
 
-    workflow = (_PROJECT / ".github/workflows/tests.yml").read_text(encoding="utf-8")
-    uploaded = re.search(r"files:\s*'\$\{\{ github\.workspace \}\}/([^']+)'", workflow)
-    assert uploaded, "the coverage upload step does not name a file"
+    for path in _workflows_uploading_coverage():
+        text = path.read_text(encoding="utf-8")
+        uploaded = re.search(r"files:\s*'?\$\{\{ github\.workspace \}\}/([^'\s]+)'?", text)
 
-    assert uploaded.group(1) == written.group(1), (
-        f"coverage upload reads {uploaded.group(1)!r} but the coverage config writes {written.group(1)!r}"
-    )
+        assert uploaded, f"{path.name} uploads coverage without naming a file, so it relies on the fallback search"
+        assert uploaded.group(1) == written.group(1), (
+            f"{path.name} reads {uploaded.group(1)!r} but the coverage config writes {written.group(1)!r}"
+        )
 
 
-def test_coverage_upload_does_not_fall_back_to_searching():
+def test_no_coverage_upload_falls_back_to_searching():
     """`fail_ci_if_error` only means something with the uploader's search disabled.
 
     With search on, a `files:` input naming nothing is not an error: the CLI scans
     the workspace, uploads whatever it finds, and the step passes.
     """
-    workflow = (_PROJECT / ".github/workflows/tests.yml").read_text(encoding="utf-8")
-
-    assert "disable_search: true" in workflow, (
-        "the coverage upload leaves search enabled, so a wrong `files:` path cannot fail the build"
-    )
+    for path in _workflows_uploading_coverage():
+        assert "disable_search: true" in path.read_text(encoding="utf-8"), (
+            f"{path.name} leaves the uploader's search enabled, so a wrong `files:` path cannot fail the build"
+        )
 
 
 def test_the_scan_can_fail(tmp_path):


### PR DESCRIPTION
> **Held for review — do not merge.** Opened by the template fan-out. The maintainer merges.

The nightly Codecov upload named no file and left the uploader's fallback search on, so it uploaded whatever it happened to find. This points it at `.artifacts/coverage.xml` with search off, and rewrites the check that was supposed to catch it. Template v0.41.2 → **v0.41.4** (`2ef4acd` → `10e9f41`).

## The bug

`nightly.yml`'s Codecov step carried `use_oidc: true` and nothing else — no `files:`, no `disable_search:`. With search enabled the uploader scans the workspace and uploads whatever it finds, so the step passes regardless of whether the intended report exists. `fail_ci_if_error` cannot mean anything in that state.

This is the exact pattern that was removed from `tests.yml` an earlier release ago. It survived there because **the check policing it named `tests.yml` and nothing else** — a check that names its own scope cannot see the instance it was not told about.

## The fix, in two halves

- The step now sets `files: '${{ github.workspace }}/.artifacts/coverage.xml'`, `disable_search: true` and `fail_ci_if_error: true`.
- `tests/test_artifact_paths.py` no longer reads `tests.yml` by name. It **discovers** every workflow containing a Codecov step and asserts over all of them, plus a guard test (`test_a_coverage_upload_exists_to_check`) so the discovered set cannot silently empty and turn the other two assertions into passes over nothing.

## Local work preserved

The template's three lines landed on **this repo's** version of the step, not the template's. Verified individually:

| local change | state |
|---|---|
| `test_coverage` (3.11 only) vs `nox -s test --python ${{ matrix.python-version }}` split, with the comment explaining the old form ran the same suite four times and tested no other interpreter | intact |
| `test_docstrings-${{ matrix.python-version }}` matrix parametrisation | intact |
| Codecov upload gated on `matrix.python-version == '3.11'` — the entry that actually produces the report — where the template gates on `'3.12'` | intact, **3.11 kept** |
| `codecov/codecov-action@fb8b3582…` digest pin, where the template ships `@v7` | intact, digest kept |

The whole-file diff of `nightly.yml` contains exactly one hunk: the template's three new lines and their comment. Nothing local was displaced.

## Verification

- **The gate is green and non-vacuous**: 7 passed, and it **discovers two** workflows — `nightly.yml` and `tests.yml` — out of 12 workflow files, matching an independent scan for `codecov/codecov-action`. The old form saw one.
- **Falsified**: stripping `files:` and `disable_search:` from `nightly.yml` in a **scratch copy** makes it fail *by name* — `nightly.yml uploads coverage without naming a file` and `nightly.yml leaves the uploader's search enabled`. The live file was never modified.
- **`tests/conftest.py` is unchanged** — 1069 lines before and after, absent from the diff. v0.41.3 was skipped deliberately: it relocated a block inside the generated conftest, which cannot apply to a project carrying its own fixtures. v0.41.4 reverts it, and its rendered conftest is byte-identical to v0.41.2's.
- **`git diff --stat -- docs/assets` is empty.**
- **Nav unchanged**: Home 1, Tutorials 14, How-to Guides 36, Examples 1, Explanation 22, Reference 22, total **96**, leaf-by-leaf diff empty.
- **Pins intact**: 52/52 `uses:` still 40-hex digests, 17/17 `astral-sh/setup-uv` still `version: "0.12.1"`.
- **`docs-deploy.yml`'s `SITE_DIR` fix intact** (5 references).
- Clean update: no conflicts, no `.rej`, no conflict markers. `tests/test_artifact_paths.py` byte-identical to the pristine render. prek 13/13.

## Note on reading the checks

`Validate Commit Message` reports **pass** on any multi-commit PR without validating anything — its steps carry `if: github.event.pull_request.commits == 1` at *step* level, so they all skip while the job still concludes `success`. Real coverage for the squash subject comes from `Validate PR Title`.

## Flagged upstream, not patched here

The template still runs `nox -s test_coverage` on every matrix entry although that session is pinned to the minimum Python, so the same suite runs once per entry and no other interpreter is exercised. This repo already works around it locally; the template inefficiency is reported upstream rather than fixed in this PR.
