### PR TITLE
fix(ci): unblock PyPI publishing by bumping gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.claude/skills/polish-changelog/SKILL.md
+++ b/.claude/skills/polish-changelog/SKILL.md
@@ -56,7 +56,7 @@ gh pr list --state open --json number,headRefName,title \
 # or match the branch prefix:
 gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("changelog-v"))'
 gh pr checkout <number>
-```text
+```
 
 ### 2. Isolate the new section
 
@@ -74,7 +74,7 @@ For each bullet, get the real context from its linked PR (the subject line rarel
 
 ```bash
 gh pr view <N> --json title,body,files --jq '{title, body, files: [.files[].path]}'
-```text
+```
 
 Rewrite the description from that evidence, following the style contract below. **If the PR's title/body/diff does not support a clearer wording that is still accurate, keep the original subject unchanged.** A plausible-but-wrong rewrite reads clean and can claim behavior the code does not have — abstaining is the correct default under uncertainty. Never assert an effect you cannot see in the PR.
 
@@ -87,6 +87,7 @@ Each description is:
 - **No trailing period.**
 - **The user-visible effect over the internal mechanism**, when they differ.
 - **Self-contained** — no repo-internal codenames ("the fan-out"), no undefined invariants, nothing that needs `git log` to understand.
+- **Never provenance alone.** See the rule below.
 
 | Before (git-cliff, verbatim subject) | After |
 |---|---|
@@ -94,6 +95,26 @@ Each description is:
 | Correct three v0.29.0 rendering bugs the fan-out surfaced | Fix three docs-rendering regressions from v0.29.0 |
 | Drop the stale 'yohou documents pre-commit' claim | Remove an outdated note about pre-commit from the docs |
 | Render numpydoc References sections as a markdown list | *(already clear — leave unchanged)* |
+
+#### A description must name a change, never just a version
+
+`Update from template v0.39.0` is not a changelog entry. It names a *source* and a *version number* and says nothing about what the release did to this package — a reader learns strictly less than from the version header they are already looking at. The same failure wears other clothes: `Sync to v0.36.0`, `Bump the pinned toolchain`, `Apply the fan-out`, `Update dependencies`.
+
+**The rule:** the description says what landed *in this package*. Where the source matters for traceability, it goes at the end in parentheses as provenance — never as the subject.
+
+| Before | After |
+|---|---|
+| Update from template v0.39.0 | Fix three release-pipeline defects (template v0.39.0) |
+| Update from template v0.38.0 | Add a CLAUDE.md project-instructions file for AI assistants (template v0.38.0) |
+| Sync to v0.35.0 | Restrict workflow permissions and add secret scanning (template v0.35.0) |
+| Update from template v0.40.1 | Fix a shell injection in the release publish job (template v0.40.1) |
+
+Two traps this rule closes:
+
+- **Normalising toward the uninformative.** When several template-update bullets appear together it is tempting to give them one consistent phrasing — and the phrasing they already share is the empty one. Consistency is worth having in the *shape* (effect first, provenance in parens), never in the content.
+- **A parenthetical is not a description.** `Update from template v0.36.0 (Codecov OIDC + scorecard pin)` looks polished because it carries real information, but it still leads with the non-event. Promote the parenthetical to the subject and demote the version.
+
+If the linked PR genuinely does not say what changed for this package, that is a grounding failure, not a licence to write the version number: say what the diff shows (`Update pinned CI action digests`) and no more.
 
 ### 5. Self-verify, then deliver
 
@@ -108,7 +129,7 @@ Then commit and push to the PR branch — **do not merge**:
 ```bash
 git commit -am "chore(changelog): polish release notes for vX.Y.Z"
 git push
-```text
+```
 
 The maintainer reviews the polished diff on the PR and merges it.
 

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 10e9f41542bbcf96855ec8049cb1e0802572a610
+_commit: 7419e837c85f2cbc9df575297b3f9f6e7573dc89
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -184,7 +184,16 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        # Must stay recent enough for the twine it bundles to accept the core
+        # metadata version `hatchling` emits. v1.13.0 bundled twine < 7, which
+        # rejects `Metadata-Version: 2.5` with `InvalidDistribution` -- and since
+        # `[build-system] requires` leaves hatchling unpinned, every project broke
+        # here the day hatchling started emitting 2.5, with no change of its own.
+        # v1.14.2 moved to twine v7. Renovate keeps this current, but its updates
+        # are rate-limited: this one sat on the dependency dashboard for two weeks
+        # while noisier digest bumps took the weekly slots, so a release-blocking
+        # bump can be queued and invisible. Check the dashboard before releasing.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true
           verify-metadata: false


### PR DESCRIPTION
**Held for review, do not merge.** Merging this is what unblocks the stuck alpha.12 publish.

## Why this exists

`pypa/gh-action-pypi-publish@v1.13.0` bundles twine < 7, which rejects the `Metadata-Version: 2.5` that hatchling now emits. Because `[build-system] requires` leaves hatchling unpinned, every generated project's publish job started failing with `InvalidDistribution` without any change of its own.

This is not hypothetical here: **yohou v0.1.0-alpha.12 already failed this way.** Its GitHub Release is sitting as a draft and the package is 404 on PyPI. Merging this PR is the fix, and the release can then be re-run.

`v1.14.2` moved to twine v7.

## What actually changes

Template v0.41.4 to v0.41.5. Three files:

| file | change |
|---|---|
| `.github/workflows/publish-release.yml` | the pin bump, plus the template's comment explaining why the pin must stay current |
| `.claude/skills/polish-changelog/SKILL.md` | new guidance: a changelog entry must name the change, not just the template version |
| `.copier-answers.yml` | `_commit` to `7419e83` |

### The pin is a digest, not the template's tag

The template ships `uses: pypa/gh-action-pypi-publish@v1.14.2` as a bare tag. This repo is digest-pinned by Renovate and scored on it by Scorecard's `PinnedDependencies` check, so the resolution keeps a digest:

```
uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
```

`dc37677b` is the dereferenced commit of the `v1.14.2` tag (the tag object itself is `a892a5a6`; it is annotated). Verified against the GitHub API, not copied from the template.

Note this is the one line where the usual fan-out rule inverts. The standing rule is to keep the local digest and discard the template's tag, but here the local digest **is** v1.13.0, the broken version. Keeping it would have produced a green PR with the bug fully intact.

## What the release did NOT change here, and why that is correct

Two of the five payload files resolved to **byte-identical** results. Both are real no-ops, not failed merges:

- **`nightly.yml`** already had the entire fix locally: `fail-fast: false`, the `test_coverage`/`test` split gated on the minimum Python, and the Codecov upload gated on the entry that produces the report. Upstream #296 is the upstreaming of this repo's own shape. The three conflicts here were comment wording only, resolved toward the local wording because it is the more specific one (it names this repo's real matrix versions and its real `test-full` job). Every functional line already matched, and `nox -s test_docstrings-${{ matrix.python-version }}` is preserved.
- **`changelog.yml`** pins `actions/create-github-app-token` at `fee1f7d6 # v2`, and `v2` and `v2.2.2` resolve to the *same commit*. This repo already runs v2.2.2's code, so keeping the local digest loses nothing.

`.github/skills/polish-changelog/SKILL.md` was also delivered, byte-identical to its `.claude` twin, but `.gitignore:178` ignores `.github/skills/` so it is untracked and cannot appear in this diff.

## Verification

- `.rej` files: **0**. Inline conflicts: **5**, across 3 files, all `UU`. A `.rej`-only sweep would have called this clean.
- Every touched file diffed **whole-file** against the pre-update baseline. `publish-release.yml` carries only the payload hunk; the other two are byte-identical.
- `git diff --stat -- docs/assets` is empty.
- `tests/conftest.py` and `mkdocs.yml` are byte-unchanged (sha256 verified). `.gitignore` untouched.
- All **59** `uses:` lines across all 12 workflows are still 40-hex digest-pinned; **17** `astral-sh/setup-uv` `version: "0.12.1"` inputs preserved, including in the four bespoke workflows copier does not own (`examples.yml`, `regenerate-datasets.yml`, `export-notebooks.yml`, `docs-deploy.yml`).
- `uv run prek run --all-files`: all 13 hooks pass, including `check yaml` and `check for merge conflicts`.

`nightly.yml` has no `pull_request` trigger, so no check on this PR exercises it. It was dispatched manually on this branch; see the comment below for the result.
