### PR TITLE
docs(explanation): link the security page from the section index

### DIFF
--- a/docs/pages/explanation/index.md
+++ b/docs/pages/explanation/index.md
@@ -41,4 +41,5 @@ Pages that draw on external academic literature or published standards close wit
 
 ## Reference
 
+- [Security](security.md): The hardened release pipeline, what each measure protects against, and how to verify a published release.
 - [Glossary](glossary.md): Definitions of key terms used across Yohou documentation.


### PR DESCRIPTION
## Description

The security posture page is in the nav but not linked from `docs/pages/explanation/index.md`, so it is reachable only via the nav sidebar. This adds the one missing bullet, in this repo`&#39;`s own list style.

## Type of Change

- [x] Documentation update

## Motivation and Context

Found while auditing the fleet after the v0.42.0 fan-out. A fan-out agent reported it in one repo; checking all seven found it in **four** (yohou, kedro-dagster, sklearn-wrap, kedro-azureml-pipeline). It breaks the convention that every section index links every sibling page, and it hides exactly the page a user looking for supply-chain guarantees would search for.

**This is not a template bug.** The template ships `explanation/index.md` with a `<!-- SUBPAGES -->` marker that expands at build time and covers every sibling automatically. The three unaffected repos still have that marker. The four affected ones replaced it with a hand-written list to carry per-page descriptions, and the list was never updated when the security page arrived with the fleet security-hardening release.

So the gap recurs by construction: **any future template page added to this section will be invisible here** until someone notices and adds it by hand. Whether the curated descriptions are worth that trade is a real question, and restoring the marker is the alternative. Not decided here.

## How Has This Been Tested?

- [x] Verified with a link-extraction check over `mkdocs.yml` nav leaves versus real `](target)` links in the index: this section now reports full coverage.

Two method notes, because both are traps this fleet has recorded before and I hit both:

- My first sweep reported **all seven repos clean**. It matched the bare page stem anywhere in the index text, so prose containing the word "security" satisfied it. The rewritten check extracts real link targets, and I falsified it against the one case verified by hand before trusting any zero from it.
- The rewritten check then reported `pages/api/index.md` as `0/15` in yohou. That is a false positive: the API index uses `<!-- API_TABLE -->`, which also expands at build time. A coverage check must skip every build-time marker, not just `SUBPAGES`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Held for review, do not merge. One line, no code changes.