### PR TITLE
fix(plotting): let per-vintage carry metrics that refuse stepwise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,14 @@ env/
 
 # Testing. `.tox/` is not something this template configures, and the bare
 # patterns below catch output from a tool run outside the project's own config.
+# The three root-level names are where coverage and mkdocs land when they are
+# invoked without the project's settings (`uv run pytest` from the repo root
+# rather than `just test`); `.artifacts/` only catches them when the config is
+# read, and 90MB of built site went untracked at the root before these existed.
 .tox/
+.coverage
+coverage.xml
+/site/
 *.cover
 *.log
 

--- a/src/yohou/plotting/evaluation.py
+++ b/src/yohou/plotting/evaluation.py
@@ -95,6 +95,53 @@ def _prepare_scorer_for_componentwise(scorer: BaseScorer) -> BaseScorer:
     return scorer_cw
 
 
+def _prepare_scorer_for_vintage_profile(scorer: BaseScorer, y_truth: pl.DataFrame) -> BaseScorer:
+    """Clone, configure and fit a scorer to leave only the vintage axis standing.
+
+    Collapsing the forecasting-step axis is the natural way to reach one row per
+    forecast origin, but a scorer may restrict which aggregation modes it
+    accepts: a metric defined over a whole forecast window has no step axis to
+    collapse and refuses ``"stepwise"`` outright. Such metrics already score once
+    per vintage, so componentwise aggregation alone leaves exactly the axis this
+    view needs.
+
+    The refusal surfaces only on ``fit`` and no public surface advertises which
+    modes a scorer takes, so the supported aggregation is found by trying. Only
+    the configuration is guarded; anything raised by scoring itself propagates.
+
+    Parameters
+    ----------
+    scorer : BaseScorer
+        Scorer to prepare.
+    y_truth : pl.DataFrame
+        Ground truth to fit the prepared clone on.
+
+    Returns
+    -------
+    BaseScorer
+        Fitted clone whose scores collapse to one row per vintage.
+
+    Raises
+    ------
+    ValueError
+        If the scorer accepts neither aggregation, re-raising its own refusal.
+
+    """
+    preferred = ["stepwise", "coveragewise"] if isinstance(scorer, BaseIntervalScorer) else ["stepwise"]
+    refusal: ValueError | None = None
+    for modes in (preferred, ["componentwise"]):
+        candidate = copy.deepcopy(scorer)
+        try:
+            candidate.set_params(aggregation_method=modes)
+            candidate.fit(y_truth)
+        except ValueError as exc:
+            refusal = refusal or exc
+            continue
+        return candidate
+    assert refusal is not None  # the loop only exits here after a refusal
+    raise refusal
+
+
 def _prepare_scorer_for_step_profile(scorer: BaseScorer) -> BaseScorer:
     """Clone and configure a scorer to leave only the forecasting-step axis.
 
@@ -3202,15 +3249,10 @@ def plot_score_per_vintage(
         y_p: pl.DataFrame,
     ) -> tuple[pl.Series, pl.Series]:
         """Compute per-vintage aggregate scores."""
-        s_cw = copy.deepcopy(s)
-        if isinstance(s_cw, BaseIntervalScorer):
-            s_cw.set_params(aggregation_method=["stepwise", "coveragewise"])
-        else:
-            s_cw.set_params(aggregation_method="stepwise")
-        s_cw.fit(y_t)
+        s_cw = _prepare_scorer_for_vintage_profile(s, y_t)
         scores_df = s_cw.score(y_t, y_p)
         if not isinstance(scores_df, pl.DataFrame):
-            msg = f"Scorer must return DataFrame for stepwise aggregation, got {type(scores_df).__name__}"
+            msg = f"Scorer must return DataFrame for per-vintage aggregation, got {type(scores_df).__name__}"
             raise TypeError(msg)
         if "vintage_time" not in scores_df.columns:
             msg = (

--- a/tests/plotting/test_evaluation.py
+++ b/tests/plotting/test_evaluation.py
@@ -2901,8 +2901,67 @@ class TestPlotScoreSummary:
         assert desc_bar.y[0] >= desc_bar.y[-1]
 
 
+class TestPlotScorePerVintageRestrictedScorer:
+    """A metric that refuses `stepwise` still reaches its per-vintage view.
+
+    Metrics defined over a whole forecast window (a day's trading result, a
+    peak-window ranking) have no step axis to collapse and reject `stepwise`
+    outright. They already score once per vintage, so this view is exactly
+    where they belong.
+    """
+
+    class _WindowOnlyMAE(MeanAbsoluteError):
+        """Stands in for a window-defined metric: componentwise or nothing."""
+
+        _VALID = {"componentwise", "vintagewise"}
+
+        def fit(self, y_train, **params):
+            modes = self.aggregation_method
+            modes = {modes} if isinstance(modes, str) else set(modes)
+            if not modes <= self._VALID:
+                msg = f"Invalid aggregation_method {sorted(modes)}. Valid: {sorted(self._VALID)}"
+                raise ValueError(msg)
+            return super().fit(y_train, **params)
+
+    def test_restricted_scorer_plots_instead_of_raising(self, multi_vintage_data):
+        """The view must not force an aggregation the scorer rejects."""
+        fig = plot_score_per_vintage(
+            self._WindowOnlyMAE(),
+            multi_vintage_data["y_truth"],
+            multi_vintage_data["y_pred"],
+        )
+        assert_figure_valid(fig)
+        assert len(fig.data) >= 1
+
+    def test_a_scorer_refusing_everything_still_reports_its_own_refusal(self, multi_vintage_data):
+        """The fallback must not swallow a scorer that accepts no aggregation."""
+
+        class _RefusesAll(MeanAbsoluteError):
+            def fit(self, y_train, **params):
+                msg = "Invalid aggregation_method: this scorer accepts none"
+                raise ValueError(msg)
+
+        with pytest.raises(ValueError, match="accepts none"):
+            plot_score_per_vintage(
+                _RefusesAll(),
+                multi_vintage_data["y_truth"],
+                multi_vintage_data["y_pred"],
+            )
+
+
 class TestPlotScorePerVintage:
     """Tests for plot_score_per_vintage function."""
+
+    def test_axis_is_one_point_per_vintage(self, multi_vintage_data):
+        """The x axis is the forecast origins, one point each."""
+        fig = plot_score_per_vintage(
+            MeanAbsoluteError(),
+            multi_vintage_data["y_truth"],
+            multi_vintage_data["y_pred"],
+        )
+        n_vintages = multi_vintage_data["y_pred"]["vintage_time"].n_unique()
+        assert len(fig.data[0].x) == n_vintages
+        assert len(set(fig.data[0].x)) == n_vintages
 
     def test_basic(self, multi_vintage_data):
         """Basic per-vintage plot with single scorer."""


### PR DESCRIPTION
## Why

`plot_score_per_vintage` forces `stepwise` into the aggregation it prepares, plus `coveragewise` for interval scorers. A metric defined over a whole forecast window has no step axis to collapse and refuses those modes outright, so every such scorer raised `ValueError` before it could draw.

That bit on the one view where those metrics belong. Their unit is a single value per forecast origin, which is exactly what this view plots, and it was the only one of the four score views that could have carried them.

## What changed

`_prepare_scorer_for_vintage_profile` discovers the supported aggregation instead of assuming it: try the richer modes, fall back to `["componentwise"]`, which leaves the vintage axis standing for a metric that already scores per vintage.

The restriction is expressed only inside `fit` and no public surface advertises which modes a scorer accepts, so trying is the only way to find out. Guarding only the configuration keeps two properties:

- anything raised by scoring itself still propagates
- a scorer that accepts neither aggregation re-raises its own refusal rather than being swallowed

Hardcoding a taxonomy of scorer types was the alternative. Rejected: the restricted scorers in the downstream project are not visible from here, and a generic fallback helps any third-party scorer with the same restriction.

## Tests

Two added:

- a scorer restricting `aggregation_method` to `{componentwise, vintagewise}` now plots rather than raising
- a scorer refusing every aggregation still surfaces its own error, so the fallback cannot mask a real misconfiguration

Plus one pinning the x axis to one point per forecast origin.

`tests/plotting`: 1065 passed. `ruff check` and `ruff format` clean.

## Verified downstream

Against a walk-forward panel with nine metrics from a real scoring block, all nine now plot per vintage. Eight give one point per vintage; `calibration_error` gives two per vintage because it does not collapse its coverage-rate axis, which reproduces with the previous aggregation too and so is **pre-existing, not from this change**. Worth a separate look.