### PR TITLE
feat(plotting): resolve per-vintage and heatmap views to panel entities

### DIFF
--- a/docs/pages/explanation/visualization.md
+++ b/docs/pages/explanation/visualization.md
@@ -164,6 +164,22 @@ Passing a specific list of group names to `groups` filters which panels appear,
 which is useful for large panel datasets where plotting everything at once would
 be overwhelming.
 
+### Two views that wait to be asked
+
+[`plot_score_per_vintage`](/pages/api/generated/yohou.plotting.plot_score_per_vintage/)
+and [`plot_score_heatmap`](/pages/api/generated/yohou.plotting.plot_score_heatmap/)
+are exceptions to the automatic activation above. Both default to
+`facet_by=None` and average the entity columns into one series, which is what
+they have always done; passing `facet_by` is what resolves them to their
+entities. Detection alone changes nothing, so panel data keeps rendering the way
+it did before these parameters existed.
+
+The heatmap spends both of its axes on step and vintage, so its entities become
+a subplot grid rather than a third axis, and every heatmap in that grid shares
+one colour scale so the entities stay comparable. Because the per-vintage view
+already spends its own grid on scorers and models, asking it for several scorers
+and faceting at once raises rather than silently dropping one of them.
+
 Color consistency across facets is managed by `PanelColorManager`, which assigns
 stable colors to member or group names so the same entity always appears in the
 same color regardless of subplot position. `LegendTracker` deduplicates legend

--- a/docs/pages/how-to/visualize-scores.md
+++ b/docs/pages/how-to/visualize-scores.md
@@ -154,6 +154,25 @@ plot_group_scores(scorer, y_test, y_pred, kind="box")
 plot_group_scores(scorer, y_test, y_pred, kind="heatmap")
 ```
 
+The vintage views in sections 4 and 6 average the entity columns unless you ask
+them not to, so a model that is accurate at most entities and wrong at one reads
+as mildly mediocre. Pass `facet_by="group"` to see the entities separately:
+
+```python
+# One per-vintage subplot per entity, models overlaid inside each
+plot_score_per_vintage(scorer["MAE"], y_test, {"ridge": y_pred_ridge}, facet_by="group")
+
+# One step-by-vintage heatmap per entity, sharing a single colour scale
+plot_score_heatmap(scorer["MAE"], y_test, y_pred_ridge, facet_by="group")
+
+# Restrict a wide panel to the entities worth looking at
+plot_score_heatmap(scorer["MAE"], y_test, y_pred_ridge, groups=["store_1"], facet_by="group")
+```
+
+Both views spend their subplot grid on the entities, so `plot_score_per_vintage`
+raises when it is given several scorers and `facet_by` together. Score one metric
+at a time when faceting.
+
 For box plots, `distribute_by` controls the variability dimension (`"time"`,
 `"vintage"`, or `"step"`).
 

--- a/src/yohou/plotting/evaluation.py
+++ b/src/yohou/plotting/evaluation.py
@@ -50,6 +50,7 @@ __all__ = [
 ]
 
 _SCORER_META_COLS = frozenset({"time", "vintage_time", "forecasting_step", "coverage_rate"})
+_FRAME_INDEX_COLS = frozenset({"time", "vintage_time"})
 
 
 def _normalize_scorers(
@@ -184,6 +185,83 @@ def _warn_large_grid(n_scorers: int, n_models: int, threshold: int = 12) -> None
             UserWarning,
             stacklevel=3,
         )
+
+
+def _panel_facet_columns(
+    frame: pl.DataFrame,
+    groups: list[str] | None,
+    facet_by: Literal["group", "member"],
+) -> dict[str, list[str]]:
+    """Bucket a frame's panel columns into one entry per facet.
+
+    Parameters
+    ----------
+    frame : pl.DataFrame
+        Frame whose columns follow the ``group__member`` convention.
+    groups : list[str] | None
+        Panel groups to keep, or ``None`` for all of them.
+    facet_by : Literal["group", "member"]
+        Whether each facet is a group (columns sharing a prefix) or a
+        member (columns sharing a postfix).
+
+    Returns
+    -------
+    dict[str, list[str]]
+        Facet label to the columns it covers. Empty when *frame* holds
+        no panel columns.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from yohou.plotting.evaluation import _panel_facet_columns
+    >>> df = pl.DataFrame({"time": [1], "a__value": [1.0], "b__value": [2.0]})
+    >>> _panel_facet_columns(df, None, "group")
+    {'a': ['a__value'], 'b': ['b__value']}
+    >>> _panel_facet_columns(df, None, "member")
+    {'value': ['a__value', 'b__value']}
+    """
+    _, panel_groups = inspect_panel(frame)
+    if not panel_groups:
+        return {}
+    selected = {g: cols for g, cols in panel_groups.items() if groups is None or g in groups}
+    if facet_by == "group":
+        return selected
+    members: dict[str, list[str]] = {}
+    for cols in selected.values():
+        for col in cols:
+            members.setdefault(_member_name(col), []).append(col)
+    return members
+
+
+def _select_facet(frame: pl.DataFrame, facet_cols: list[str]) -> pl.DataFrame:
+    """Narrow a truth or prediction frame to one facet's columns.
+
+    A facet column brings its companions with it: predictions name their
+    bounds ``{col}_lower_{rate}`` and ``{col}_upper_{rate}``, and their
+    class probabilities ``{col}_proba_{label}``, so an interval scorer
+    would fail on a facet holding the point column alone.
+
+    Frames that carry none of the facet's columns are returned whole, so
+    a global truth column stays usable against every facet.
+
+    Parameters
+    ----------
+    frame : pl.DataFrame
+        Truth or prediction frame, with its index columns.
+    facet_cols : list[str]
+        Panel columns belonging to the facet.
+
+    Returns
+    -------
+    pl.DataFrame
+        The frame narrowed to its index columns, *facet_cols*, and the
+        companion columns derived from them.
+    """
+    prefixes = tuple(f"{col}_" for col in facet_cols)
+    keep = [c for c in frame.columns if c in _FRAME_INDEX_COLS or c in facet_cols or c.startswith(prefixes)]
+    if not any(c not in _FRAME_INDEX_COLS for c in keep):
+        return frame
+    return frame.select(keep)
 
 
 def _render_residual_diagnostics(
@@ -3125,6 +3203,8 @@ def plot_score_per_vintage(
     kind: Literal["line", "bar"] = "line",
     compare_by: Literal["scorer", "model"] = "scorer",
     show_trend: bool = False,
+    groups: list[str] | None = None,
+    facet_by: Literal["group", "member"] | None = None,
     facet_n_cols: int = 2,
     color_palette: list[str] | None = None,
     show_legend: bool = True,
@@ -3168,6 +3248,18 @@ def plot_score_per_vintage(
         dimension is overlaid vs faceted.
     show_trend : bool, default=False
         Overlay a linear trend line.
+    groups : list[str] | None, default=None
+        Panel groups to draw. ``None`` draws every group found in
+        ``y_truth``. Only consulted when ``facet_by`` is set.
+    facet_by : Literal["group", "member"] | None, default=None
+        Resolve panel data to one subplot per group (or per member),
+        with models overlaid inside each. ``None`` averages the entity
+        columns into a single trace.
+
+        Unlike :func:`plot_score_time_series` and
+        :func:`plot_score_per_step`, this view does not facet on merely
+        detecting panel columns: panel data alone renders exactly as it
+        did before, and faceting happens only when asked for here.
     facet_n_cols : int, default=2
         Columns in the faceted grid.
     color_palette : list[str] | None, default=None
@@ -3205,6 +3297,9 @@ def plot_score_per_vintage(
         If ``y_pred`` has no ``vintage_time`` column, a ``ValueError`` is
         raised later (from the scorer) reporting that ``vintage_time`` is
         missing.
+        If several scorers are passed together with ``facet_by``: the
+        subplot grid is already spent on scorers and models, so entities
+        have nowhere to go.
 
     Examples
     --------
@@ -3337,6 +3432,69 @@ def plot_score_per_vintage(
                 col=col,
             )
 
+    # Panel dispatch. Entered on the caller's ask rather than on detecting panel
+    # columns, so panel data alone keeps the averaged trace earlier callers saw.
+    if facet_by is not None:
+        panel_facets = _panel_facet_columns(y_truth, groups, facet_by)
+        if panel_facets:
+            if multi_scorer:
+                msg = (
+                    "Multi-scorer is not supported with faceting in plot_score_per_vintage. "
+                    "Pass a single scorer instead."
+                )
+                raise ValueError(msg)
+
+            panel_labels = list(panel_facets)
+            n_cols = min(facet_n_cols, len(panel_labels))
+            n_rows = (len(panel_labels) + n_cols - 1) // n_cols
+            colors = resolve_color_palette(color_palette, n_models)
+            panel_scorer = next(iter(scorer_dict.values()))
+
+            fig = make_subplots(
+                rows=n_rows,
+                cols=n_cols,
+                subplot_titles=panel_labels,
+                shared_xaxes=True,
+                vertical_spacing=_subplot_spacing(n_rows),
+            )
+
+            legend_tracker = LegendTracker()
+            for facet_idx, facet_label in enumerate(panel_labels):
+                r = facet_idx // n_cols + 1
+                c = facet_idx % n_cols + 1
+                facet_cols = panel_facets[facet_label]
+                y_truth_f = _select_facet(y_truth, facet_cols)
+                for m_idx, (m_name, y_pm) in enumerate(y_pred_dict.items()):
+                    vintages, sv = _compute_vintage_scores(
+                        panel_scorer,
+                        y_truth_f,
+                        _select_facet(y_pm, facet_cols),
+                    )
+                    _render_vintage(
+                        fig,
+                        m_name,
+                        vintages,
+                        sv,
+                        colors[m_idx],
+                        legend_tracker.should_show(m_name),
+                        row=r,
+                        col=c,
+                    )
+
+            panel_scorer_name = panel_scorer.__class__.__name__
+            fig = apply_default_layout(
+                fig,
+                title=title or f"{panel_scorer_name} by Vintage",
+                x_label=x_label or "Vintage (Observed Time)",
+                y_label=y_label or panel_scorer_name,
+                width=width,
+                height=height or max(300 * n_rows, 400),
+            )
+            if kind == "bar" and n_models > 1:
+                fig.update_layout(barmode="group")
+            fig.update_layout(showlegend=show_legend)
+            return fig
+
     # Multi-scorer + multi-model -> faceted subplots
     if multi_scorer and n_models > 1:
         _warn_large_grid(n_scorers, n_models)
@@ -3439,6 +3597,68 @@ def plot_score_per_vintage(
     return fig
 
 
+def _score_heatmap_matrix(
+    scorer: BaseScorer,
+    y_truth: pl.DataFrame,
+    y_pred: pl.DataFrame,
+    vintages: pl.Series,
+) -> tuple[np.ndarray, list[str], list[str]]:
+    """Score every vintage separately into a ``(vintages x steps)`` matrix.
+
+    Parameters
+    ----------
+    scorer : BaseScorer
+        Scorer to clone, prepare componentwise and fit on *y_truth*.
+    y_truth : pl.DataFrame
+        Ground truth with ``"time"`` column.
+    y_pred : pl.DataFrame
+        Predictions with ``"vintage_time"`` and ``"time"`` columns.
+    vintages : pl.Series
+        Sorted unique vintage values to score, one per matrix row.
+
+    Returns
+    -------
+    z : np.ndarray
+        Score matrix, one row per vintage and one column per step.
+    vintage_labels : list[str]
+        Row labels.
+    step_labels : list[str]
+        Column labels.
+    """
+    scorer_cw = _prepare_scorer_for_componentwise(copy.deepcopy(scorer))
+    scorer_cw.fit(y_truth)
+
+    score_matrix: list[list[float]] = []
+    vintage_labels: list[str] = []
+    n_steps: int | None = None
+
+    for vintage_val in vintages:
+        y_pred_v = y_pred.filter(pl.col("vintage_time") == vintage_val)
+        scores_df = scorer_cw.score(y_truth, y_pred_v)
+
+        if not isinstance(scores_df, pl.DataFrame):
+            msg = f"Scorer must return DataFrame for componentwise aggregation, got {type(scores_df).__name__}"
+            raise TypeError(msg)
+
+        score_cols = [c for c in scores_df.columns if c not in _SCORER_META_COLS]
+        if len(score_cols) == 1:
+            row_scores = scores_df[score_cols[0]].to_list()
+        else:
+            row_scores = scores_df.select(score_cols).mean_horizontal().to_list()
+
+        if n_steps is None:
+            n_steps = len(row_scores)
+
+        # Pad or truncate to consistent length
+        row_scores = row_scores[:n_steps] + [float("nan")] * max(0, n_steps - len(row_scores))
+
+        score_matrix.append(row_scores)
+        vintage_labels.append(str(vintage_val))
+
+    step_labels = [str(i) for i in range(1, (n_steps or 0) + 1)]
+    return np.array(score_matrix), vintage_labels, step_labels
+
+
 def plot_score_heatmap(
     scorer: BaseScorer,
     y_truth: pl.DataFrame,
@@ -3446,6 +3666,9 @@ def plot_score_heatmap(
     *,
     x_dim: Literal["step", "vintage"] = "step",
     y_dim: Literal["step", "vintage"] = "vintage",
+    groups: list[str] | None = None,
+    facet_by: Literal["group", "member"] | None = None,
+    facet_n_cols: int = 2,
     color_palette: str | None = None,
     text_format: str = ".2f",
     show_text: bool = True,
@@ -3475,6 +3698,20 @@ def plot_score_heatmap(
     y_dim : str, default="vintage"
         Dimension for the y-axis: ``"step"`` or ``"vintage"``.
         Must differ from ``x_dim``.
+    groups : list[str] | None, default=None
+        Panel groups to draw. ``None`` draws every group found in
+        ``y_truth``. Only consulted when ``facet_by`` is set.
+    facet_by : Literal["group", "member"] | None, default=None
+        Resolve panel data to one heatmap per group (or per member).
+        Both axes are already spent on step and vintage, so the entity
+        dimension becomes a subplot grid. All heatmaps in the grid share
+        one colour scale, so entities stay comparable at a glance.
+        ``None`` averages the entity columns into a single grid.
+
+        As with :func:`plot_score_per_vintage`, faceting happens only
+        when asked for here, never on merely detecting panel columns.
+    facet_n_cols : int, default=2
+        Columns in the faceted grid.
     color_palette : str or None, default=None
         Plotly colorscale name. If None, auto-selects based on
         ``scorer._lower_is_better``: ``"Blues"`` when lower is better,
@@ -3556,51 +3793,6 @@ def plot_score_heatmap(
         msg = "y_pred has only a single vintage (vintage_time). plot_score_heatmap requires at least 2 vintages."
         raise ValueError(msg)
 
-    # Compute per-vintage, per-step scores
-    scorer_cw = _prepare_scorer_for_componentwise(copy.deepcopy(scorer))
-    scorer_cw.fit(y_truth)
-
-    score_matrix: list[list[float]] = []
-    vintage_labels: list[str] = []
-    n_steps: int | None = None
-
-    for vintage_val in vintages:
-        y_pred_v = y_pred.filter(pl.col("vintage_time") == vintage_val)
-        scores_df = scorer_cw.score(y_truth, y_pred_v)
-
-        if not isinstance(scores_df, pl.DataFrame):
-            msg = f"Scorer must return DataFrame for componentwise aggregation, got {type(scores_df).__name__}"
-            raise TypeError(msg)
-
-        score_cols = [c for c in scores_df.columns if c not in _SCORER_META_COLS]
-        if len(score_cols) == 1:
-            row_scores = scores_df[score_cols[0]].to_list()
-        else:
-            row_scores = scores_df.select(score_cols).mean_horizontal().to_list()
-
-        if n_steps is None:
-            n_steps = len(row_scores)
-
-        # Pad or truncate to consistent length
-        row_scores = row_scores[:n_steps] + [float("nan")] * max(0, n_steps - len(row_scores))
-
-        score_matrix.append(row_scores)
-        vintage_labels.append(str(vintage_val))
-
-    step_labels = [str(i) for i in range(1, (n_steps or 0) + 1)]
-    z = np.array(score_matrix)
-
-    # Arrange dimensions
-    if x_dim == "step" and y_dim == "vintage":
-        x_labels = step_labels
-        y_labels = vintage_labels
-        z_plot = z
-    else:
-        # x_dim == "vintage" and y_dim == "step"
-        x_labels = vintage_labels
-        y_labels = step_labels
-        z_plot = z.T
-
     # Auto-select colorscale
     if color_palette is None:
         lower_is_better = getattr(scorer, "_lower_is_better", True)
@@ -3608,8 +3800,88 @@ def plot_score_heatmap(
     else:
         colorscale = color_palette
 
-    # Build text annotations
-    text_vals = [[f"{v:{text_format}}" for v in row] for row in z_plot] if show_text else None
+    def _orient(
+        z: np.ndarray, vintage_labels: list[str], step_labels: list[str]
+    ) -> tuple[np.ndarray, list[str], list[str]]:
+        """Lay the matrix out along the requested axes."""
+        if x_dim == "step" and y_dim == "vintage":
+            return z, step_labels, vintage_labels
+        # x_dim == "vintage" and y_dim == "step"
+        return z.T, vintage_labels, step_labels
+
+    def _cell_text(z_plot: np.ndarray) -> list[list[str]] | None:
+        """Format the per-cell annotations, or None when they are off."""
+        if not show_text:
+            return None
+        return [[f"{v:{text_format}}" for v in row] for row in z_plot]
+
+    scorer_name = scorer.__class__.__name__
+    default_x = x_label or ("Horizon Step" if x_dim == "step" else "Vintage (Observed Time)")
+    default_y = y_label or ("Horizon Step" if y_dim == "step" else "Vintage (Observed Time)")
+
+    # Panel dispatch. Entered on the caller's ask rather than on detecting panel
+    # columns, so panel data alone keeps the averaged grid earlier callers saw.
+    if facet_by is not None:
+        panel_facets = _panel_facet_columns(y_truth, groups, facet_by)
+        if panel_facets:
+            panel_labels = list(panel_facets)
+            n_cols = min(facet_n_cols, len(panel_labels))
+            n_rows = (len(panel_labels) + n_cols - 1) // n_cols
+            fig = make_subplots(
+                rows=n_rows,
+                cols=n_cols,
+                subplot_titles=panel_labels,
+                vertical_spacing=_subplot_spacing(n_rows),
+            )
+
+            oriented = []
+            for facet_label in panel_labels:
+                facet_cols = panel_facets[facet_label]
+                z_f, vintage_labels_f, step_labels_f = _score_heatmap_matrix(
+                    scorer,
+                    _select_facet(y_truth, facet_cols),
+                    _select_facet(y_pred, facet_cols),
+                    vintages,
+                )
+                oriented.append(_orient(z_f, vintage_labels_f, step_labels_f))
+
+            # One colour range over the whole grid: entities are only comparable
+            # if the same colour means the same score in every subplot.
+            finite = [z_plot[np.isfinite(z_plot)] for z_plot, _, _ in oriented]
+            finite = [part for part in finite if part.size]
+            zmin = float(min(part.min() for part in finite)) if finite else 0.0
+            zmax = float(max(part.max() for part in finite)) if finite else 1.0
+
+            for facet_idx, (z_plot, x_labels, y_labels) in enumerate(oriented):
+                fig.add_trace(
+                    go.Heatmap(
+                        z=z_plot,
+                        x=x_labels,
+                        y=y_labels,
+                        coloraxis="coloraxis",
+                        text=_cell_text(z_plot),
+                        texttemplate="%{text}" if show_text else None,
+                        hovertemplate="x: %{x}<br>y: %{y}<br>Score: %{z:.3f}<extra></extra>",
+                    ),
+                    row=facet_idx // n_cols + 1,
+                    col=facet_idx % n_cols + 1,
+                )
+
+            fig = apply_default_layout(
+                fig,
+                title=title or f"{scorer_name} Heatmap",
+                x_label=default_x,
+                y_label=default_y,
+                width=width,
+                height=height,
+            )
+            fig.update_layout(coloraxis={"colorscale": colorscale, "cmin": zmin, "cmax": zmax})
+            return fig
+
+    # Compute per-vintage, per-step scores
+    z, vintage_labels, step_labels = _score_heatmap_matrix(scorer, y_truth, y_pred, vintages)
+    z_plot, x_labels, y_labels = _orient(z, vintage_labels, step_labels)
+    text_vals = _cell_text(z_plot)
 
     fig = go.Figure(
         data=go.Heatmap(
@@ -3623,9 +3895,6 @@ def plot_score_heatmap(
         )
     )
 
-    scorer_name = scorer.__class__.__name__
-    default_x = x_label or ("Horizon Step" if x_dim == "step" else "Vintage (Observed Time)")
-    default_y = y_label or ("Horizon Step" if y_dim == "step" else "Vintage (Observed Time)")
     default_title = title or f"{scorer_name} Heatmap"
 
     fig = apply_default_layout(

--- a/tests/plotting/test_evaluation.py
+++ b/tests/plotting/test_evaluation.py
@@ -3540,3 +3540,221 @@ class TestScoreDistributionKdeWarning:
         y_pred = pl.DataFrame({"time": dates, "y": [5.0] * n})
         with pytest.warns(UserWarning, match="KDE"):
             plot_score_distribution(MeanAbsoluteError(), y_truth, y_pred, kind="kde")
+
+
+@pytest.fixture
+def uneven_panel_vintages():
+    """A two-entity panel where one model is only wrong at one entity.
+
+    ``uniform`` is off by 5 everywhere; ``lopsided`` is perfect at
+    ``site_a`` and off by 10 at ``site_b``. Averaged over the entities the
+    two are indistinguishable, which is what faceting has to reveal.
+    """
+    times = [datetime(2020, 1, 1) + timedelta(hours=h) for h in range(12)]
+    vintage_times = [datetime(2019, 12, 31)] * 6 + [datetime(2020, 1, 1)] * 6
+    y_truth = pl.DataFrame({
+        "time": times,
+        "site_a__value": [10.0 + i for i in range(12)],
+        "site_b__value": [30.0 + i for i in range(12)],
+    })
+    lopsided = pl.DataFrame({
+        "vintage_time": vintage_times,
+        "time": times,
+        "site_a__value": y_truth["site_a__value"],
+        "site_b__value": y_truth["site_b__value"] + 10.0,
+    })
+    uniform = pl.DataFrame({
+        "vintage_time": vintage_times,
+        "time": times,
+        "site_a__value": y_truth["site_a__value"] + 5.0,
+        "site_b__value": y_truth["site_b__value"] + 5.0,
+    })
+    return {"y_truth": y_truth, "lopsided": lopsided, "uniform": uniform}
+
+
+class TestPlotScorePerVintagePanel:
+    """Per-vintage resolves panel data to its entities when asked to."""
+
+    def test_facet_by_group_yields_one_subplot_per_entity(self, uneven_panel_vintages):
+        fig = plot_score_per_vintage(
+            MeanAbsoluteError(),
+            uneven_panel_vintages["y_truth"],
+            {"lopsided": uneven_panel_vintages["lopsided"]},
+            facet_by="group",
+        )
+        assert len({trace.yaxis for trace in fig.data}) == 2
+
+    def test_one_bad_entity_is_visible_rather_than_averaged_away(self, uneven_panel_vintages):
+        fig = plot_score_per_vintage(
+            MeanAbsoluteError(),
+            uneven_panel_vintages["y_truth"],
+            {
+                "lopsided": uneven_panel_vintages["lopsided"],
+                "uniform": uneven_panel_vintages["uniform"],
+            },
+            facet_by="group",
+        )
+        by_axis = {}
+        for trace in fig.data:
+            by_axis.setdefault(trace.yaxis, {})[trace.name] = list(trace.y)
+        per_entity = [axis["lopsided"] for axis in by_axis.values()]
+        assert per_entity[0] != per_entity[1]
+        assert any(scores != by_axis[axis]["uniform"] for axis, scores in zip(by_axis, per_entity, strict=True))
+
+    def test_without_facet_by_the_entities_are_still_averaged(self, uneven_panel_vintages):
+        fig = plot_score_per_vintage(
+            MeanAbsoluteError(),
+            uneven_panel_vintages["y_truth"],
+            {
+                "lopsided": uneven_panel_vintages["lopsided"],
+                "uniform": uneven_panel_vintages["uniform"],
+            },
+        )
+        traces = {trace.name: list(trace.y) for trace in fig.data}
+        assert len({trace.yaxis for trace in fig.data}) == 1
+        assert traces["lopsided"] == traces["uniform"]
+
+    def test_groups_filters_which_entities_are_drawn(self, uneven_panel_vintages):
+        fig = plot_score_per_vintage(
+            MeanAbsoluteError(),
+            uneven_panel_vintages["y_truth"],
+            uneven_panel_vintages["lopsided"],
+            groups=["site_a"],
+            facet_by="group",
+        )
+        assert len({trace.yaxis for trace in fig.data}) == 1
+
+    def test_facet_by_member_groups_the_shared_column(self, uneven_panel_vintages):
+        fig = plot_score_per_vintage(
+            MeanAbsoluteError(),
+            uneven_panel_vintages["y_truth"],
+            uneven_panel_vintages["lopsided"],
+            facet_by="member",
+        )
+        assert len({trace.yaxis for trace in fig.data}) == 1
+
+    def test_scorer_dict_over_panel_data_still_averages_without_faceting(self, uneven_panel_vintages):
+        fig = plot_score_per_vintage(
+            {"MAE": MeanAbsoluteError(), "RMSE": RootMeanSquaredError()},
+            uneven_panel_vintages["y_truth"],
+            uneven_panel_vintages["lopsided"],
+        )
+        assert len(fig.data) == 2
+
+    def test_scorer_dict_with_faceting_raises(self, uneven_panel_vintages):
+        with pytest.raises(ValueError, match="Multi-scorer is not supported with faceting"):
+            plot_score_per_vintage(
+                {"MAE": MeanAbsoluteError(), "RMSE": RootMeanSquaredError()},
+                uneven_panel_vintages["y_truth"],
+                uneven_panel_vintages["lopsided"],
+                facet_by="group",
+            )
+
+    def test_non_panel_data_ignores_the_request_to_facet(self, multi_vintage_data):
+        fig = plot_score_per_vintage(
+            MeanAbsoluteError(),
+            multi_vintage_data["y_truth"],
+            multi_vintage_data["y_pred"],
+            facet_by="group",
+        )
+        assert len({trace.yaxis for trace in fig.data}) == 1
+
+
+class TestPlotScoreHeatmapPanel:
+    """The heatmap spends a subplot grid on entities, not a third axis."""
+
+    def test_one_heatmap_per_entity_each_still_vintages_by_steps(self, uneven_panel_vintages):
+        fig = plot_score_heatmap(
+            MeanAbsoluteError(),
+            uneven_panel_vintages["y_truth"],
+            uneven_panel_vintages["lopsided"],
+            facet_by="group",
+        )
+        assert len(fig.data) == 2
+        for trace in fig.data:
+            assert np.array(trace.z).shape == (2, 6)
+
+    def test_every_heatmap_shares_one_colour_range(self, uneven_panel_vintages):
+        fig = plot_score_heatmap(
+            MeanAbsoluteError(),
+            uneven_panel_vintages["y_truth"],
+            uneven_panel_vintages["lopsided"],
+            facet_by="group",
+        )
+        assert {trace.coloraxis for trace in fig.data} == {"coloraxis"}
+        assert fig.layout.coloraxis.cmin == 0.0
+        assert fig.layout.coloraxis.cmax == 10.0
+
+    def test_the_failing_entity_reads_differently_from_the_healthy_one(self, uneven_panel_vintages):
+        fig = plot_score_heatmap(
+            MeanAbsoluteError(),
+            uneven_panel_vintages["y_truth"],
+            uneven_panel_vintages["lopsided"],
+            facet_by="group",
+        )
+        cells = [np.unique(np.array(trace.z)).tolist() for trace in fig.data]
+        assert cells == [[0.0], [10.0]]
+
+    def test_without_facet_by_the_grid_is_unchanged(self, uneven_panel_vintages):
+        fig = plot_score_heatmap(
+            MeanAbsoluteError(),
+            uneven_panel_vintages["y_truth"],
+            uneven_panel_vintages["lopsided"],
+        )
+        assert len(fig.data) == 1
+        assert np.array(fig.data[0].z).shape == (2, 6)
+        assert np.unique(np.array(fig.data[0].z)).tolist() == [5.0]
+
+    def test_faceting_respects_swapped_axes(self, uneven_panel_vintages):
+        fig = plot_score_heatmap(
+            MeanAbsoluteError(),
+            uneven_panel_vintages["y_truth"],
+            uneven_panel_vintages["lopsided"],
+            x_dim="vintage",
+            y_dim="step",
+            facet_by="group",
+        )
+        for trace in fig.data:
+            assert np.array(trace.z).shape == (6, 2)
+
+    def test_non_panel_data_ignores_the_request_to_facet(self, multi_vintage_data):
+        fig = plot_score_heatmap(
+            MeanAbsoluteError(),
+            multi_vintage_data["y_truth"],
+            multi_vintage_data["y_pred"],
+            facet_by="group",
+        )
+        assert len(fig.data) == 1
+
+
+class TestFacetedIntervalScoring:
+    """A facet carries the bound columns its point column needs."""
+
+    @pytest.fixture
+    def panel_with_bounds(self):
+        times = [datetime(2020, 1, 1) + timedelta(hours=h) for h in range(12)]
+        vintage_times = [datetime(2019, 12, 31)] * 6 + [datetime(2020, 1, 1)] * 6
+        truth_a = [10.0 + i for i in range(12)]
+        truth_b = [30.0 + i for i in range(12)]
+        y_truth = pl.DataFrame({"time": times, "site_a__value": truth_a, "site_b__value": truth_b})
+        columns = {"vintage_time": vintage_times, "time": times}
+        for entity, base, spread in (("site_a", truth_a, 3.0), ("site_b", truth_b, 9.0)):
+            columns[f"{entity}__value"] = base
+            for rate in (0.5, 0.8):
+                columns[f"{entity}__value_lower_{rate}"] = [v - spread for v in base]
+                columns[f"{entity}__value_upper_{rate}"] = [v + spread for v in base]
+        return y_truth, pl.DataFrame(columns)
+
+    def test_interval_scorer_survives_faceting(self, panel_with_bounds):
+        y_truth, y_pred = panel_with_bounds
+        scorer = IntervalScore(coverage_rates=[0.5, 0.8])
+        scorer.fit(y_truth)
+        fig = plot_score_per_vintage(scorer, y_truth, y_pred, facet_by="group")
+        assert len({trace.yaxis for trace in fig.data}) == 2
+
+    def test_interval_scorer_survives_heatmap_faceting(self, panel_with_bounds):
+        y_truth, y_pred = panel_with_bounds
+        scorer = IntervalScore(coverage_rates=[0.5, 0.8])
+        scorer.fit(y_truth)
+        fig = plot_score_heatmap(scorer, y_truth, y_pred, facet_by="group")
+        assert len(fig.data) == 2


### PR DESCRIPTION
## Why

`plot_score_per_vintage` and `plot_score_heatmap` were the two score views with no panel support. Both collapsed the per-entity score columns with `mean_horizontal()` before drawing, so a model that is accurate at three entities and badly wrong at a fourth reads as mildly mediocre, and a bad vintage never says which entity caused it.

The other score views (`plot_score_time_series`, `plot_score_distribution`, `plot_score_per_step`) already take `groups` and `facet_by`.

## What changed

- Both views take `groups` and `facet_by`. One subplot per group (or per member), models overlaid.
- The heatmap already spends both axes on step and vintage, so its entities become a subplot grid rather than a third axis. Every heatmap in the grid shares one colour scale, so a weak entity is visible next to healthy ones instead of each being auto-scaled to look the same.
- The per-vintage grid is already spent on scorers and models, so asking for several scorers together with `facet_by` raises, the way `plot_score_per_step` already does for multi-scorer panel data.
- A facet carries its point column's companions (`{col}_lower_{rate}`, `{col}_upper_{rate}`, `{col}_proba_{label}`), without which an interval scorer fails on the narrowed frame.

## Not breaking

Unlike the views that facet on *detecting* panel columns, these two enter the panel branch only when `facet_by` is passed. Panel data alone renders exactly as before, so every existing caller and doctest keeps its output. `facet_by=None` remains the default, and that deliberate inconsistency with the sibling views is documented rather than silent.

## Docs

The panel section of the visualization explanation page promised that panel mode activates with no configuration and that `facet_by` defaults to `"member"`. That is now untrue for these two views, so the page names them as exceptions. The visualize-scores how-to gains the per-entity call for both views.

## Tests

16 new tests: one subplot per entity, per-entity series that differ, the unfaceted output unchanged, the `groups` filter, member faceting, the multi-scorer refusal, non-panel data ignoring the request to facet, the shared colour range, swapped axes, and interval scorers surviving faceting in both views.

`uv run pytest tests/plotting`: 1081 passed.