### PR TITLE
fix(interval)!: calibrate conformal intervals per value column

### DIFF
--- a/docs/pages/api/interval.md
+++ b/docs/pages/api/interval.md
@@ -10,6 +10,8 @@ Interval forecasters for prediction uncertainty quantification.
 
 | Name | Description |
 |------|-------------|
+| [`AdaptiveConformalInference`](generated/yohou.interval.AdaptiveConformalInference.md) | Online miscoverage-level adjustment (Gibbs and Candes, 2021). |
+| [`BaseConformalAdapter`](generated/yohou.interval.BaseConformalAdapter.md) | Base class for adaptive conformal inference adapters. |
 | [`BaseIntervalForecaster`](generated/yohou.interval.BaseIntervalForecaster.md) | Base class for interval forecasters. |
 | [`BaseSimilarity`](generated/yohou.interval.BaseSimilarity.md) | Base class for similarity measures used in interval forecasting. |
 | [`IntervalReductionForecaster`](generated/yohou.interval.IntervalReductionForecaster.md) | Interval forecaster using sklearn estimators on tabularized time series. |

--- a/docs/pages/api/testing.md
+++ b/docs/pages/api/testing.md
@@ -54,6 +54,7 @@ Testing utilities for Yohou estimators.
 | [`check_interval_bounds`](generated/yohou.testing.check_interval_bounds.md) | Check upper >= lower for all coverage rates and time steps. |
 | [`check_interval_prediction_columns`](generated/yohou.testing.check_interval_prediction_columns.md) | Check interval predictions have {col}_lower_{rate} and {col}_upper_{rate} format. |
 | [`check_interval_prediction_types`](generated/yohou.testing.check_interval_prediction_types.md) | Check interval forecaster has 'interval' in forecaster_type tag. |
+| [`check_per_column_calibration_independence`](generated/yohou.testing.check_per_column_calibration_independence.md) | Check each value column's interval is calibrated from that column alone. |
 | [`assert_request_equal`](generated/yohou.testing.assert_request_equal.md) | Assert metadata request matches expected dictionary. |
 | [`assert_request_is_empty`](generated/yohou.testing.assert_request_is_empty.md) | Check if a metadata request dict is empty. |
 | [`check_recorded_metadata`](generated/yohou.testing.check_recorded_metadata.md) | Check whether the expected metadata is passed to the object's method. |

--- a/docs/pages/explanation/interval-forecasting.md
+++ b/docs/pages/explanation/interval-forecasting.md
@@ -154,15 +154,42 @@ then produces intervals that adapt to local conditions.
 [`DistanceSimilarity`](/pages/api/generated/yohou.interval.DistanceSimilarity/)
 computes distances between the current prediction context (the feature vector derived
 from the point forecaster's observation window at predict time) and each calibration
-feature vector stored during `fit()`. It then converts distances to weights using a
-numerically stable softmax of negative distances with uniform mass reserved for the
-test point:
+feature vector stored during `fit()`. Each feature column is first divided by its
+own spread, measured at `fit()` time. Then the distances are divided by a fitted
+distance scale (the median pairwise distance among the calibration features) and by
+the `bandwidth` parameter. Writing that scaled distance as
+$\tilde{d} = d / (\text{bandwidth} \cdot \text{distance scale})$, the weights are a
+numerically stable softmax of negative scaled distances with uniform mass reserved
+for the test point:
 
-$$w_{ji} = \frac{\exp(-(d_{ji} - \max_k d_{jk}))}{1 + \sum_k \exp(-(d_{jk} - \max_k d_{jk}))}$$
+$$w_{ji} = \frac{\exp(-(\tilde{d}_{ji} - \min_k \tilde{d}_{jk}))}{1 + \sum_k \exp(-(\tilde{d}_{jk} - \min_k \tilde{d}_{jk}))}$$
 
 Calibration points close to the current prediction get exponentially higher weights
 than distant ones. The distance metric is configurable: euclidean, cityblock, cosine,
 or any metric supported by `scipy.spatial.distance.cdist`.
+
+The two scalings each fix a different failure. Dividing by the fitted distance scale
+makes the weights invariant to a rescaling of the data: without it, the softmax has no
+width of its own, so how concentrated the weights are depends on the units. The same
+series measured in thousands rather than units would put nearly all its weight on a
+single calibration row, and the resulting interval would be read off one conformity
+score. Dividing each column by its own spread stops a single high-magnitude column
+from deciding the neighbourhood for every other column, which is what happens on a
+panel whose entities differ in size.
+
+`bandwidth` is the knob left over once the scale is handled. Below 1 concentrates
+weight on nearer calibration rows, above 1 flattens toward uniform. Reach for it when
+the default neighbourhood is wider or narrower than the structure you know is in your
+data.
+
+The two similarities default it differently, and the reason is worth knowing.
+`DistanceSimilarity` defaults to `1.0`. `SeasonalSimilarity` defaults to `0.5`, because
+its harmonic features are bounded on the unit circle: their median pairwise distance is
+around 1.5, so dividing by it flattens a spread that was already narrow. At `1.0` a
+weekly seasonality keeps roughly 41 of 50 calibration rows as effective sample size,
+near enough to uniform that the weighted quantile usually lands on the same order
+statistic as the unweighted one, which makes the similarity do nothing visible. At `0.5`
+it keeps roughly 25 and the weighting bites.
 
 The leading `1` in the denominator reserves uniform mass for the hypothetical test
 point, so each weight row is non-negative and sums to a value strictly below 1. This
@@ -272,9 +299,12 @@ summarized below.
 | Similarity weighting | which residuals count | `similarity` |
 | Adaptive conformal inference | how far into their tail to reach | `adapter` |
 
-The adapter tracks one level per horizon step (or a single shared level with
-`alpha_pooling="shared"`), and one level per tail for asymmetric conformity
-scorers so a lopsided error distribution corrects each side separately.
+The adapter tracks one level per horizon step and value column (or one level per
+value column shared across steps with `alpha_pooling="shared"`), and one level per
+tail for asymmetric conformity scorers so a lopsided error distribution corrects
+each side separately. `alpha_pooling` pools along the horizon axis only: two
+entities' levels are never fused, so a chronically miscovered entity widens its own
+intervals and nobody else's.
 
 ## Quantile Reduction Intervals
 
@@ -354,15 +384,44 @@ and
 support panel data through the `panel_strategy` parameter:
 
 - **`"global"`** (default): fits a single shared model across all groups, but
-  maintains per-group transformer state and observation buffers. Groups share a
-  single calibration set or quantile model. For independent per-group models, use
+  maintains per-group transformer state and observation buffers. For independent
+  per-group models, use
   [`LocalPanelForecaster`](/pages/api/generated/yohou.compose.LocalPanelForecaster/).
-- **`"multivariate"`**: pools data across groups, sharing calibration scores or
-  quantile models. This is useful when individual groups have limited data and
-  borrowing strength across entities improves interval quality.
+- **`"multivariate"`**: skips panel detection entirely and treats `__`-prefixed
+  columns as ordinary multivariate columns, so one transformer and one model see
+  the full wide frame. Use it when cross-group feature interactions matter.
 
 The choice mirrors the panel strategies available in point forecasting. See
 [Panel Data](panel-data.md) for the full treatment.
+
+### What `panel_strategy` does not govern
+
+`panel_strategy` decides how the *point model* is fitted and how per-group state
+is kept. It does not decide the calibration axis. Conformal calibration is always
+per value column, under either strategy: each `{group}__{variable}` column takes
+the quantile of its own conformity scores, and the adaptive level, when an
+`adapter` is configured, is likewise tracked per column.
+
+This matters when entities differ in magnitude. A store selling 50 units a day
+and one selling 5,000 need interval widths two orders of magnitude apart. Sharing
+one calibration across them would over-cover the small entity and under-cover the
+large one, and the sharing would be invisible: both intervals are well-formed, one
+is simply too wide and the other too narrow.
+
+There is deliberately no option to pool calibration scores across entities, and no
+`calibration_pooling` parameter. Pooling raw residuals from entities of different
+magnitude is what produces the failure above, and pooling is only defensible with a
+scale-free conformity score such as
+[`GammaResidual`](/pages/api/generated/yohou.metrics.conformity.GammaResidual/).
+The same reasoning is why the adapter has no `entity_pooling` parameter alongside
+its `alpha_pooling`. Both were considered and deferred rather than rejected: the
+default had to settle first, and both could be added later without moving it.
+
+Note also that entity count never starves calibration here. `calibration_size` slices
+rows, and every entity shares the time index, so each entity receives the full
+calibration count no matter how many entities there are. What can starve it is a short
+history: a coverage rate of `1 - alpha` needs at least `1/alpha - 1` calibration scores
+to be expressible at all, meaning 19 for 95% and 99 for 99%.
 
 ## Coverage Rates
 

--- a/docs/pages/explanation/interval-forecasting.md
+++ b/docs/pages/explanation/interval-forecasting.md
@@ -409,13 +409,30 @@ large one, and the sharing would be invisible: both intervals are well-formed, o
 is simply too wide and the other too narrow.
 
 There is deliberately no option to pool calibration scores across entities, and no
-`calibration_pooling` parameter. Pooling raw residuals from entities of different
-magnitude is what produces the failure above, and pooling is only defensible with a
-scale-free conformity score such as
-[`GammaResidual`](/pages/api/generated/yohou.metrics.conformity.GammaResidual/).
-The same reasoning is why the adapter has no `entity_pooling` parameter alongside
-its `alpha_pooling`. Both were considered and deferred rather than rejected: the
-default had to settle first, and both could be added later without moving it.
+`calibration_pooling` parameter. Three things stand in the way, and they are not
+equally tractable.
+
+The first is magnitude. Pooling raw residuals from entities of different size is what
+produces the failure above, and a scale-free score such as
+[`GammaResidual`](/pages/api/generated/yohou.metrics.conformity.GammaResidual/), which
+divides by the predicted level, removes it.
+
+The second is volatility, and the level-based score does not remove it. Two entities of
+the same size whose errors differ threefold in spread still contribute incomparable
+scores. Making them comparable needs a score divided by a per-entity dispersion
+estimate, which yohou does not currently provide.
+
+The third is dependence, and no conformity score removes it. Entities observed at the
+same timestamp share shocks, so their scores are correlated within a timestamp and much
+less so across timestamps. A pooled sequence with that block structure is not
+exchangeable, which is the assumption the finite-sample guarantee rests on. It also
+means pooling buys far less than the entity count suggests: under same-timestamp
+correlation `rho` the effective gain saturates near `1 / rho`, so two hundred entities
+that move together are worth about as much as ten.
+
+The same reasoning is why the adapter has no `entity_pooling` parameter alongside its
+`alpha_pooling`. Both were considered and deferred rather than rejected, but the
+prerequisite is a dispersion-normalized conformity score, not merely a scale-free one.
 
 Note also that entity count never starves calibration here. `calibration_size` slices
 rows, and every entity shares the time index, so each entity receives the full
@@ -436,6 +453,22 @@ scores are stored and the quantile computation is applied at prediction time; no
 re-calibration is needed. For `IntervalReductionForecaster`, new coverage rates
 require that the underlying estimator can produce predictions at the corresponding
 quantile levels.
+
+### How many calibration scores a rate needs
+
+A conformal bound is an order statistic of the calibration scores, specifically the
+`ceil((n + 1) * q)`-th, where `q` is the tail level. That index exists only while it
+stays within `n`, which means a rate needs at least `q / (1 - q)` scores per value
+column to be representable at all: 9 for a symmetric 90%, 99 for a symmetric 99%, and
+roughly double each for an asymmetric scorer, which splits the miscoverage across two
+tails. Beyond that point the correct bound is unbounded, and any finite number the
+implementation returns under-covers.
+
+`SplitConformalForecaster` warns when you ask for a rate its calibration set cannot
+express, naming the horizon step and the count you would need. Note that the constraint
+is per value column but `calibration_size` slices rows, so every entity of a panel gets
+the full count no matter how many entities there are. A short history is what runs you
+out, not a wide panel.
 
 The right coverage rate reflects the cost asymmetry of the decision. Safety-critical
 applications (capacity planning, risk management) warrant high coverage because the

--- a/src/yohou/interval/adapter.py
+++ b/src/yohou/interval/adapter.py
@@ -29,10 +29,13 @@ class AdaptiveConformalInference(BaseConformalAdapter):
     conformity scorer is asymmetric, a lower and an upper level are tracked
     separately, each targeting $\alpha^{*}/2$.
 
-    This adapter owns one horizon step; ``SplitConformalForecaster`` clones
-    one per step and supplies the miscoverage indicators (it holds the
-    calibration scores and any similarity weights). The adapter is the
-    level-recursion state machine only.
+    This adapter owns one horizon step and one value column;
+    ``SplitConformalForecaster`` clones one per pair and supplies that column's
+    own miscoverage indicators (it holds the calibration scores and any
+    similarity weights). The adapter is the level-recursion state machine only.
+    Keying by column as well as step is what keeps one entity's misses from
+    moving another entity's interval, since the quantile the level modulates is
+    itself per column.
 
     Parameters
     ----------

--- a/src/yohou/interval/base.py
+++ b/src/yohou/interval/base.py
@@ -7,6 +7,7 @@ import numpy as np
 import polars as pl
 import polars.selectors as cs
 from pydantic import StrictFloat, StrictInt
+from scipy.spatial.distance import pdist
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted
 
@@ -39,27 +40,100 @@ class BaseSimilarity(BaseEstimator, metaclass=abc.ABCMeta):
     _parameter_constraints: dict = {}
 
     @staticmethod
+    def _fit_feature_scale(features: np.ndarray) -> np.ndarray:
+        """Fit a per-column spread for standardizing a feature matrix.
+
+        Without this, a distance over columns of mixed magnitude is decided
+        almost entirely by the largest column, so every other column's
+        neighbourhood is chosen for it.
+
+        Parameters
+        ----------
+        features : numpy.ndarray
+            Fit-time feature matrix of shape ``(n_rows, n_features)``.
+
+        Returns
+        -------
+        numpy.ndarray
+            One positive scale per column. A column with zero or non-finite
+            spread (a constant feature) scales by ``1.0`` rather than
+            dividing by zero.
+
+        """
+        scale = np.std(np.asarray(features, dtype=np.float64), axis=0)
+        scale = np.atleast_1d(scale)
+        scale[~np.isfinite(scale) | (scale <= 0.0)] = 1.0
+        return scale
+
+    @staticmethod
+    def _fit_distance_scale(features: np.ndarray, metric: str, metric_params: dict[str, object] | None) -> float:
+        """Fit the distance scale as the median pairwise fit-time distance.
+
+        The softmax below has no width of its own, so without dividing by a
+        fitted scale the weight concentration is a function of the units of
+        the data: the same series at 100x the magnitude collapses onto its
+        single nearest calibration row.
+
+        Parameters
+        ----------
+        features : numpy.ndarray
+            Fit-time feature matrix, already standardized where the caller
+            standardizes.
+        metric : str
+            Distance metric, matching the one used at predict time.
+        metric_params : dict or None
+            Extra keyword arguments forwarded to the metric.
+
+        Returns
+        -------
+        float
+            The median pairwise distance, or ``1.0`` when it is zero, not
+            finite, or undefined for fewer than two rows.
+
+        """
+        features = np.asarray(features, dtype=np.float64)
+        if features.shape[0] < 2:
+            return 1.0
+
+        pairwise = pdist(features, metric=metric, **(metric_params or {}))  # ty: ignore[no-matching-overload]
+        if pairwise.size == 0:
+            return 1.0
+
+        median = float(np.median(pairwise))
+        return median if np.isfinite(median) and median > 0.0 else 1.0
+
+    @staticmethod
     def _to_weights(
         distances: np.ndarray,
+        distance_scale: float = 1.0,
+        bandwidth: float = 1.0,
     ) -> np.ndarray[tuple[int, int], np.dtype[np.floating[Any]]]:
         r"""Convert a distance matrix to calibration weights.
 
-        Applies a numerically-stable softmax of negative distances and
-        reserves uniform mass for the (hypothetical) test point over the
-        calibration axis:
+        Divides distances by the fitted scale and the bandwidth, then applies
+        a numerically-stable softmax of negative scaled distances, reserving
+        uniform mass for the (hypothetical) test point over the calibration
+        axis. Writing $\tilde{d} = d / (\text{bandwidth} \cdot
+        \text{distance\_scale})$:
 
-        $$w_{ji} = \frac{\exp(-(d_{ji} - \min_k d_{jk}))}
-        {1 + \sum_k \exp(-(d_{jk} - \min_k d_{jk}))}$$
+        $$w_{ji} = \frac{\exp(-(\tilde{d}_{ji} - \min_k \tilde{d}_{jk}))}
+        {1 + \sum_k \exp(-(\tilde{d}_{jk} - \min_k \tilde{d}_{jk}))}$$
 
-        Each output row is non-negative and sums to a value strictly less
-        than 1; the remainder ``1 / (1 + \sum_k raw)`` is the mass reserved
-        for the new test point, following the non-exchangeable conformal
-        construction (Barber et al., 2023).
+        Dividing by the fitted scale is what makes the weights invariant to a
+        rescaling of the data. Each output row is non-negative and sums to a
+        value strictly less than 1; the remainder ``1 / (1 + \sum_k raw)`` is
+        the mass reserved for the new test point, following the
+        non-exchangeable conformal construction (Barber et al., 2023).
 
         Parameters
         ----------
         distances : numpy.ndarray
             Distance matrix of shape ``(n_pred, n_calibration)``.
+        distance_scale : float, default=1.0
+            Fitted distance scale from :meth:`_fit_distance_scale`.
+        bandwidth : float, default=1.0
+            Multiplier on the scale. Below 1 concentrates weight on nearer
+            rows, above 1 flattens toward uniform.
 
         Returns
         -------
@@ -67,9 +141,10 @@ class BaseSimilarity(BaseEstimator, metaclass=abc.ABCMeta):
             Weight matrix of shape ``(n_pred, n_calibration)``.
 
         """
+        scaled = distances / (bandwidth * distance_scale)
         # Stable softmax of the exponent -d: subtract its row max (= -min(d)),
         # so every exponent is <= 0 and exp() cannot overflow.
-        neg_d = -distances
+        neg_d = -scaled
         neg_d = neg_d - neg_d.max(axis=1, keepdims=True)
         return BaseSimilarity._reserve_mass(np.exp(neg_d))
 

--- a/src/yohou/interval/similarity.py
+++ b/src/yohou/interval/similarity.py
@@ -1,6 +1,7 @@
 """Similarity measures for interval forecasting."""
 
 import math
+import numbers
 from datetime import timedelta
 from typing import Any, Literal
 
@@ -11,7 +12,7 @@ from sklearn.base import clone
 from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
 
-from yohou.utils._compat import _BaseComposition, _fit_context
+from yohou.utils._compat import Interval, _BaseComposition, _fit_context
 
 from .base import BaseSimilarity
 
@@ -27,13 +28,15 @@ class DistanceSimilarity(BaseSimilarity):
     by interval forecasters to weight conformity scores when constructing
     prediction intervals.
 
-    The weight for the *i*-th historical observation given prediction
-    *j* is computed with a numerically-stable softmax of negative
-    distances that reserves uniform mass for the (hypothetical) test
-    point over the calibration axis:
+    Each feature column is divided by its fit-time spread before distances
+    are computed, and the distances are then divided by ``bandwidth`` times a
+    fitted distance scale. Writing that scaled distance as $\tilde{d}$, the
+    weight for the *i*-th historical observation given prediction *j* is a
+    numerically-stable softmax of negative scaled distances that reserves
+    uniform mass for the (hypothetical) test point over the calibration axis:
 
-    $$w_{ji} = \frac{\exp(-(d_{ji} - \max_k d_{jk}))}
-    {1 + \sum_k \exp(-(d_{jk} - \max_k d_{jk}))}$$
+    $$w_{ji} = \frac{\exp(-(\tilde{d}_{ji} - \min_k \tilde{d}_{jk}))}
+    {1 + \sum_k \exp(-(\tilde{d}_{jk} - \min_k \tilde{d}_{jk}))}$$
 
     where $d_{ji} = d(x_j, x_i)$ for the chosen distance metric. The
     ``+1`` in the denominator reserves mass for the new test point
@@ -50,12 +53,32 @@ class DistanceSimilarity(BaseSimilarity):
         Additional keyword arguments forwarded to the distance metric
         function.
 
+    bandwidth : float > 0, default=1.0
+        Multiplier on the fitted distance scale. Values below 1 concentrate
+        weight on nearer calibration rows, values above 1 flatten the weights
+        toward uniform.
+
+    Attributes
+    ----------
+    _feature_scale_ : numpy.ndarray
+        Per-column spread fitted at ``fit``, used to standardize features
+        before distances are computed.
+
+    _distance_scale_ : float
+        Median pairwise distance among the standardized fit-time features.
+
     Notes
     -----
     The distance-to-weight conversion uses the softmax of negative
     distances, so distant observations contribute exponentially less
     than nearby ones. The weights are further normalised so that each
     prediction row sums to a value in (0, 1).
+
+    Both scales are fitted once and frozen: ``observe`` does not re-estimate
+    them, so ``predict`` is a function of the fitted state and the prediction
+    alone and ``rewind`` has no scale history to undo. Dividing by them is what
+    makes the weights invariant to a rescaling of the data, and stops a single
+    high-magnitude column from choosing the neighbourhood for the others.
 
     References
     ----------
@@ -114,15 +137,35 @@ class DistanceSimilarity(BaseSimilarity):
     _parameter_constraints: dict = {
         "metric": [str],
         "metric_params": [dict, None],
+        "bandwidth": [Interval(numbers.Real, 0, None, closed="neither")],
     }
 
     def __init__(
         self,
         metric: str = "euclidean",
         metric_params: dict[str, object] | None = None,
+        bandwidth: float = 1.0,
     ) -> None:
         self.metric = metric
         self.metric_params = metric_params
+        self.bandwidth = bandwidth
+
+    def _standardize(self, features: pl.DataFrame) -> np.ndarray:
+        """Divide each feature column by its fitted spread.
+
+        Parameters
+        ----------
+        features : pl.DataFrame
+            Feature matrix including its ``"time"`` column.
+
+        Returns
+        -------
+        numpy.ndarray
+            Standardized values with ``"time"`` dropped.
+
+        """
+        values = features.select(pl.exclude("time")).to_numpy().astype(np.float64)
+        return values / self._feature_scale_
 
     def _get_X(
         self,
@@ -204,6 +247,14 @@ class DistanceSimilarity(BaseSimilarity):
         """
         X_features = self._get_X(y_pred, X_actual)
         self._X_observed = X_features
+
+        # Both scales are fitted once here and never re-estimated by observe.
+        # A moving denominator would make predict depend on observation history
+        # in a way rewind would have to undo exactly, and would make two runs
+        # over the same data disagree.
+        raw = X_features.select(pl.exclude("time")).to_numpy().astype(np.float64)
+        self._feature_scale_ = self._fit_feature_scale(raw)
+        self._distance_scale_ = self._fit_distance_scale(raw / self._feature_scale_, self.metric, self.metric_params)
 
         return self
 
@@ -295,10 +346,12 @@ class DistanceSimilarity(BaseSimilarity):
         check_is_fitted(self, "_X_observed")
         X_features = self._get_X(y_pred, X_actual)
 
-        XA = X_features.select(pl.exclude("time")).to_numpy()
-        XB = self._X_observed.select(pl.exclude("time")).to_numpy()
+        # Standardized on both sides with the same fitted spread, so no single
+        # high-magnitude column decides the neighbourhood for the others.
+        XA = self._standardize(X_features)
+        XB = self._standardize(self._X_observed)
         distances: np.ndarray = cdist(XA, XB, metric=self.metric, **(self.metric_params or {}))  # ty: ignore[no-matching-overload]
-        return self._to_weights(distances)
+        return self._to_weights(distances, self._distance_scale_, self.bandwidth)
 
 
 class SeasonalSimilarity(BaseSimilarity):
@@ -331,10 +384,36 @@ class SeasonalSimilarity(BaseSimilarity):
     metric_params : dict or None, default=None
         Additional keyword arguments forwarded to the distance metric.
 
+    bandwidth : float > 0, default=0.5
+        Multiplier on the fitted distance scale. Values below 1 concentrate
+        weight on nearer calibration rows, values above 1 flatten the weights
+        toward uniform.
+
+        The default is below 1 here, unlike `DistanceSimilarity`, because
+        harmonic features are bounded on the unit circle. Their median pairwise
+        distance is around 1.5, so dividing by it flattens an already narrow
+        spread: at ``bandwidth=1.0`` a weekly seasonality retains about 41 of 50
+        calibration rows as effective sample size, close enough to uniform that
+        the weighted quantile usually selects the same order statistic as the
+        unweighted one. At ``0.5`` it retains about 25 of 50, which discriminates
+        while still averaging over a useful neighbourhood.
+
+        This default does not reproduce the behaviour from before the distance
+        scale was introduced, and cannot: expressed in this parameterisation the
+        old concentration was 0.64 for a weekly seasonality, 0.47 with two
+        harmonics, 0.71 monthly, and 1.66 annually. It varied with the
+        configuration precisely because it was unscaled, which is what this
+        parameterisation removes.
+
     Attributes
     ----------
     first_time_ : datetime
         Reference timestamp from the first calibration prediction.
+
+    _distance_scale_ : float
+        Median pairwise distance among the fit-time harmonic features. Unlike
+        `DistanceSimilarity`, no per-column standardization is applied: the
+        harmonics are already on a common scale.
     interval_td_ : timedelta
         Time interval between consecutive timestamps, auto-detected
         from calibration data. When ``fit`` receives a single timestamp the
@@ -350,11 +429,19 @@ class SeasonalSimilarity(BaseSimilarity):
 
     The weight normalisation matches ``DistanceSimilarity`` exactly, via the
     shared [`BaseSimilarity._to_weights`][yohou.interval.base.BaseSimilarity]:
-    a numerically-stable softmax of negative distances with uniform mass
-    reserved for the test point, ``w_{ji} = raw_{ji} / (1 + \sum_k raw_{jk})``
-    where ``raw_{ji} = \exp(-(d_{ji} - \max_k d_{jk}))``. Each row is
-    non-negative and sums below 1, following the non-exchangeable conformal
-    construction (Barber et al., 2023).
+    distances are divided by ``bandwidth`` times the fitted distance scale,
+    then converted by a numerically-stable softmax of negative scaled distances
+    with uniform mass reserved for the test point,
+    ``w_{ji} = raw_{ji} / (1 + \sum_k raw_{jk})`` where
+    ``raw_{ji} = \exp(-(\tilde{d}_{ji} - \min_k \tilde{d}_{jk}))`` and
+    ``\tilde{d} = d / (bandwidth \cdot distance\_scale)``. Note the baseline is
+    the row *minimum*. Each row is non-negative and sums below 1, following the
+    non-exchangeable conformal construction (Barber et al., 2023).
+
+    What differs from ``DistanceSimilarity`` is the input to that shared
+    conversion, not the conversion: features here are harmonics of time rather
+    than data values, so there is no per-column standardization step, and the
+    default ``bandwidth`` is lower.
 
     References
     ----------
@@ -398,6 +485,7 @@ class SeasonalSimilarity(BaseSimilarity):
         "harmonics": [dict, None],
         "metric": [str],
         "metric_params": [dict, None],
+        "bandwidth": [Interval(numbers.Real, 0, None, closed="neither")],
     }
 
     def __init__(
@@ -406,11 +494,13 @@ class SeasonalSimilarity(BaseSimilarity):
         harmonics: dict[float, list[int]] | None = None,
         metric: str = "euclidean",
         metric_params: dict[str, object] | None = None,
+        bandwidth: float = 0.5,
     ) -> None:
         self.seasonality = seasonality
         self.harmonics = harmonics
         self.metric = metric
         self.metric_params = metric_params
+        self.bandwidth = bandwidth
 
     def _resolve_harmonics(self) -> dict[float, list[int]]:
         """Resolve harmonics, defaulting to first harmonic per seasonality.
@@ -506,6 +596,10 @@ class SeasonalSimilarity(BaseSimilarity):
             self.interval_td_ = timedelta(0)
 
         self._features_observed = self._extract_features(times)
+        # Harmonic features are bounded and commensurate by construction, so
+        # there is nothing to standardize; only the distance scale is fitted,
+        # which gives this class the same bandwidth control as the others.
+        self._distance_scale_ = self._fit_distance_scale(self._features_observed, self.metric, self.metric_params)
 
         return self
 
@@ -597,7 +691,7 @@ class SeasonalSimilarity(BaseSimilarity):
             metric=self.metric,
             **(self.metric_params or {}),
         )  # ty: ignore[no-matching-overload]
-        return self._to_weights(distances)
+        return self._to_weights(distances, self._distance_scale_, self.bandwidth)
 
 
 class CompositeSimilarity(BaseSimilarity, _BaseComposition):

--- a/src/yohou/interval/similarity.py
+++ b/src/yohou/interval/similarity.py
@@ -383,33 +383,15 @@ class SeasonalSimilarity(BaseSimilarity):
         Distance metric for ``scipy.spatial.distance.cdist``.
     metric_params : dict or None, default=None
         Additional keyword arguments forwarded to the distance metric.
-
     bandwidth : float > 0, default=0.5
         Multiplier on the fitted distance scale. Values below 1 concentrate
         weight on nearer calibration rows, values above 1 flatten the weights
         toward uniform.
 
-        The default is below 1 here, unlike `DistanceSimilarity`, because
-        harmonic features are bounded on the unit circle. Their median pairwise
-        distance is around 1.5, so dividing by it flattens an already narrow
-        spread: at ``bandwidth=1.0`` a weekly seasonality retains about 41 of 50
-        calibration rows as effective sample size, close enough to uniform that
-        the weighted quantile usually selects the same order statistic as the
-        unweighted one. At ``0.5`` it retains about 25 of 50, which discriminates
-        while still averaging over a useful neighbourhood.
-
-        This default does not reproduce the behaviour from before the distance
-        scale was introduced, and cannot: expressed in this parameterisation the
-        old concentration was 0.64 for a weekly seasonality, 0.47 with two
-        harmonics, 0.71 monthly, and 1.66 annually. It varied with the
-        configuration precisely because it was unscaled, which is what this
-        parameterisation removes.
-
     Attributes
     ----------
     first_time_ : datetime
         Reference timestamp from the first calibration prediction.
-
     _distance_scale_ : float
         Median pairwise distance among the fit-time harmonic features. Unlike
         `DistanceSimilarity`, no per-column standardization is applied: the

--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -18,7 +18,7 @@ from yohou.utils import POINT_INTERVAL, Tags, validate_forecaster_data
 from yohou.utils._compat import Interval, _fit_context
 
 from .base import BaseConformalAdapter, BaseIntervalForecaster, BaseSimilarity
-from .utils import warn_if_weights_collapsed, weighted_quantile
+from .utils import warn_if_calibration_too_small, warn_if_weights_collapsed, weighted_quantile
 
 __all__ = ["SplitConformalForecaster"]
 
@@ -596,7 +596,11 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         if self.similarity is not None and hasattr(self, "similarities_"):
             weight_matrix = self.similarities_[step_key].predict(y_pred=scored_pred).astype(np.float64)
         else:
-            weight_matrix = np.ones((scores_new.height, n_calib), dtype=np.float64)
+            # Uniform weights that reserve mass for the test point, mirroring
+            # BaseSimilarity._reserve_mass. weighted_quantile does not
+            # renormalize, so 1/(n+1) each is what reproduces the standard
+            # ceil((n+1) * q) conformal order statistic.
+            weight_matrix = np.full((scores_new.height, n_calib), 1.0 / (n_calib + 1), dtype=np.float64)
 
         row_index = {t: i for i, t in enumerate(y["time"].to_list())}
         scored_values = {c: scores_new[c].to_numpy().astype(np.float64) for c in value_cols}
@@ -1415,8 +1419,18 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             conformity_scorer_step = self.conformity_scorers_[f"step_{step}"]
             conformity_scores_step = self.conformity_scores_.filter(pl.col("step") == step).drop("step")
 
+            # One scorer per step, so its symmetry is fixed for every rate below.
+            step_tags = conformity_scorer_step.__sklearn_tags__()
+            assert step_tags.scorer_tags is not None
+            step_symmetric = step_tags.scorer_tags.symmetric
+
             rate_parts: list[pl.DataFrame] = []
             for coverage_rate in coverage_rates:
+                # Checked once per (step, rate), before any path computes a
+                # quantile, so it covers the static, weighted and adapted paths
+                # alike rather than being repeated in each.
+                warn_if_calibration_too_small(conformity_scores_step.height, coverage_rate, step_symmetric, step)
+
                 adapter_active = hasattr(self, "adapters_") and coverage_rate in tracked_rates
                 # Empty unless the adapter is active, in which case it carries one
                 # effective level per value column.
@@ -1454,7 +1468,9 @@ class SplitConformalForecaster(BaseIntervalForecaster):
                             step=step,
                         )
                 elif adapter_active:
-                    uniform_weights = np.ones(conformity_scores_step.height, dtype=np.float64)
+                    n_calib = conformity_scores_step.height
+                    # Reserved-mass uniform weights; see _adapter_step_errors.
+                    uniform_weights = np.full(n_calib, 1.0 / (n_calib + 1), dtype=np.float64)
                     y_pred_interval_rate_step = self._adapter_inverse_score(
                         y_pred_step=y_pred_step,
                         conformity_scores_step=conformity_scores_step,

--- a/src/yohou/interval/split_conformal.py
+++ b/src/yohou/interval/split_conformal.py
@@ -18,7 +18,7 @@ from yohou.utils import POINT_INTERVAL, Tags, validate_forecaster_data
 from yohou.utils._compat import Interval, _fit_context
 
 from .base import BaseConformalAdapter, BaseIntervalForecaster, BaseSimilarity
-from .utils import weighted_quantile
+from .utils import warn_if_weights_collapsed, weighted_quantile
 
 __all__ = ["SplitConformalForecaster"]
 
@@ -322,12 +322,17 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             scorer_tags = self.conformity_scorer.__sklearn_tags__()
             assert scorer_tags.scorer_tags is not None
             self._adapter_symmetric_ = scorer_tags.scorer_tags.symmetric
+            # One clone per (step, value column). The level modulates a quantile
+            # that is already per column, so a level shared across columns would
+            # let one entity's misses widen every other entity's interval.
+            adapter_columns = [c for c in conformity_scores.columns if c not in ("time", "step")]
             self.adapters_ = {}
             for step in range(1, 1 + forecasting_horizon):
                 key = f"step_{step}"
-                self.adapters_[key] = clone(self.adapter).fit(
-                    self.fit_coverage_rates_, symmetric=self._adapter_symmetric_
-                )
+                self.adapters_[key] = {
+                    column: clone(self.adapter).fit(self.fit_coverage_rates_, symmetric=self._adapter_symmetric_)
+                    for column in adapter_columns
+                }
 
         return self
 
@@ -535,8 +540,8 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         coverage_rates: list[float],
         symmetric: bool,
         n_rows: int,
-    ) -> list[dict[float, object]]:
-        """Build one per-row miscoverage dict per observed row for a step.
+    ) -> list[dict[str, dict[float, object]]]:
+        """Build one per-row, per-column miscoverage dict for a step.
 
         Rows this step could not score (its prediction reached past the
         observed truth) receive a zero-update sentinel so every step advances
@@ -564,14 +569,14 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         Returns
         -------
         list of dict
-            Length ``n_rows``; each dict maps a coverage rate to its
-            miscoverage signal.
+            Length ``n_rows``; each entry maps a value column to a dict from
+            coverage rate to that column's own miscoverage signal.
 
         """
         value_cols = [c for c in calib.columns if c != "time"]
         calib_cols = {c: calib[c].to_numpy().astype(np.float64) for c in value_cols}
         n_calib = calib.height
-        levels = self.adapters_[step_key].predict()
+        levels = {column: adapter.predict() for column, adapter in self.adapters_[step_key].items()}
 
         def sentinel(coverage_rate: float) -> object:
             """Return the zero-update error for a row this step could not score."""
@@ -579,7 +584,9 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             return alpha_target if symmetric else (alpha_target / 2.0, alpha_target / 2.0)
 
         # Default every row to the zero-update sentinel, then fill scored rows.
-        errors: list[dict[float, object]] = [{cr: sentinel(cr) for cr in coverage_rates} for _ in range(n_rows)]
+        errors: list[dict[str, dict[float, object]]] = [
+            {c: {cr: sentinel(cr) for cr in coverage_rates} for c in value_cols} for _ in range(n_rows)
+        ]
 
         if scores_new.height == 0:
             return errors
@@ -598,41 +605,48 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             i = row_index[t]
             weights = weight_matrix[j]
             for coverage_rate in coverage_rates:
-                level = levels[coverage_rate]
-                if symmetric:
-                    misses = []
-                    for c in value_cols:
+                # Each column is judged against its own level and its own
+                # threshold, and reports its own binary outcome. Averaging the
+                # outcomes across columns, as this once did, fed a fraction into
+                # a recursion the spec defines with an indicator, and coupled
+                # every entity's level to every other entity's misses.
+                for c in value_cols:
+                    level = levels[c][coverage_rate]
+                    score = scored_values[c][j]
+                    if symmetric:
                         q = float(self._adapter_thresholds(calib_cols[c], weights, level, True))  # ty: ignore[invalid-argument-type]
-                        misses.append(1.0 if scored_values[c][j] > q else 0.0)
-                    errors[i][coverage_rate] = float(np.mean(misses))
-                else:
-                    lower_misses, upper_misses = [], []
-                    for c in value_cols:
+                        errors[i][c][coverage_rate] = 1.0 if score > q else 0.0
+                    else:
                         lower_q, upper_q = self._adapter_thresholds(calib_cols[c], weights, level, False)  # ty: ignore[not-iterable]
-                        s = scored_values[c][j]
-                        lower_misses.append(1.0 if s < lower_q else 0.0)
-                        upper_misses.append(1.0 if s > upper_q else 0.0)
-                    errors[i][coverage_rate] = (float(np.mean(lower_misses)), float(np.mean(upper_misses)))
+                        errors[i][c][coverage_rate] = (
+                            1.0 if score < lower_q else 0.0,
+                            1.0 if score > upper_q else 0.0,
+                        )
 
         return errors
 
     @staticmethod
     def _pool_adapter_errors(
-        per_step_errors: dict[str, list[dict[float, object]]],
+        per_step_errors: dict[str, list[dict[str, dict[float, object]]]],
         coverage_rates: list[float],
         symmetric: bool,
         n_rows: int,
-    ) -> list[dict[float, object]]:
+    ) -> list[dict[str, dict[float, object]]]:
         """Average per-step miscoverage into one shared per-row trajectory.
 
         Used for ``alpha_pooling="shared"``: a single pooled update is fed to
         every step's adapter, so the per-step dict alone (which cannot see
         across steps) still yields one shared level.
 
+        Pooling runs along the horizon-step axis only. Each value column is
+        pooled with itself across steps and never with another column, so two
+        columns' levels stay free to diverge under ``"shared"``.
+
         Parameters
         ----------
         per_step_errors : dict
-            Maps each ``"step_k"`` key to its length-``n_rows`` error list.
+            Maps each ``"step_k"`` key to its length-``n_rows`` error list,
+            each entry keyed by value column then coverage rate.
         coverage_rates : list of float
             Tracked coverage rates.
         symmetric : bool
@@ -643,20 +657,26 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         Returns
         -------
         list of dict
-            Length ``n_rows`` pooled error list.
+            Length ``n_rows`` pooled error list, still keyed by value column.
 
         """
         keys = list(per_step_errors)
-        pooled: list[dict[float, object]] = []
+        columns = list(per_step_errors[keys[0]][0]) if keys and n_rows else []
+        pooled: list[dict[str, dict[float, object]]] = []
         for i in range(n_rows):
-            row: dict[float, object] = {}
-            for coverage_rate in coverage_rates:
-                if symmetric:
-                    row[coverage_rate] = float(np.mean([per_step_errors[k][i][coverage_rate] for k in keys]))
-                else:
-                    lowers = [per_step_errors[k][i][coverage_rate][0] for k in keys]  # ty: ignore[not-subscriptable]
-                    uppers = [per_step_errors[k][i][coverage_rate][1] for k in keys]  # ty: ignore[not-subscriptable]
-                    row[coverage_rate] = (float(np.mean(lowers)), float(np.mean(uppers)))
+            row: dict[str, dict[float, object]] = {}
+            for column in columns:
+                column_row: dict[float, object] = {}
+                for coverage_rate in coverage_rates:
+                    if symmetric:
+                        column_row[coverage_rate] = float(
+                            np.mean([per_step_errors[k][i][column][coverage_rate] for k in keys])
+                        )
+                    else:
+                        lowers = [per_step_errors[k][i][column][coverage_rate][0] for k in keys]  # ty: ignore[not-subscriptable]
+                        uppers = [per_step_errors[k][i][column][coverage_rate][1] for k in keys]  # ty: ignore[not-subscriptable]
+                        column_row[coverage_rate] = (float(np.mean(lowers)), float(np.mean(uppers)))
+                row[column] = column_row
             pooled.append(row)
         return pooled
 
@@ -684,7 +704,7 @@ class SplitConformalForecaster(BaseIntervalForecaster):
 
         y_pred = self.point_forecaster_.predict(forecasting_horizon=fh)
 
-        per_step_errors: dict[str, list[dict[float, object]]] = {}
+        per_step_errors: dict[str, list[dict[str, dict[float, object]]]] = {}
         for step in range(1, 1 + fh):
             key = f"step_{step}"
             scorer = self.conformity_scorers_[key]
@@ -705,10 +725,12 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         if getattr(self.adapter, "alpha_pooling", "per_step") == "shared":
             pooled = self._pool_adapter_errors(per_step_errors, coverage_rates, symmetric, n_rows)
             for key in per_step_errors:
-                self.adapters_[key].observe(pooled)
+                for column, adapter in self.adapters_[key].items():
+                    adapter.observe([row[column] for row in pooled])
         else:
             for key, errors in per_step_errors.items():
-                self.adapters_[key].observe(errors)
+                for column, adapter in self.adapters_[key].items():
+                    adapter.observe([row[column] for row in errors])
 
     def _rewind_adapter(self, y: pl.DataFrame) -> None:
         """Roll each per-step adapter back by ``len(y)`` observations.
@@ -723,8 +745,11 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             return
 
         n_rewind = len(y)
-        for adapter in self.adapters_.values():
-            adapter.rewind(n_rewind)
+        # Every clone advanced by the same row count, so every clone rolls back
+        # by it too, keeping the per-column histories aligned.
+        for step_adapters in self.adapters_.values():
+            for adapter in step_adapters.values():
+                adapter.rewind(n_rewind)
 
     def observe(
         self,
@@ -1138,6 +1163,7 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         coverage_rate: float,
         weights: np.ndarray,
         conformity_scorer_step: BaseConformityScorer,
+        step: int = 1,
     ) -> pl.DataFrame:
         """Compute prediction intervals using similarity-weighted quantiles.
 
@@ -1166,6 +1192,11 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         value_cols = [c for c in conformity_scores_step.columns if c != "time"]
         scores_no_time = conformity_scores_step.drop("time", strict=False)
         y_pred_values = y_pred_step.drop("time")
+
+        # One weight row serves every value column, so the collapse check runs
+        # once here rather than inside the per-column loop below. Checking it
+        # per column would emit the same warning n times for one event.
+        warn_if_weights_collapsed(weights, step, coverage_rate)
 
         # Read scorer characteristics from tags instead of checking types
         tags = conformity_scorer_step.__sklearn_tags__()
@@ -1202,9 +1233,10 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         y_pred_step: pl.DataFrame,
         conformity_scores_step: pl.DataFrame,
         coverage_rate: float,
-        level: object,
+        levels: dict[str, object],
         weights: np.ndarray,
         conformity_scorer_step: BaseConformityScorer,
+        step: int = 1,
     ) -> pl.DataFrame:
         """Build an interval at the adapter's effective level.
 
@@ -1223,13 +1255,16 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             Conformity scores for this step with ``"time"``.
         coverage_rate : float
             Nominal coverage rate used only to label the output columns.
-        level : float or tuple of float
-            Effective level from the adapter: ``alpha`` for symmetric
+        levels : dict of str to (float or tuple of float)
+            Effective level per value column: ``alpha`` for symmetric
             scorers, ``(beta_lower, beta_upper)`` for asymmetric ones.
         weights : np.ndarray
             Per-calibration weights (similarity weights, or uniform).
         conformity_scorer_step : BaseConformityScorer
             Fitted conformity scorer (for tags and formatting).
+        step : int, default=1
+            Horizon step, used only to name the step in a collapsed-weight
+            warning.
 
         Returns
         -------
@@ -1241,6 +1276,9 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         value_cols = [c for c in conformity_scores_step.columns if c != "time"]
         scores_no_time = conformity_scores_step.drop("time", strict=False)
         y_pred_values = y_pred_step.drop("time")
+
+        # Once per weight row, for the same reason as in _weighted_inverse_score.
+        warn_if_weights_collapsed(weights, step, coverage_rate)
 
         tags = conformity_scorer_step.__sklearn_tags__()
         assert tags.scorer_tags is not None
@@ -1256,7 +1294,7 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             pred_val = float(y_pred_values[col][0])
             scale = (pred_val + epsilon) if multiplicative else 1.0
 
-            thresholds = self._adapter_thresholds(scores_col, weights, level, symmetric)
+            thresholds = self._adapter_thresholds(scores_col, weights, levels[col], symmetric)
             if symmetric:
                 q = float(thresholds)  # ty: ignore[invalid-argument-type]
                 lower_data[col] = [pred_val - q * scale]
@@ -1351,7 +1389,10 @@ class SplitConformalForecaster(BaseIntervalForecaster):
         # so the fallback is never silent.
         tracked_rates: set[float] = set()
         if hasattr(self, "adapters_"):
-            tracked_rates = set(self.adapters_["step_1"].predict().keys())
+            # Every clone is seeded with the same rates at fit, so any one of
+            # them answers which rates are tracked.
+            any_adapter = next(iter(self.adapters_["step_1"].values()))
+            tracked_rates = set(any_adapter.predict().keys())
             for coverage_rate in coverage_rates:
                 if coverage_rate not in tracked_rates:
                     warnings.warn(
@@ -1377,7 +1418,16 @@ class SplitConformalForecaster(BaseIntervalForecaster):
             rate_parts: list[pl.DataFrame] = []
             for coverage_rate in coverage_rates:
                 adapter_active = hasattr(self, "adapters_") and coverage_rate in tracked_rates
-                effective_level = self.adapters_[f"step_{step}"].predict()[coverage_rate] if adapter_active else None
+                # Empty unless the adapter is active, in which case it carries one
+                # effective level per value column.
+                effective_levels: dict[str, object] = (
+                    {
+                        column: adapter.predict()[coverage_rate]
+                        for column, adapter in self.adapters_[f"step_{step}"].items()
+                    }
+                    if adapter_active
+                    else {}
+                )
 
                 if self.similarity is not None and hasattr(self, "similarities_"):
                     similarity_step = self.similarities_[f"step_{step}"]
@@ -1389,9 +1439,10 @@ class SplitConformalForecaster(BaseIntervalForecaster):
                             y_pred_step=y_pred_step,
                             conformity_scores_step=conformity_scores_step,
                             coverage_rate=coverage_rate,
-                            level=effective_level,
+                            levels=effective_levels,
                             weights=step_weights,
                             conformity_scorer_step=conformity_scorer_step,
+                            step=step,
                         )
                     else:
                         y_pred_interval_rate_step = self._weighted_inverse_score(
@@ -1400,6 +1451,7 @@ class SplitConformalForecaster(BaseIntervalForecaster):
                             coverage_rate=coverage_rate,
                             weights=step_weights,
                             conformity_scorer_step=conformity_scorer_step,
+                            step=step,
                         )
                 elif adapter_active:
                     uniform_weights = np.ones(conformity_scores_step.height, dtype=np.float64)
@@ -1407,9 +1459,10 @@ class SplitConformalForecaster(BaseIntervalForecaster):
                         y_pred_step=y_pred_step,
                         conformity_scores_step=conformity_scores_step,
                         coverage_rate=coverage_rate,
-                        level=effective_level,
+                        levels=effective_levels,
                         weights=uniform_weights,
                         conformity_scorer_step=conformity_scorer_step,
+                        step=step,
                     )
                 else:
                     y_pred_interval_rate_step = conformity_scorer_step.inverse_score(

--- a/src/yohou/interval/utils.py
+++ b/src/yohou/interval/utils.py
@@ -5,14 +5,34 @@ import warnings
 import numpy as np
 import numpy.typing as npt
 
-__all__ = ["warn_if_weights_collapsed", "weighted_quantile"]
+__all__ = [
+    "required_calibration_size",
+    "warn_if_calibration_too_small",
+    "warn_if_weights_collapsed",
+    "weighted_quantile",
+]
 
 
 def weighted_quantile(x: npt.NDArray[np.float64], q: float, weights: npt.NDArray[np.float64]) -> float:
-    """Compute weighted quantile using cumulative sum approach.
+    """Compute a weighted conformal quantile.
 
-    Weights are normalized to sum to 1 internally so that all quantile
-    levels are computable regardless of the raw weight magnitude.
+    Returns the smallest value ``x[i]`` (in sorted order) whose cumulative
+    weight reaches ``1 - q``.
+
+    The weights are used as given and are **not** renormalized. Callers pass
+    weights that already reserve mass for the hypothetical test point, so each
+    row sums to strictly less than 1: uniform weights are ``1 / (n + 1)`` each
+    and similarity weights come from
+    [`BaseSimilarity._reserve_mass`][yohou.interval.base.BaseSimilarity].
+    That reserved remainder is the weighted analogue of the ``(n + 1)``
+    correction in unweighted split conformal, and it is what makes coverage at
+    least ``1 - q``. Renormalizing to sum to 1, as this function used to do,
+    cancels the reservation and costs exactly one order statistic.
+
+    When the calibration mass never reaches ``1 - q`` the correct bound is
+    unbounded. The largest observed score is returned instead, which
+    under-covers; callers detect that case up front with
+    :func:`warn_if_calibration_too_small` and warn.
 
     Parameters
     ----------
@@ -20,13 +40,12 @@ def weighted_quantile(x: npt.NDArray[np.float64], q: float, weights: npt.NDArray
         Input array of values.
 
     q : float
-        Quantile level to compute (between 0 and 1).  The function
-        returns the smallest value ``x[i]`` (in sorted order) such that
-        the cumulative normalized weight up to ``x[i]`` is at least
+        Miscoverage level (between 0 and 1). The cumulative weight target is
         ``1 - q``.
 
     weights : np.ndarray
-        Weights for each value in x (must match length of x).
+        Weights for each value in x (must match length of x), already
+        carrying reserved test-point mass.
 
     Returns
     -------
@@ -38,27 +57,121 @@ def weighted_quantile(x: npt.NDArray[np.float64], q: float, weights: npt.NDArray
     ValueError
         If ``x`` and ``weights`` have different lengths, or if the weights
         sum to zero (no calibration mass), which would otherwise yield an
-        undefined (infinite) quantile that silently corrupts interval bounds.
+        undefined quantile that silently corrupts interval bounds.
 
     """
     if len(x) != len(weights):
         raise ValueError(f"x and weights must have the same length, got {len(x)} and {len(weights)}")
 
-    w_sum = np.sum(weights)
-    if w_sum == 0:
+    if np.sum(weights) == 0:
         raise ValueError(
             "weighted_quantile received weights that sum to zero; cannot compute a "
             "weighted quantile. This usually means all similarity weights collapsed "
             "to zero for the current prediction context."
         )
 
-    # Normalize so the weighted CDF reaches 1, making all quantile levels computable
-    w_norm = weights / w_sum
     # Sort scores ascending and reorder weights to match
     x_ordered = np.argsort(x)
-    # Walk up the sorted scores until cumulative weight reaches the (1-q)-th level
-    index_threshold = np.min(np.where(np.cumsum(w_norm[x_ordered]) >= 1 - q))
-    return float(np.sort(x)[index_threshold])
+    x_sorted = x[x_ordered]
+    # Walk up the sorted scores until cumulative weight reaches the (1-q)-th level.
+    reached = np.where(np.cumsum(weights[x_ordered]) >= 1 - q)[0]
+    if reached.size == 0:
+        # Not enough calibration mass to reach the level: the conformal bound is
+        # unbounded. Return the widest finite bound available.
+        return float(x_sorted[-1])
+    return float(x_sorted[int(reached[0])])
+
+
+def required_calibration_size(coverage_rate: float, symmetric: bool) -> int:
+    """Smallest calibration count that can express a coverage rate.
+
+    Split conformal takes the ``ceil((n + 1) * q)``-th order statistic of the
+    calibration scores, which is what makes coverage at least ``q``. That index
+    exists only while ``ceil((n + 1) * q) <= n``, which rearranges to
+    ``n >= q / (1 - q)``. Above that rate the correct bound is unbounded, and
+    any finite value the implementation returns instead under-covers.
+
+    Asymmetric scorers split the miscoverage across two tails, so the binding
+    level is ``q = 1 - alpha / 2`` rather than the coverage rate itself, and
+    they need roughly twice as many scores for the same rate.
+
+    Parameters
+    ----------
+    coverage_rate : float
+        Nominal coverage rate.
+    symmetric : bool
+        Whether the conformity scorer is symmetric. Asymmetric scorers split
+        the miscoverage across two tails, so each tail sits further out and
+        needs roughly twice as many scores.
+
+    Returns
+    -------
+    int
+        Minimum number of calibration scores per value column. Returns ``0``
+        when the rate imposes no constraint.
+
+    """
+    if coverage_rate >= 1.0:
+        return 0
+
+    tail_level = coverage_rate if symmetric else 1.0 - (1.0 - coverage_rate) / 2.0
+    if tail_level >= 1.0:
+        return 0
+
+    # q / (1 - q) is the closed form, but it is not safe to ceil directly:
+    # 0.9 / (1 - 0.9) evaluates to 9.000000000000002, which would demand 10
+    # scores where 9 suffices. Start just below the closed form and step up
+    # until the conformal index actually fits, which is exact by construction.
+    candidate = max(int(np.floor(tail_level / (1.0 - tail_level))) - 1, 1)
+    while int(np.ceil((candidate + 1) * tail_level)) > candidate:
+        candidate += 1
+    return candidate
+
+
+def warn_if_calibration_too_small(n_scores: int, coverage_rate: float, symmetric: bool, step: int) -> bool:
+    """Warn when the calibration set cannot express the requested coverage.
+
+    Below the required count the interval is narrower than the nominal rate
+    implies: an asymmetric scorer clamps at the span of the observed scores and
+    stops widening, a symmetric one selects too low an order statistic. Either
+    way the frame is well-formed and the columns are labelled with the rate that
+    was asked for, which is what makes this worth saying out loud.
+
+    Parameters
+    ----------
+    n_scores : int
+        Calibration scores available per value column for this step.
+    coverage_rate : float
+        Nominal coverage rate being computed.
+    symmetric : bool
+        Whether the conformity scorer is symmetric.
+    step : int
+        Horizon step, named in the warning.
+
+    Returns
+    -------
+    bool
+        Whether a warning was emitted.
+
+    Warns
+    -----
+    UserWarning
+        When ``n_scores`` is below the count the rate requires.
+
+    """
+    required = required_calibration_size(coverage_rate, symmetric)
+    if n_scores >= required:
+        return False
+
+    warnings.warn(
+        f"Coverage rate {coverage_rate} at step {step} needs at least {required} calibration scores per "
+        f"value column, but only {n_scores} are available. The interval is capped at the span of the "
+        "observed conformity scores, so it is narrower than the nominal rate implies and will under-cover. "
+        "Increase calibration_size, extend the history, or request a lower coverage rate.",
+        UserWarning,
+        stacklevel=3,
+    )
+    return True
 
 
 def warn_if_weights_collapsed(weights: npt.NDArray[np.float64], step: int, coverage_rate: float) -> float:

--- a/src/yohou/interval/utils.py
+++ b/src/yohou/interval/utils.py
@@ -1,9 +1,11 @@
 """Utility functions for weighted quantile calculations."""
 
+import warnings
+
 import numpy as np
 import numpy.typing as npt
 
-__all__ = ["weighted_quantile"]
+__all__ = ["warn_if_weights_collapsed", "weighted_quantile"]
 
 
 def weighted_quantile(x: npt.NDArray[np.float64], q: float, weights: npt.NDArray[np.float64]) -> float:
@@ -57,3 +59,52 @@ def weighted_quantile(x: npt.NDArray[np.float64], q: float, weights: npt.NDArray
     # Walk up the sorted scores until cumulative weight reaches the (1-q)-th level
     index_threshold = np.min(np.where(np.cumsum(w_norm[x_ordered]) >= 1 - q))
     return float(np.sort(x)[index_threshold])
+
+
+def warn_if_weights_collapsed(weights: npt.NDArray[np.float64], step: int, coverage_rate: float) -> float:
+    """Warn when a weight row carries almost no calibration mass.
+
+    A weight vector concentrated on one calibration row makes the weighted
+    quantile a function of a single score, so both tails return that score and
+    the interval collapses to zero width at a nominal coverage rate. That is
+    never intentional, and it is silent otherwise: the emitted interval is
+    well-formed, just meaningless. Guarding on the weights rather than on the
+    emitted width avoids firing on the legitimate case of constant residuals,
+    where a zero-width interval is the correct answer.
+
+    Parameters
+    ----------
+    weights : np.ndarray
+        Weight row of shape ``(n_calibration,)``.
+    step : int
+        Horizon step the weights belong to, named in the warning.
+    coverage_rate : float
+        Nominal coverage rate being computed, named in the warning.
+
+    Returns
+    -------
+    float
+        The effective sample size ``(sum w)^2 / sum(w^2)``, or ``0.0`` when
+        the weights carry no mass at all.
+
+    Warns
+    -----
+    UserWarning
+        When the effective sample size falls below 2.
+
+    """
+    total = float(np.sum(weights))
+    sum_of_squares = float(np.sum(np.square(weights)))
+    effective_sample_size = (total**2) / sum_of_squares if sum_of_squares > 0 else 0.0
+
+    if effective_sample_size < 2.0:
+        warnings.warn(
+            f"Similarity weights for step {step} at coverage rate {coverage_rate} have collapsed to "
+            f"{effective_sample_size:.2f} effective calibration rows out of {len(weights)}. The interval "
+            "is being read off almost a single conformity score and may be degenerate. This usually means "
+            "the similarity is over-concentrating; raise its `bandwidth` to widen the neighbourhood.",
+            UserWarning,
+            stacklevel=3,
+        )
+
+    return effective_sample_size

--- a/src/yohou/metrics/conformity.py
+++ b/src/yohou/metrics/conformity.py
@@ -140,9 +140,15 @@ class Residual(BaseConformityScorer):
             self, y_true=None, y_pred=y_pred, scores=conformity_scores, inverse=True
         )
 
-        # Compute intervals
-        lower_quantile, upper_quantile = self._compute_asymmetric_quantiles(conformity_scores, coverage_rate)
-        lower_bound, upper_bound = y_pred + lower_quantile, y_pred + upper_quantile
+        # Compute intervals. The quantiles arrive one per value column, in the
+        # score frame's column order, which matches y_pred's positionally.
+        lower_quantiles, upper_quantiles = self._compute_asymmetric_quantiles(conformity_scores, coverage_rate)
+        lower_bound = y_pred.with_columns([
+            pl.col(col) + q for col, q in zip(y_pred.columns, lower_quantiles, strict=True)
+        ])
+        upper_bound = y_pred.with_columns([
+            pl.col(col) + q for col, q in zip(y_pred.columns, upper_quantiles, strict=True)
+        ])
 
         y_pred_interval = self._format_y_pred_interval(lower_bound, upper_bound, coverage_rate)
 
@@ -275,9 +281,10 @@ class AbsoluteResidual(Residual):
             self, y_true=None, y_pred=y_pred, scores=conformity_scores, inverse=True
         )
 
-        # Compute symmetric intervals
-        quantile = self._compute_symmetric_quantiles(conformity_scores, coverage_rate)
-        lower_bound, upper_bound = y_pred - quantile, y_pred + quantile
+        # Compute symmetric intervals, one half-width per value column
+        quantiles = self._compute_symmetric_quantiles(conformity_scores, coverage_rate)
+        lower_bound = y_pred.with_columns([pl.col(col) - q for col, q in zip(y_pred.columns, quantiles, strict=True)])
+        upper_bound = y_pred.with_columns([pl.col(col) + q for col, q in zip(y_pred.columns, quantiles, strict=True)])
 
         y_pred_interval = self._format_y_pred_interval(lower_bound, upper_bound, coverage_rate)
 
@@ -414,16 +421,19 @@ class GammaResidual(BaseConformityScorer):
             self, y_true=None, y_pred=y_pred, scores=conformity_scores, inverse=True
         )
 
-        # Compute quantiles
-        lower_q, upper_q = self._compute_asymmetric_quantiles(conformity_scores, coverage_rate)
+        # Compute quantiles, one pair per value column
+        lower_quantiles, upper_quantiles = self._compute_asymmetric_quantiles(conformity_scores, coverage_rate)
 
-        # Determine explicit float types for Polars
-        lower_q, upper_q = float(lower_q), float(upper_q)
-
-        # Reconstruct y
-        denom = y_pred + self.epsilon
-        lower_bound = y_pred + lower_q * denom
-        upper_bound = y_pred + upper_q * denom
+        # Reconstruct y. The score is relative to the prediction, so each
+        # column's quantile is scaled by that column's own denominator.
+        lower_bound = y_pred.with_columns([
+            pl.col(col) + float(q) * (pl.col(col) + self.epsilon)
+            for col, q in zip(y_pred.columns, lower_quantiles, strict=True)
+        ])
+        upper_bound = y_pred.with_columns([
+            pl.col(col) + float(q) * (pl.col(col) + self.epsilon)
+            for col, q in zip(y_pred.columns, upper_quantiles, strict=True)
+        ])
 
         y_pred_interval = self._format_y_pred_interval(lower_bound, upper_bound, coverage_rate)
 

--- a/src/yohou/metrics/conformity_base.py
+++ b/src/yohou/metrics/conformity_base.py
@@ -110,9 +110,24 @@ class BaseConformityScorer(BaseScorer, metaclass=abc.ABCMeta):
             medians = np.quantile(scores_array, 0.5, axis=0, method="lower")
             return list(np.atleast_1d(medians)), list(np.atleast_1d(medians))
 
-        lower_quantiles = np.quantile(scores_array, alpha / 2.0, axis=0, method="lower")
+        # Split conformal takes the ceil((n+1) * q)-th order statistic, not the
+        # plain empirical quantile. The (n+1) accounts for the test point being
+        # exchangeable with the calibration scores, and is what makes coverage
+        # at least the nominal rate. Without it the bound is one order statistic
+        # short and under-covers by construction, at every sample size.
+        n = scores_array.shape[0]
+        ordered = np.sort(scores_array, axis=0)
 
-        upper_quantiles = np.quantile(scores_array, 1.0 - alpha / 2.0, axis=0, method="higher")
+        upper_index = int(np.ceil((n + 1) * (1.0 - alpha / 2.0)))
+        lower_index = int(np.floor((n + 1) * (alpha / 2.0)))
+
+        # Beyond the resolvable range the true bound is unbounded; the widest
+        # observed score is the closest finite stand-in. Callers warn.
+        upper_index = min(max(upper_index, 1), n)
+        lower_index = min(max(lower_index, 1), n)
+
+        upper_quantiles = ordered[upper_index - 1]
+        lower_quantiles = ordered[lower_index - 1]
 
         return list(np.atleast_1d(lower_quantiles)), list(np.atleast_1d(upper_quantiles))
 
@@ -153,7 +168,12 @@ class BaseConformityScorer(BaseScorer, metaclass=abc.ABCMeta):
                 "Increase calibration_size or reduce forecasting_horizon."
             )
 
-        quantiles = np.quantile(conformity_array, coverage_rate, axis=0, method="lower")
+        # Same (n+1) conformal correction as the asymmetric variant, applied to
+        # the single half-width instead of two tails.
+        n = conformity_array.shape[0]
+        ordered = np.sort(conformity_array, axis=0)
+        index = min(max(int(np.ceil((n + 1) * coverage_rate)), 1), n)
+        quantiles = ordered[index - 1]
 
         return list(np.atleast_1d(quantiles))
 

--- a/src/yohou/metrics/conformity_base.py
+++ b/src/yohou/metrics/conformity_base.py
@@ -49,26 +49,35 @@ class BaseConformityScorer(BaseScorer, metaclass=abc.ABCMeta):
         return super().fit(y_train, forecaster=forecaster, **params)
 
     @staticmethod
-    def _compute_asymmetric_quantiles(conformity_scores: pl.DataFrame, coverage_rate: float) -> tuple[float, float]:
-        """Compute lower and upper quantiles for asymmetric intervals.
+    def _compute_asymmetric_quantiles(
+        conformity_scores: pl.DataFrame, coverage_rate: float
+    ) -> tuple[list[float], list[float]]:
+        """Compute lower and upper quantiles per value column.
+
+        One quantile pair is derived per column, from that column's scores
+        alone. Reducing the whole frame to a single pair gave every column the
+        same interval width, which over-covers low-magnitude columns and
+        under-covers high-magnitude ones.
 
         Parameters
         ----------
         conformity_scores : pl.DataFrame
-            Conformity scores from calibration.
+            Conformity scores from calibration, one column per value column.
 
         coverage_rate : float
             Target coverage rate.
 
         Returns
         -------
-        lower_quantile : float
-            Lower quantile value. When ``coverage_rate == 0`` this is the
-            median (quantile 0.5) of the scores.
+        lower_quantiles : list of float
+            Lower quantile per column, in column order. When
+            ``coverage_rate == 0`` each is the median (quantile 0.5) of that
+            column's scores.
 
-        upper_quantile : float
-            Upper quantile value. When ``coverage_rate == 0`` this is the
-            median (quantile 0.5) of the scores.
+        upper_quantiles : list of float
+            Upper quantile per column, in column order. When
+            ``coverage_rate == 0`` each is the median (quantile 0.5) of that
+            column's scores.
 
         Raises
         ------
@@ -95,32 +104,37 @@ class BaseConformityScorer(BaseScorer, metaclass=abc.ABCMeta):
 
         alpha = 1.0 - coverage_rate
 
+        # axis=0 reduces down each column, so a frame of n columns yields n
+        # quantiles rather than one over the flattened array.
         if coverage_rate == 0:
-            median_val: float = np.quantile(scores_array, 0.5, method="lower")
-            return median_val, median_val
+            medians = np.quantile(scores_array, 0.5, axis=0, method="lower")
+            return list(np.atleast_1d(medians)), list(np.atleast_1d(medians))
 
-        lower_quantile: float = np.quantile(scores_array, alpha / 2.0, method="lower")
+        lower_quantiles = np.quantile(scores_array, alpha / 2.0, axis=0, method="lower")
 
-        upper_quantile: float = np.quantile(scores_array, 1.0 - alpha / 2.0, method="higher")
+        upper_quantiles = np.quantile(scores_array, 1.0 - alpha / 2.0, axis=0, method="higher")
 
-        return lower_quantile, upper_quantile
+        return list(np.atleast_1d(lower_quantiles)), list(np.atleast_1d(upper_quantiles))
 
     @staticmethod
-    def _compute_symmetric_quantiles(conformity_scores: pl.DataFrame, coverage_rate: float) -> float:
-        """Compute quantile for symmetric intervals.
+    def _compute_symmetric_quantiles(conformity_scores: pl.DataFrame, coverage_rate: float) -> list[float]:
+        """Compute the symmetric half-width quantile per value column.
+
+        As with the asymmetric variant, the reduction runs down each column so
+        a column's interval is calibrated from its own scores alone.
 
         Parameters
         ----------
         conformity_scores : pl.DataFrame
-            Conformity scores from calibration.
+            Conformity scores from calibration, one column per value column.
 
         coverage_rate : float
             Target coverage rate.
 
         Returns
         -------
-        float
-            Quantile value for symmetric intervals.
+        list of float
+            Quantile per column, in column order.
 
         Raises
         ------
@@ -139,9 +153,9 @@ class BaseConformityScorer(BaseScorer, metaclass=abc.ABCMeta):
                 "Increase calibration_size or reduce forecasting_horizon."
             )
 
-        quantile: float = np.quantile(conformity_array, coverage_rate, method="lower")
+        quantiles = np.quantile(conformity_array, coverage_rate, axis=0, method="lower")
 
-        return quantile
+        return list(np.atleast_1d(quantiles))
 
     @staticmethod
     def _format_y_pred_interval(

--- a/src/yohou/testing/__init__.py
+++ b/src/yohou/testing/__init__.py
@@ -132,6 +132,7 @@ from .interval import (
     check_interval_bounds,
     check_interval_prediction_columns,
     check_interval_prediction_types,
+    check_per_column_calibration_independence,
 )
 from .metadata_routing import (
     assert_request_equal,
@@ -300,6 +301,7 @@ __all__ = [
     "check_interval_bounds",
     "check_interval_prediction_columns",
     "check_interval_prediction_types",
+    "check_per_column_calibration_independence",
     "check_estimator_parameter",
     "check_reduction_strategy",
     "check_panel_data",

--- a/src/yohou/testing/generators.py
+++ b/src/yohou/testing/generators.py
@@ -69,6 +69,7 @@ from .interval import (
     check_interval_bounds,
     check_interval_prediction_columns,
     check_interval_prediction_types,
+    check_per_column_calibration_independence,
 )
 from .panel import (
     check_panel_data,
@@ -638,6 +639,15 @@ def _yield_yohou_forecaster_checks(
             check_coverage_rates_validation,
             {"y": y_train, "X_actual": X_actual_train, "X_future": X_future_train, "X_forecast": X_forecast_train},
         )
+        # Gated on conformity-score calibration: the invariant is about which
+        # scores a column's quantile comes from, so a forecaster that predicts
+        # its bounds directly (quantile regression) has nothing to check.
+        if hasattr(forecaster, "conformity_scorer"):
+            yield (
+                "check_per_column_calibration_independence",
+                check_per_column_calibration_independence,
+                {"y_train": y_train},
+            )
 
     # Class-probability forecaster checks
     if forecaster_type is not None and "class_proba" in forecaster_type:

--- a/src/yohou/testing/interval.py
+++ b/src/yohou/testing/interval.py
@@ -4,6 +4,8 @@ This module provides validation functions specific to interval forecasters
 (BaseIntervalForecaster implementations).
 """
 
+import math
+
 import polars as pl
 from sklearn.base import clone
 
@@ -15,6 +17,7 @@ __all__ = [
     "check_interval_bounds",
     "check_interval_prediction_columns",
     "check_interval_prediction_types",
+    "check_per_column_calibration_independence",
 ]
 
 
@@ -229,3 +232,79 @@ def check_coverage_rates_validation(
         )
     except ValueError as e:
         assert "coverage" in str(e).lower(), f"ValueError should mention coverage_rates, got: {e}"
+
+
+def check_per_column_calibration_independence(forecaster, y_train: pl.DataFrame) -> None:
+    """Check each value column's interval is calibrated from that column alone.
+
+    Multiplies one value column by a constant and asserts two things: that
+    column's interval width scales with it, and every other column's width does
+    not move. A forecaster that reduces a multi-column conformity frame to one
+    shared quantile fails both halves, which is the defect this check exists to
+    catch: before it, a frame holding a scale-1 and a scale-100 column gave both
+    the same width, over-covering the small column and under-covering the large.
+
+    The check builds its own inner point forecaster rather than reusing the one
+    under test. The independence half is only well defined when the point model
+    does not pool rows across columns: a shared global model legitimately moves
+    every column's prediction when one column's data changes, so the width shift
+    would not be attributable to the calibration axis.
+
+    Parameters
+    ----------
+    forecaster : BaseIntervalForecaster
+        Forecaster under test. Used for its class and constructor parameters;
+        a fresh clone is fitted here.
+    y_train : pl.DataFrame
+        Training data. Ignored except for its time column, since the check
+        generates its own two-column frame with a known scale relationship.
+
+    Raises
+    ------
+    AssertionError
+        If the scaled column's width does not track its data, or if another
+        column's width moves in response.
+
+    """
+    from yohou.point import SeasonalNaive
+
+    times = y_train["time"]
+    if len(times) < 60:
+        return
+
+    seasonality = 7
+    base = [10.0 + 5.0 * ((i % seasonality) - 3) / 3.0 for i in range(len(times))]
+    jitter = [0.4 * (((i * 37) % 11) / 11.0 - 0.5) for i in range(len(times))]
+    quiet = [b + j for b, j in zip(base, jitter, strict=True)]
+
+    factor = 100.0
+    frame = pl.DataFrame({"time": times, "a__value": quiet, "b__value": quiet})
+    scaled = frame.with_columns(pl.col("b__value") * factor)
+
+    def widths(y: pl.DataFrame) -> dict[str, float]:
+        """Fit a fresh clone on ``y`` and return its interval width per column."""
+        candidate = clone(forecaster)
+        candidate.set_params(point_forecaster=SeasonalNaive(seasonality=seasonality))
+        calibration_size = min(50, len(times) // 3)
+        candidate.set_params(calibration_size=calibration_size)
+        candidate.fit(y, forecasting_horizon=1, coverage_rates=[0.9])
+        intervals = candidate.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])
+        return {
+            column: float(intervals[f"{column}_upper_0.9"][0] - intervals[f"{column}_lower_0.9"][0])
+            for column in ("a__value", "b__value")
+        }
+
+    before, after = widths(frame), widths(scaled)
+
+    if before["b__value"] <= 0.0:
+        return
+
+    observed_factor = after["b__value"] / before["b__value"]
+    assert 0.5 * factor < observed_factor < 2.0 * factor, (
+        f"scaling column 'b__value' by {factor} changed its interval width by {observed_factor:.2f}x. "
+        "A column's width must be calibrated from that column's own conformity scores."
+    )
+    assert math.isclose(after["a__value"], before["a__value"], rel_tol=1e-9), (
+        f"scaling column 'b__value' moved column 'a__value' width from {before['a__value']} to "
+        f"{after['a__value']}. Calibration must not be pooled across value columns."
+    )

--- a/tests/interval/test_adapter.py
+++ b/tests/interval/test_adapter.py
@@ -37,6 +37,15 @@ def _fit(adapter=None, scorer=None, similarity=None, horizon=3, calib=50):
     return forecaster, y
 
 
+def _level(forecaster, step: int = 1, column: str = "value"):
+    """Effective level for one (step, value column) pair.
+
+    Adapter clones are keyed by step and then by value column, so a univariate
+    fixture reaches its only adapter through the sole column name.
+    """
+    return forecaster.adapters_[f"step_{step}"][column].predict()
+
+
 def _width(intervals: pl.DataFrame, rate: float = 0.9) -> list[float]:
     """Interval widths for the given coverage rate."""
     return (intervals[f"value_upper_{rate}"] - intervals[f"value_lower_{rate}"]).to_list()
@@ -138,11 +147,11 @@ class TestAdapterInForecaster:
     def test_observe_adapts_then_rewind_restores(self):
         forecaster, y = _fit(adapter=AdaptiveConformalInference(step_size=0.1))
         new = y[180:188]
-        before = forecaster.adapters_["step_1"].predict()
+        before = _level(forecaster)
         forecaster.observe(new)
-        assert forecaster.adapters_["step_1"].predict() != before
+        assert _level(forecaster) != before
         forecaster.rewind(new)
-        assert forecaster.adapters_["step_1"].predict() == before
+        assert _level(forecaster) == before
 
     def test_untracked_rate_warns_and_falls_back(self):
         forecaster, _ = _fit(adapter=AdaptiveConformalInference())
@@ -160,12 +169,12 @@ class TestAdapterInForecaster:
 
     def test_symmetric_scorer_single_level(self):
         forecaster, y = _fit(adapter=AdaptiveConformalInference(), scorer=AbsoluteResidual())
-        level = forecaster.adapters_["step_1"].predict()[0.9]
+        level = _level(forecaster)[0.9]
         assert isinstance(level, float)
 
     def test_asymmetric_scorer_two_tails(self):
         forecaster, y = _fit(adapter=AdaptiveConformalInference(), scorer=Residual())
-        level = forecaster.adapters_["step_1"].predict()[0.9]
+        level = _level(forecaster)[0.9]
         assert isinstance(level, tuple) and len(level) == 2
 
     def test_composes_with_similarity(self):
@@ -178,7 +187,7 @@ class TestAdapterInForecaster:
         forecaster.observe(y[180:188])
         intervals = forecaster.predict_interval()
         assert len(intervals) == 3
-        assert forecaster.adapters_["step_1"].predict()[0.9] != 0.1
+        assert _level(forecaster)[0.9] != 0.1
 
     def test_shared_pooling_ties_steps_together(self):
         forecaster, y = _fit(
@@ -186,7 +195,7 @@ class TestAdapterInForecaster:
             scorer=AbsoluteResidual(),
         )
         forecaster.observe(y[180:188])
-        levels = [forecaster.adapters_[f"step_{s}"].predict()[0.9] for s in (1, 2, 3)]
+        levels = [_level(forecaster, s)[0.9] for s in (1, 2, 3)]
         assert levels[0] == pytest.approx(levels[1]) == pytest.approx(levels[2])
 
     def test_shared_pooling_with_asymmetric_scorer(self):
@@ -196,7 +205,7 @@ class TestAdapterInForecaster:
             scorer=Residual(),
         )
         forecaster.observe(y[180:188])
-        levels = [forecaster.adapters_[f"step_{s}"].predict()[0.9] for s in (1, 2, 3)]
+        levels = [_level(forecaster, s)[0.9] for s in (1, 2, 3)]
         # Every step shares one (lower, upper) trajectory.
         assert all(isinstance(level, tuple) for level in levels)
         assert levels[0] == pytest.approx(levels[1])
@@ -208,7 +217,7 @@ class TestAdapterInForecaster:
             scorer=AbsoluteResidual(),
         )
         forecaster.observe(y[180:190])
-        levels = {s: forecaster.adapters_[f"step_{s}"].predict()[0.9] for s in (1, 2, 3)}
+        levels = {s: _level(forecaster, s)[0.9] for s in (1, 2, 3)}
         # Different horizons generally realize different coverage, so at least
         # one step's level should differ from another.
         assert len({round(v, 6) for v in levels.values()}) > 1
@@ -218,3 +227,103 @@ class TestAdapterInForecaster:
         out = forecaster.observe_predict_interval(y[180:190], stride=1, coverage_rates=[0.9])
         assert "value_lower_0.9" in out.columns
         assert len(out) > 0
+
+
+def _two_column_series(n: int = 200) -> pl.DataFrame:
+    """Two seasonal panel entities sharing a time index."""
+    dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+
+    def series(seed: int) -> list[float]:
+        rng = np.random.default_rng(seed)
+        return [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + rng.normal(0, 0.5) for i in range(n)]
+
+    return pl.DataFrame({"time": dates, "a__value": series(1), "b__value": series(2)})
+
+
+class TestAdapterEntityAxis:
+    """Each value column adapts from its own miscoverage.
+
+    Regression coverage for the cross-entity mean: ``_adapter_step_errors`` fed
+    ``np.mean(misses)`` over all value columns into a recursion the spec defines
+    with a binary indicator, so one chronically miscovered entity dragged every
+    other entity's level with it.
+    """
+
+    @staticmethod
+    def _fit(y: pl.DataFrame) -> SplitConformalForecaster:
+        return SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            adapter=AdaptiveConformalInference(step_size=0.1),
+        ).fit(y[:180], forecasting_horizon=1, coverage_rates=[0.9])
+
+    def test_one_columns_miscoverage_does_not_affect_the_other(self):
+        """Shocking one column must leave the other column's level untouched.
+
+        Compared across two runs rather than before-and-after within one: a
+        covered column still advances its own level, because the recursion
+        moves by ``step_size * alpha_target`` when the miscoverage indicator is
+        zero. The property under test is independence between columns.
+        """
+        y = _two_column_series()
+
+        def observe_and_read(shock: bool) -> dict[str, object]:
+            forecaster = self._fit(y)
+            row = y[180:181]
+            if shock:
+                # "b" lands far outside any calibrated interval; "a" is untouched.
+                row = row.with_columns(pl.col("b__value") + 100_000.0)
+            forecaster.observe(y=row)
+            return {column: adapter.predict()[0.9] for column, adapter in forecaster.adapters_["step_1"].items()}
+
+        quiet, shocked = observe_and_read(shock=False), observe_and_read(shock=True)
+
+        assert shocked["a__value"] == quiet["a__value"], "another column's shock must not reach this column's level"
+        assert shocked["b__value"] != quiet["b__value"], "the shocked column's level must respond"
+
+    def test_adapters_are_keyed_by_step_and_column(self):
+        y = _two_column_series()
+        forecaster = self._fit(y)
+
+        assert set(forecaster.adapters_) == {"step_1"}
+        assert set(forecaster.adapters_["step_1"]) == {"a__value", "b__value"}
+
+    def test_a_column_of_a_panel_matches_the_equivalent_single_column_run(self):
+        """One column of a multi-column frame must adapt exactly as it would alone."""
+        y = _two_column_series()
+        panel = self._fit(y)
+        univariate = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            adapter=AdaptiveConformalInference(step_size=0.1),
+        ).fit(y[:180].select(["time", "a__value"]), forecasting_horizon=1, coverage_rates=[0.9])
+
+        panel.observe(y=y[180:185])
+        univariate.observe(y=y[180:185].select(["time", "a__value"]))
+
+        assert (
+            panel.adapters_["step_1"]["a__value"].predict()[0.9]
+            == univariate.adapters_["step_1"]["a__value"].predict()[0.9]
+        )
+
+    def test_shared_pooling_still_lets_columns_diverge(self):
+        """``alpha_pooling="shared"`` pools across steps, never across columns."""
+        y = _two_column_series()
+        forecaster = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=AbsoluteResidual(),
+            adapter=AdaptiveConformalInference(step_size=0.1, alpha_pooling="shared"),
+        ).fit(y[:180], forecasting_horizon=2, coverage_rates=[0.9])
+
+        # Only "b" is shocked, so only "b" should be driven away from "a".
+        forecaster.observe(y=y[180:184].with_columns(pl.col("b__value") + 100_000.0))
+
+        levels = {column: adapter.predict()[0.9] for column, adapter in forecaster.adapters_["step_1"].items()}
+        assert levels["a__value"] != levels["b__value"], "shared pooling must not fuse the columns"
+
+        # Within a column, the shared trajectory still ties the two steps.
+        for column in ("a__value", "b__value"):
+            step_1 = forecaster.adapters_["step_1"][column].predict()[0.9]
+            step_2 = forecaster.adapters_["step_2"][column].predict()[0.9]
+            assert step_1 == pytest.approx(step_2), f"{column} steps should share one trajectory"

--- a/tests/interval/test_panel.py
+++ b/tests/interval/test_panel.py
@@ -74,12 +74,16 @@ class TestSplitConformalPanelChecks:
 
     @pytest.mark.slow
     def test_split_conformal_panel_checks(self, panel_time_series_factory):
-        y = panel_time_series_factory(length=100, n_series=3)
-        y_train, y_test = y[:80], y[80:]
+        # Sized so the default 0.95 rate is expressible at every horizon step:
+        # an asymmetric scorer needs 39 scores there, and step 3 sees
+        # calibration_size - 2. At the previous 30 the sweep ran in a regime the
+        # forecaster itself warns about, which is not what these checks are for.
+        y = panel_time_series_factory(length=220, n_series=3)
+        y_train, y_test = y[:180], y[180:]
 
         forecaster = SplitConformalForecaster(
             point_forecaster=SeasonalNaive(seasonality=7),
-            calibration_size=30,
+            calibration_size=50,
         )
         forecaster.fit(y_train, forecasting_horizon=3)
 

--- a/tests/interval/test_panel.py
+++ b/tests/interval/test_panel.py
@@ -1,10 +1,15 @@
 """Tests for cross-learning functionality in interval forecasters."""
 
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
 import pytest
 from sklearn.base import clone
 
 from conftest import run_checks
-from yohou.interval import IntervalReductionForecaster
+from yohou.interval import IntervalReductionForecaster, SplitConformalForecaster
+from yohou.point import SeasonalNaive
 from yohou.testing import _yield_yohou_forecaster_checks
 
 
@@ -56,3 +61,66 @@ class TestIntervalReductionPanelBehavior:
 
         with pytest.raises(ValueError, match="fitted on global data"):
             forecaster.predict_interval(forecasting_horizon=3, groups=["feature_0"])
+
+
+class TestSplitConformalPanelChecks:
+    """Systematic checks for SplitConformalForecaster on panel data.
+
+    The existing systematic run for this class uses ``n_targets=1``, so until
+    now no generated check had ever seen it hold more than one value column.
+    That is why a pooled calibration quantile survived: every green check was
+    measured on data that could not expose it.
+    """
+
+    @pytest.mark.slow
+    def test_split_conformal_panel_checks(self, panel_time_series_factory):
+        y = panel_time_series_factory(length=100, n_series=3)
+        y_train, y_test = y[:80], y[80:]
+
+        forecaster = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=30,
+        )
+        forecaster.fit(y_train, forecasting_horizon=3)
+
+        run_checks(
+            forecaster,
+            _yield_yohou_forecaster_checks(forecaster, y_train, None, y_test, None),
+            expected_failures=set(),
+        )
+
+
+class TestMultiVariablePanelCalibration:
+    """Calibration is keyed by value column, which is finer than by group."""
+
+    def test_four_columns_get_four_independent_calibrations(self):
+        """Two groups times two variables is four calibrations, not two."""
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(160)]
+
+        def series(scale: float, seed: int) -> list[float]:
+            rng = np.random.default_rng(seed)
+            return [scale * (10.0 + 5.0 * np.sin(2 * np.pi * i / 7)) + rng.normal(0, 0.5 * scale) for i in range(160)]
+
+        y = pl.DataFrame({
+            "time": dates,
+            "a__sales": series(1.0, 1),
+            "a__returns": series(10.0, 2),
+            "b__sales": series(100.0, 3),
+            "b__returns": series(1000.0, 4),
+        })
+        columns = ["a__sales", "a__returns", "b__sales", "b__returns"]
+
+        forecaster = SplitConformalForecaster(point_forecaster=SeasonalNaive(seasonality=7), calibration_size=40).fit(
+            y[:140], forecasting_horizon=1, coverage_rates=[0.9]
+        )
+
+        intervals = forecaster.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])
+        widths = {c: float(intervals[f"{c}_upper_0.9"][0] - intervals[f"{c}_lower_0.9"][0]) for c in columns}
+
+        # Each width tracks its own column's scale, so consecutive columns
+        # differ by roughly the 10x scale step between them.
+        for finer, coarser in zip(columns, columns[1:], strict=False):
+            ratio = widths[coarser] / widths[finer]
+            assert 3.0 < ratio < 30.0, f"{coarser} should be about 10x {finer}, got {widths}"
+
+        assert len(set(widths.values())) == 4, f"expected four distinct calibrations, got {widths}"

--- a/tests/interval/test_similarity.py
+++ b/tests/interval/test_similarity.py
@@ -1,5 +1,6 @@
 """Tests for similarity measures in interval forecasting."""
 
+import warnings
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -455,7 +456,17 @@ class TestSeasonalSimilarityIntegration:
         assert "time" in intervals.columns
 
     def test_produces_different_intervals_than_unweighted(self):
-        """Test that temporal similarity changes intervals vs unweighted."""
+        """Seasonal weighting changes the interval at the default bandwidth.
+
+        Left at the default deliberately, so this also pins that the default is
+        not a no-op. `SeasonalSimilarity` defaults `bandwidth` to 0.5 rather
+        than 1.0 because harmonic features are bounded on the unit circle: at
+        1.0 the weights retain about 41 of 50 calibration rows as effective
+        sample size, close enough to uniform that the weighted quantile picks
+        the same order statistic as the unweighted one and the bounds come out
+        bit-identical. At 0.5 the effective sample size is about 25 and the
+        bound moves.
+        """
         from yohou.interval import SplitConformalForecaster
         from yohou.metrics.conformity import AbsoluteResidual
         from yohou.point import SeasonalNaive
@@ -917,3 +928,226 @@ class TestCompositeNamedAccess:
     def test_distinct_names_still_validate(self, train_data):
         y, y_pred = train_data
         assert self._composite().fit(y, y_pred) is not None
+
+
+class TestMixedScaleFrames:
+    """Weight concentration must not depend on the magnitude of the data.
+
+    Regression coverage for the unscaled softmax: on a frame mixing scale 1 and
+    scale 100 the distance spread was large enough that all weight mass landed on
+    a single calibration row, both tail quantiles returned that same score, and
+    ``predict_interval`` emitted intervals of width exactly zero at nominal 90%.
+    """
+
+    @staticmethod
+    def _mixed_scale_frame(n: int = 200) -> pl.DataFrame:
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+
+        def series(scale: float, seed: int) -> list[float]:
+            rng = np.random.default_rng(seed)
+            return [scale * (10.0 + 5.0 * np.sin(2 * np.pi * i / 7)) + rng.normal(0, 0.5 * scale) for i in range(n)]
+
+        return pl.DataFrame({"time": dates, "small__sales": series(1.0, 1), "big__sales": series(100.0, 2)})
+
+    def test_distance_similarity_keeps_intervals_non_degenerate(self):
+        from yohou.interval import SplitConformalForecaster
+        from yohou.point import SeasonalNaive
+
+        y = self._mixed_scale_frame()
+        forecaster = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            similarity=DistanceSimilarity(),
+        ).fit(y[:180], forecasting_horizon=1, coverage_rates=[0.9])
+
+        intervals = forecaster.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])
+        for column in ("small__sales", "big__sales"):
+            width = float(intervals[f"{column}_upper_0.9"][0] - intervals[f"{column}_lower_0.9"][0])
+            assert width > 0.0, f"{column} received a zero-width 90% interval"
+
+    def test_distance_similarity_weights_do_not_collapse(self):
+        """The cause, not the symptom: mass must not concentrate on one row."""
+        from yohou.interval import SplitConformalForecaster
+        from yohou.point import SeasonalNaive
+
+        y = self._mixed_scale_frame()
+        forecaster = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            similarity=DistanceSimilarity(),
+        ).fit(y[:180], forecasting_horizon=1, coverage_rates=[0.9])
+
+        y_pred = forecaster.point_forecaster_.predict(forecasting_horizon=1).drop("vintage_time", strict=False)
+        weights = np.asarray(forecaster.similarities_["step_1"].predict(y_pred=y_pred)[0], dtype=float)
+        effective_sample_size = weights.sum() ** 2 / (weights**2).sum()
+
+        assert effective_sample_size > 2.0, f"weights collapsed to {effective_sample_size:.2f} effective rows"
+
+
+class TestWeightScaling:
+    """The fitted distance scale, the bandwidth knob, and their fallbacks."""
+
+    @staticmethod
+    def _series(scale: float, n: int = 120, seed: int = 7) -> tuple[pl.DataFrame, pl.DataFrame]:
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        rng = np.random.default_rng(seed)
+        truth = [scale * (10.0 + 5.0 * np.sin(2 * np.pi * i / 7)) for i in range(n)]
+        pred = [v + rng.normal(0, 0.05 * scale) for v in truth]
+        return (
+            pl.DataFrame({"time": dates, "value": truth}),
+            pl.DataFrame({"time": dates, "value": pred}),
+        )
+
+    @staticmethod
+    def _effective_sample_size(similarity: DistanceSimilarity, y_pred: pl.DataFrame) -> float:
+        weights = np.asarray(similarity.predict(y_pred=y_pred)[0], dtype=float)
+        return float(weights.sum() ** 2 / (weights**2).sum())
+
+    def test_effective_sample_size_is_equal_across_scales(self):
+        """Weight concentration must not depend on the units of the data.
+
+        Promoted from the exploration probe that established the defect: before
+        the fitted distance scale, effective sample size ran 49.9, 13.4 and 2.9
+        at data scales 0.01, 1 and 100 respectively.
+        """
+        sizes = []
+        for scale in (0.01, 1.0, 100.0, 10_000.0):
+            y, y_pred = self._series(scale)
+            similarity = DistanceSimilarity().fit(y, y_pred)
+            sizes.append(self._effective_sample_size(similarity, y_pred[:1]))
+
+        assert sizes[0] == pytest.approx(sizes[1], rel=1e-6), f"scale changed concentration: {sizes}"
+        assert sizes[0] == pytest.approx(sizes[2], rel=1e-6), f"scale changed concentration: {sizes}"
+        assert sizes[0] == pytest.approx(sizes[3], rel=1e-6), f"scale changed concentration: {sizes}"
+
+    def test_smaller_bandwidth_concentrates_weight(self):
+        y, y_pred = self._series(1.0)
+        tight = DistanceSimilarity(bandwidth=0.25).fit(y, y_pred)
+        loose = DistanceSimilarity(bandwidth=4.0).fit(y, y_pred)
+
+        assert self._effective_sample_size(tight, y_pred[:1]) < self._effective_sample_size(loose, y_pred[:1])
+
+    def test_bandwidth_is_tunable_through_a_forecaster(self):
+        """``similarity__bandwidth`` must reach the sub-estimator like any nested param."""
+        from yohou.interval import SplitConformalForecaster
+
+        forecaster = SplitConformalForecaster(similarity=DistanceSimilarity())
+        assert "similarity__bandwidth" in forecaster.get_params(deep=True)
+
+        forecaster.set_params(similarity__bandwidth=0.5)
+        assert forecaster.similarity.bandwidth == 0.5
+
+    def test_scales_are_frozen_at_fit(self):
+        """Observing must not move either scale, so predict stays reproducible."""
+        y, y_pred = self._series(1.0)
+        similarity = DistanceSimilarity().fit(y[:100], y_pred[:100])
+        before = (similarity._feature_scale_.copy(), similarity._distance_scale_)
+
+        # A batch an order of magnitude larger than the fit window.
+        similarity.observe(y=y[100:] * 10, y_pred=y_pred[100:].with_columns(pl.col("value") * 10))
+
+        assert np.array_equal(similarity._feature_scale_, before[0])
+        assert similarity._distance_scale_ == before[1]
+
+    def test_rewind_reproduces_the_earlier_weight_matrix(self):
+        y, y_pred = self._series(1.0)
+        similarity = DistanceSimilarity().fit(y[:100], y_pred[:100])
+        target = y_pred[:1]
+        before = similarity.predict(y_pred=target).copy()
+
+        similarity.observe(y=y[100:110], y_pred=y_pred[100:110])
+        similarity.rewind(y=y[100:110], y_pred=y_pred[100:110])
+
+        assert np.allclose(similarity.predict(y_pred=target), before)
+
+    def test_zero_variance_column_falls_back_to_unit_scale(self):
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(20)]
+        rng = np.random.default_rng(0)
+        y_pred = pl.DataFrame({
+            "time": dates,
+            "constant": [3.0] * 20,
+            "varying": rng.normal(0, 1, 20).tolist(),
+        })
+        similarity = DistanceSimilarity().fit(y_pred, y_pred)
+
+        assert similarity._feature_scale_[0] == 1.0
+        assert np.isfinite(similarity.predict(y_pred=y_pred[:1])).all()
+
+    def test_identical_features_fall_back_to_unit_distance_scale(self):
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(20)]
+        y_pred = pl.DataFrame({"time": dates, "value": [3.0] * 20})
+        similarity = DistanceSimilarity().fit(y_pred, y_pred)
+
+        assert similarity._distance_scale_ == 1.0
+        assert np.isfinite(similarity.predict(y_pred=y_pred[:1])).all()
+
+
+class TestCollapsedWeightWarning:
+    """A weight row that has collapsed onto one calibration score is reported."""
+
+    @staticmethod
+    def _frame(n: int = 200) -> pl.DataFrame:
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+
+        def series(scale: float, seed: int) -> list[float]:
+            rng = np.random.default_rng(seed)
+            return [scale * (10.0 + 5.0 * np.sin(2 * np.pi * i / 7)) + rng.normal(0, 0.5 * scale) for i in range(n)]
+
+        return pl.DataFrame({"time": dates, "a__sales": series(1.0, 1), "b__sales": series(1.0, 2)})
+
+    def _fit(self, bandwidth: float):
+        from yohou.interval import SplitConformalForecaster
+        from yohou.point import SeasonalNaive
+
+        return SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            similarity=DistanceSimilarity(bandwidth=bandwidth),
+        ).fit(self._frame()[:180], forecasting_horizon=1, coverage_rates=[0.9])
+
+    def test_collapsed_weights_warn_exactly_once_for_a_multi_column_frame(self):
+        """A tiny bandwidth forces all mass onto the nearest calibration row."""
+        forecaster = self._fit(bandwidth=1e-3)
+
+        with pytest.warns(UserWarning, match="effective calibration rows") as record:
+            forecaster.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])
+
+        collapse_warnings = [w for w in record if "effective calibration rows" in str(w.message)]
+        assert len(collapse_warnings) == 1, "one weight row serves both columns, so one warning is expected"
+        assert "step 1" in str(collapse_warnings[0].message)
+        assert "0.9" in str(collapse_warnings[0].message)
+
+    def test_healthy_weights_are_silent(self):
+        forecaster = self._fit(bandwidth=1.0)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            forecaster.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])
+
+    def test_distance_similarity_default_bandwidth_discriminates(self):
+        """The other class's default must not be a no-op either.
+
+        `DistanceSimilarity` keeps `bandwidth=1.0` where `SeasonalSimilarity`
+        drops to 0.5, because its features carry the data's own spread rather
+        than sitting on the unit circle. Pinned so a future change to either
+        default cannot quietly turn the weighting off.
+        """
+        from yohou.interval import SplitConformalForecaster
+        from yohou.point import SeasonalNaive
+
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(200)]
+        rng = np.random.default_rng(42)
+        y = pl.DataFrame({
+            "time": dates,
+            "value": [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + rng.normal(0, 0.5) for i in range(200)],
+        })
+
+        def upper_bound(similarity) -> float:
+            forecaster = SplitConformalForecaster(
+                point_forecaster=SeasonalNaive(seasonality=7),
+                calibration_size=50,
+                similarity=similarity,
+            ).fit(y[:180], forecasting_horizon=1, coverage_rates=[0.9])
+            return float(forecaster.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])["value_upper_0.9"][0])
+
+        assert upper_bound(DistanceSimilarity()) != pytest.approx(upper_bound(None))

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -1,5 +1,6 @@
 """Tests for SplitConformalForecaster."""
 
+import warnings
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -2002,3 +2003,70 @@ class TestCalibrationIndependenceCheck:
         # that catches this: the small column's width moves with it.
         with pytest.raises(AssertionError, match=r"(own conformity scores|pooled across value columns)"):
             check_per_column_calibration_independence(forecaster, y_train=y[:180])
+
+
+class TestConformalCoverage:
+    """Realized coverage must reach the nominal rate, not sit below it.
+
+    The existing tests pin order-statistic indices, which move together with an
+    off-by-one in the quantile convention and so cannot detect one. This asserts
+    the property the convention exists to deliver: with the ``(n + 1)``
+    correction the bound covers at least the nominal rate; without it every
+    sample size under-covers.
+    """
+
+    @staticmethod
+    def _series(n: int = 500, seed: int = 3) -> pl.DataFrame:
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        rng = np.random.default_rng(seed)
+        return pl.DataFrame({
+            "time": dates,
+            "value": [10.0 + 5.0 * np.sin(2 * np.pi * i / 7) + rng.normal(0, 1.0) for i in range(n)],
+        })
+
+    @pytest.mark.parametrize("scorer", [Residual(), AbsoluteResidual()], ids=["asymmetric", "symmetric"])
+    @pytest.mark.parametrize("rate", [0.8, 0.9])
+    def test_realized_coverage_reaches_the_nominal_rate(self, scorer, rate):
+        y = self._series()
+        n_train, n_steps = 300, 150
+        forecaster = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=clone(scorer),
+        ).fit(y[:n_train], forecasting_horizon=1, coverage_rates=[rate])
+
+        covered = 0
+        for k in range(n_steps):
+            intervals = forecaster.predict_interval(forecasting_horizon=1, coverage_rates=[rate])
+            row = y[n_train + k : n_train + k + 1]
+            truth = float(row["value"][0])
+            lower = float(intervals[f"value_lower_{rate}"][0])
+            upper = float(intervals[f"value_upper_{rate}"][0])
+            covered += int(lower <= truth <= upper)
+            forecaster.observe(y=row)
+
+        realized = covered / n_steps
+        # Split conformal is conservative, so the bound is one-sided. The slack
+        # below nominal absorbs sampling noise over 150 steps without admitting
+        # the systematic one-order-statistic shortfall this guards against.
+        assert realized >= rate - 0.03, f"realized {realized:.1%} against nominal {rate:.0%}"
+
+    def test_warns_through_predict_interval_when_the_rate_is_unreachable(self):
+        """The guard must be wired into the emitting path, not only importable."""
+        y = self._series(n=200)
+        forecaster = SplitConformalForecaster(point_forecaster=SeasonalNaive(seasonality=7), calibration_size=20).fit(
+            y[:180], forecasting_horizon=1, coverage_rates=[0.99]
+        )
+
+        with pytest.warns(UserWarning, match="needs at least .* calibration scores per value column"):
+            forecaster.predict_interval(forecasting_horizon=1, coverage_rates=[0.99])
+
+    def test_reachable_rate_is_silent_through_predict_interval(self):
+        y = self._series(n=300)
+        forecaster = SplitConformalForecaster(point_forecaster=SeasonalNaive(seasonality=7), calibration_size=100).fit(
+            y[:250], forecasting_horizon=1, coverage_rates=[0.9]
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            forecaster.predict_interval(forecasting_horizon=1, coverage_rates=[0.9])

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -1989,6 +1989,21 @@ class TestCalibrationIndependenceCheck:
 
         check_per_column_calibration_independence(forecaster, y_train=y[:180])
 
+    def test_check_skips_a_history_too_short_to_judge(self, y_X_factory):
+        """Under 60 timestamps the check cannot fit and calibrate, so it declines.
+
+        Returning rather than asserting keeps the systematic sweep usable on the
+        short fixtures other checks run on, instead of failing them for a reason
+        unrelated to calibration scope.
+        """
+        y, _ = y_X_factory(length=200, n_targets=1, n_features=0, seed=42)
+        forecaster = SplitConformalForecaster(point_forecaster=SeasonalNaive(seasonality=7), calibration_size=50).fit(
+            y[:180], forecasting_horizon=1
+        )
+
+        # No assertion error despite the frame being far too short to calibrate.
+        check_per_column_calibration_independence(forecaster, y_train=y[:40])
+
     def test_check_rejects_a_pooling_implementation(self, y_X_factory):
         y, _ = y_X_factory(length=200, n_targets=1, n_features=0, seed=42)
         forecaster = SplitConformalForecaster(

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -9,11 +9,11 @@ from sklearn.base import clone
 from sklearn.exceptions import NotFittedError
 
 from conftest import run_checks
-from yohou.interval import DistanceSimilarity, SplitConformalForecaster
+from yohou.interval import AdaptiveConformalInference, DistanceSimilarity, SplitConformalForecaster
 from yohou.interval.similarity import SeasonalSimilarity
 from yohou.metrics import AbsoluteResidual, Residual
 from yohou.point import SeasonalNaive
-from yohou.testing import _yield_yohou_forecaster_checks
+from yohou.testing import _yield_yohou_forecaster_checks, check_per_column_calibration_independence
 
 
 @pytest.fixture
@@ -1842,3 +1842,161 @@ class TestReplayLeftTheBlockObserved:
         """
         with pytest.raises(RuntimeError, match=r"at \[datetime\.datetime\(2024, 1, 2"):
             self._check({"p0": datetime(2024, 1, 5), "p1": datetime(2024, 1, 2)})
+
+
+def _mixed_scale_frame(n: int = 200, *, panel: bool = True, factor: float = 100.0) -> pl.DataFrame:
+    """Two seasonal series whose residual spreads differ by ``factor``.
+
+    Both columns share a 7-step seasonality so ``SeasonalNaive(7)`` leaves only
+    noise behind, which makes each column's conformity scores a clean readout of
+    its own noise level.
+    """
+    dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+
+    def series(scale: float, seed: int) -> list[float]:
+        rng = np.random.default_rng(seed)
+        return [scale * (10.0 + 5.0 * np.sin(2 * np.pi * i / 7)) + rng.normal(0, 0.5 * scale) for i in range(n)]
+
+    small, big = "small__sales", "big__sales"
+    if not panel:
+        small, big = "small_sales", "big_sales"
+    return pl.DataFrame({"time": dates, small: series(1.0, 1), big: series(factor, 2)})
+
+
+def _fit_conformal(y: pl.DataFrame, **kwargs) -> SplitConformalForecaster:
+    """Fit a conformal forecaster over the first 180 rows of ``y``."""
+    forecaster = SplitConformalForecaster(
+        point_forecaster=SeasonalNaive(seasonality=7),
+        calibration_size=50,
+        **kwargs,
+    )
+    return forecaster.fit(y[:180], forecasting_horizon=1, coverage_rates=[0.9])
+
+
+def _widths(forecaster: SplitConformalForecaster, columns: list[str], rate: float = 0.9) -> dict[str, float]:
+    """Interval width per value column at one coverage rate."""
+    intervals = forecaster.predict_interval(forecasting_horizon=1, coverage_rates=[rate])
+    return {c: float(intervals[f"{c}_upper_{rate}"][0] - intervals[f"{c}_lower_{rate}"][0]) for c in columns}
+
+
+class TestPerColumnCalibration:
+    """Each value column is calibrated from its own conformity scores.
+
+    Regression coverage for the whole-frame ``np.quantile`` reduction that gave
+    every column one shared width: a 100x scale gap between two columns produced
+    identical intervals for both, over-covering the small column and
+    under-covering the large one.
+    """
+
+    def test_panel_columns_of_differing_scale_get_different_widths(self):
+        y = _mixed_scale_frame()
+        forecaster = _fit_conformal(y)
+        widths = _widths(forecaster, ["small__sales", "big__sales"])
+
+        ratio = widths["big__sales"] / widths["small__sales"]
+        assert 50.0 < ratio < 200.0, f"expected widths to track each column's own scale, got {widths}"
+
+    def test_plain_multivariate_columns_of_differing_scale_get_different_widths(self):
+        """The defect was never panel-specific: it hit any multi-column frame."""
+        y = _mixed_scale_frame(panel=False)
+        forecaster = _fit_conformal(y)
+        widths = _widths(forecaster, ["small_sales", "big_sales"])
+
+        ratio = widths["big_sales"] / widths["small_sales"]
+        assert 50.0 < ratio < 200.0, f"expected widths to track each column's own scale, got {widths}"
+
+    def test_each_width_matches_its_own_columns_quantile(self):
+        """The width is the column's own score quantile, not any pooled statistic."""
+        y = _mixed_scale_frame()
+        forecaster = _fit_conformal(y)
+        widths = _widths(forecaster, ["small__sales", "big__sales"])
+
+        scores = forecaster.conformity_scores_.filter(pl.col("step") == 1).drop("step", "time")
+        for column, width in widths.items():
+            column_scores = scores[column].to_numpy()
+            expected = float(
+                np.quantile(column_scores, 0.95, method="higher") - np.quantile(column_scores, 0.05, method="lower")
+            )
+            assert width == pytest.approx(expected), f"{column} width should come from its own scores"
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({}, id="static"),
+            pytest.param({"similarity": SeasonalSimilarity(seasonality=[7.0])}, id="similarity"),
+            pytest.param({"adapter": AdaptiveConformalInference()}, id="adapter"),
+        ],
+    )
+    def test_calibration_axis_is_the_same_on_every_path(self, kwargs):
+        """Configuring a similarity or an adapter must not change what is calibrated from what.
+
+        The three ``predict_interval`` paths used to disagree: the static one
+        reduced the whole conformity frame to a single quantile while the other
+        two reduced per column. Whichever path runs, a column's width must track
+        that column's own scores.
+        """
+        y = _mixed_scale_frame()
+        forecaster = _fit_conformal(y, **kwargs)
+        widths = _widths(forecaster, ["small__sales", "big__sales"])
+
+        ratio = widths["big__sales"] / widths["small__sales"]
+        assert 50.0 < ratio < 200.0, f"path {kwargs or 'static'} pooled across columns, got {widths}"
+
+
+class _PoolingResidual(Residual):
+    """A scorer that reduces the whole conformity frame to one quantile.
+
+    Reproduces the pre-fix behaviour deliberately, so the systematic check has
+    something known-broken to reject. Without this the check is only ever run
+    against a correct implementation, which proves it does not crash, not that
+    it detects anything.
+    """
+
+    def inverse_score(self, y_pred, conformity_scores, coverage_rate):  # noqa: D102
+        from yohou.utils.validate_data import validate_scorer_data
+
+        y_pred, conformity_scores, context = validate_scorer_data(
+            self, y_true=None, y_pred=y_pred, scores=conformity_scores, inverse=True
+        )
+        alpha = 1.0 - coverage_rate
+        flat = conformity_scores.to_numpy()
+        lower = float(np.quantile(flat, alpha / 2.0, method="lower"))
+        upper = float(np.quantile(flat, 1.0 - alpha / 2.0, method="higher"))
+        interval = self._format_y_pred_interval(y_pred + lower, y_pred + upper, coverage_rate)
+        return pl.DataFrame({"time": context.time_values}).hstack(interval)
+
+
+class TestCalibrationIndependenceCheck:
+    """The systematic check that enforces per-column calibration."""
+
+    def test_check_is_yielded_for_split_conformal(self, y_X_factory):
+        y, _ = y_X_factory(length=200, n_targets=1, n_features=0, seed=42)
+        forecaster = SplitConformalForecaster(point_forecaster=SeasonalNaive(seasonality=7), calibration_size=50).fit(
+            y[:180], forecasting_horizon=1
+        )
+
+        names = [name for name, _, _ in _yield_yohou_forecaster_checks(forecaster, y[:180], None, y[180:], None)]
+        assert "check_per_column_calibration_independence" in names
+
+    def test_check_passes_on_the_fixed_implementation(self, y_X_factory):
+        y, _ = y_X_factory(length=200, n_targets=1, n_features=0, seed=42)
+        forecaster = SplitConformalForecaster(point_forecaster=SeasonalNaive(seasonality=7), calibration_size=50).fit(
+            y[:180], forecasting_horizon=1
+        )
+
+        check_per_column_calibration_independence(forecaster, y_train=y[:180])
+
+    def test_check_rejects_a_pooling_implementation(self, y_X_factory):
+        y, _ = y_X_factory(length=200, n_targets=1, n_features=0, seed=42)
+        forecaster = SplitConformalForecaster(
+            point_forecaster=SeasonalNaive(seasonality=7),
+            calibration_size=50,
+            conformity_scorer=_PoolingResidual(),
+        ).fit(y[:180], forecasting_horizon=1)
+
+        # Either half of the invariant may fire first. Under pooling the large
+        # column's width does still scale with its own data, because the pooled
+        # quantile is dominated by that column, so it is the independence half
+        # that catches this: the small column's width moves with it.
+        with pytest.raises(AssertionError, match=r"(own conformity scores|pooled across value columns)"):
+            check_per_column_calibration_independence(forecaster, y_train=y[:180])

--- a/tests/interval/test_split_conformal.py
+++ b/tests/interval/test_split_conformal.py
@@ -1913,11 +1913,13 @@ class TestPerColumnCalibration:
 
         scores = forecaster.conformity_scores_.filter(pl.col("step") == 1).drop("step", "time")
         for column, width in widths.items():
-            column_scores = scores[column].to_numpy()
-            expected = float(
-                np.quantile(column_scores, 0.95, method="higher") - np.quantile(column_scores, 0.05, method="lower")
-            )
-            assert width == pytest.approx(expected), f"{column} width should come from its own scores"
+            ordered = np.sort(scores[column].to_numpy())
+            # Split conformal order statistics at 90%: the tails are
+            # floor((n+1) * 0.05) and ceil((n+1) * 0.95), one-indexed.
+            n = ordered.size
+            lower = ordered[max(int(np.floor((n + 1) * 0.05)), 1) - 1]
+            upper = ordered[min(int(np.ceil((n + 1) * 0.95)), n) - 1]
+            assert width == pytest.approx(float(upper - lower)), f"{column} width should come from its own scores"
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/tests/interval/test_utils.py
+++ b/tests/interval/test_utils.py
@@ -199,3 +199,11 @@ class TestConformalCorrection:
         weighted = weighted_quantile(scores, 1.0 - rate, reserved)
 
         assert weighted == pytest.approx(unweighted)
+
+    def test_rate_whose_tail_rounds_to_one_imposes_no_constraint(self):
+        """A rate just below 1 can round its derived tail level to exactly 1.0.
+
+        ``1 - (1 - 0.9999999999999999) / 2`` evaluates to ``1.0`` in float64, so
+        the closed form would divide by zero. The guard returns 0 instead.
+        """
+        assert required_calibration_size(0.9999999999999999, symmetric=False) == 0

--- a/tests/interval/test_utils.py
+++ b/tests/interval/test_utils.py
@@ -3,6 +3,7 @@
 import warnings
 
 import numpy as np
+import polars as pl
 import pytest
 
 from yohou.interval.utils import (
@@ -178,3 +179,23 @@ class TestConformalCorrection:
         x = np.arange(n, dtype=float)
         # Total mass 5/21 never reaches 0.99.
         assert weighted_quantile(x, 0.01, np.full(n, 1.0 / 21.0)) == pytest.approx(x[-1])
+
+    @pytest.mark.parametrize("rate", [0.5, 0.8, 0.9, 0.95])
+    def test_weighted_and_unweighted_paths_select_the_same_score(self, rate):
+        """The two reductions must agree, or configuring a similarity would shift the bound.
+
+        The unweighted path takes ``ceil((n + 1) * rate)`` directly; the weighted
+        path reaches the same index because uniform reserved-mass weights of
+        ``1 / (n + 1)`` accumulate to ``rate`` at exactly that point.
+        """
+        from yohou.metrics.conformity_base import BaseConformityScorer
+
+        rng = np.random.default_rng(5)
+        scores = np.sort(rng.normal(0, 1, 40))
+        frame = pl.DataFrame({"value": scores})
+
+        unweighted = BaseConformityScorer._compute_symmetric_quantiles(frame, rate)[0]
+        reserved = np.full(scores.size, 1.0 / (scores.size + 1))
+        weighted = weighted_quantile(scores, 1.0 - rate, reserved)
+
+        assert weighted == pytest.approx(unweighted)

--- a/tests/interval/test_utils.py
+++ b/tests/interval/test_utils.py
@@ -1,9 +1,15 @@
 """Tests for interval utility functions."""
 
+import warnings
+
 import numpy as np
 import pytest
 
-from yohou.interval.utils import weighted_quantile
+from yohou.interval.utils import (
+    required_calibration_size,
+    warn_if_calibration_too_small,
+    weighted_quantile,
+)
 
 
 def test_weighted_quantile_reexported_from_package():
@@ -115,3 +121,60 @@ class TestWeightedQuantile:
         weights = np.array([0.5, 0.5])
         with pytest.raises(ValueError, match="same length"):
             weighted_quantile(x, q=0.5, weights=weights)
+
+
+class TestConformalCorrection:
+    """The (n+1) correction and the rate-resolution guard."""
+
+    @pytest.mark.parametrize(
+        ("rate", "symmetric", "expected"),
+        [
+            (0.9, True, 9),
+            (0.99, True, 99),
+            (0.9, False, 19),
+            (0.99, False, 199),
+            (1.0, True, 0),
+        ],
+    )
+    def test_required_calibration_size(self, rate, symmetric, expected):
+        """``n >= q / (1 - q)`` is where ``ceil((n+1) * q)`` still fits in ``n``."""
+        assert required_calibration_size(rate, symmetric) == expected
+
+    @pytest.mark.parametrize(("rate", "symmetric"), [(0.9, True), (0.99, True), (0.9, False), (0.8, False)])
+    def test_required_size_is_exactly_where_the_index_fits(self, rate, symmetric):
+        required = required_calibration_size(rate, symmetric)
+        tail = rate if symmetric else 1.0 - (1.0 - rate) / 2.0
+
+        assert int(np.ceil((required + 1) * tail)) <= required
+        assert int(np.ceil(required * tail)) > required - 1
+
+    def test_warns_below_the_required_size_and_is_silent_above(self):
+        with pytest.warns(UserWarning, match="calibration scores per value column"):
+            assert warn_if_calibration_too_small(10, 0.99, symmetric=True, step=1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            assert not warn_if_calibration_too_small(200, 0.99, symmetric=True, step=1)
+
+    def test_weighted_quantile_does_not_renormalize(self):
+        """Reserved test-point mass must survive into the quantile.
+
+        Renormalizing the row to sum to 1 cancels the reservation and costs
+        exactly one order statistic, which is the weighted analogue of dropping
+        the ``(n+1)`` correction.
+        """
+        n = 20
+        x = np.arange(n, dtype=float)
+        reserved = np.full(n, 1.0 / (n + 1))
+
+        picked = weighted_quantile(x, 0.1, reserved)
+        conformal_index = int(np.ceil((n + 1) * 0.9))
+
+        assert picked == pytest.approx(x[conformal_index - 1])
+
+    def test_weighted_quantile_falls_back_when_mass_is_short(self):
+        """Too little calibration mass means an unbounded bound; return the widest finite one."""
+        n = 5
+        x = np.arange(n, dtype=float)
+        # Total mass 5/21 never reaches 0.99.
+        assert weighted_quantile(x, 0.01, np.full(n, 1.0 / 21.0)) == pytest.approx(x[-1])

--- a/tests/metrics/test_conformity.py
+++ b/tests/metrics/test_conformity.py
@@ -283,3 +283,85 @@ class TestConformityScorerTags:
         tags = _ConcreteAbsoluteQuantileResidual().__sklearn_tags__()
         assert tags.scorer_tags is not None
         assert tags.scorer_tags.symmetric is True
+
+
+class TestMultiColumnInverseScore:
+    """Each value column's bounds come from that column's own quantile.
+
+    The quantile helpers used to reduce the whole frame with one `np.quantile`
+    call, so a frame holding columns of different magnitude got one shared
+    width. These pin the reduction at the level it was changed: a direct
+    `inverse_score` call, which is public API and is reachable without going
+    through a forecaster.
+    """
+
+    TIMES = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(5)]
+
+    @property
+    def scores(self) -> pl.DataFrame:
+        """Signed scores whose two columns differ 100x in spread."""
+        return pl.DataFrame({
+            "time": self.TIMES,
+            "small": [-0.1, -0.05, 0.0, 0.05, 0.1],
+            "big": [-10.0, -5.0, 0.0, 5.0, 10.0],
+        })
+
+    @property
+    def y_pred(self) -> pl.DataFrame:
+        return pl.DataFrame({"time": [datetime(2020, 2, 1)], "small": [1.0], "big": [100.0]})
+
+    def test_residual_uses_each_columns_own_quantile(self):
+        scorer = Residual().fit(self.scores)
+        intervals = scorer.inverse_score(self.y_pred, self.scores, 0.6)
+
+        # At coverage 0.6 the tails are taken at 0.2 (method="lower") and 0.8
+        # (method="higher"). On five points those land on index 0 and index 4,
+        # so the bounds use each column's most extreme score: -0.1/0.1 added to
+        # a prediction of 1.0, and -10/10 added to 100.0.
+        assert intervals["small_lower_0.6"][0] == pytest.approx(0.9)
+        assert intervals["small_upper_0.6"][0] == pytest.approx(1.1)
+        assert intervals["big_lower_0.6"][0] == pytest.approx(90.0)
+        assert intervals["big_upper_0.6"][0] == pytest.approx(110.0)
+
+    def test_absolute_residual_uses_each_columns_own_quantile(self):
+        scores = self.scores.with_columns(pl.col("small").abs(), pl.col("big").abs())
+        scorer = AbsoluteResidual().fit(scores)
+        intervals = scorer.inverse_score(self.y_pred, scores, 0.6)
+
+        # Symmetric: the 0.6 quantile (method="lower") of each column's sorted
+        # absolute scores, so one half-width per column, 0.05 and 5.0.
+        assert intervals["small_lower_0.6"][0] == pytest.approx(0.95)
+        assert intervals["small_upper_0.6"][0] == pytest.approx(1.05)
+        assert intervals["big_lower_0.6"][0] == pytest.approx(95.0)
+        assert intervals["big_upper_0.6"][0] == pytest.approx(105.0)
+
+    def test_gamma_residual_scales_each_column_by_its_own_prediction(self):
+        """The multiplicative path: per-column quantile times per-column denominator."""
+        scores = pl.DataFrame({
+            "time": self.TIMES,
+            "small": [-0.2, -0.1, 0.0, 0.1, 0.2],
+            "big": [-0.04, -0.02, 0.0, 0.02, 0.04],
+        })
+        # epsilon must be strictly positive; keep it far below the predictions
+        # so it does not perturb the expected bounds.
+        scorer = GammaResidual(epsilon=1e-12).fit(scores)
+        intervals = scorer.inverse_score(self.y_pred, scores, 0.6)
+
+        # Tails land on index 0 and 4 as above, so each column uses its own
+        # extreme relative score against its own prediction:
+        # small: 1.0 + (-0.2 * 1.0) and 1.0 + (0.2 * 1.0)
+        assert intervals["small_lower_0.6"][0] == pytest.approx(0.8)
+        assert intervals["small_upper_0.6"][0] == pytest.approx(1.2)
+        # big: 100.0 + (-0.04 * 100.0) and 100.0 + (0.04 * 100.0)
+        assert intervals["big_lower_0.6"][0] == pytest.approx(96.0)
+        assert intervals["big_upper_0.6"][0] == pytest.approx(104.0)
+
+    def test_helpers_return_one_value_per_column(self):
+        """The reduction returns n values for an n-column frame, not one."""
+        scorer = Residual().fit(self.scores)
+        scores_no_time = self.scores.drop("time")
+
+        lower, upper = scorer._compute_asymmetric_quantiles(scores_no_time, 0.6)
+        assert len(lower) == 2
+        assert len(upper) == 2
+        assert len(scorer._compute_symmetric_quantiles(scores_no_time, 0.6)) == 2

--- a/tests/metrics/test_conformity.py
+++ b/tests/metrics/test_conformity.py
@@ -366,3 +366,34 @@ class TestMultiColumnInverseScore:
         assert len(lower) == 2
         assert len(upper) == 2
         assert len(scorer._compute_symmetric_quantiles(scores_no_time, 0.6)) == 2
+
+
+class TestEmptyConformityFrame:
+    """Both quantile helpers reject an empty calibration set by name."""
+
+    @pytest.mark.parametrize("rate", [0.5, 0.9])
+    def test_asymmetric_helper_raises_on_empty(self, rate):
+        empty = pl.DataFrame({"value": []}, schema={"value": pl.Float64})
+        with pytest.raises(ValueError, match="calibration set is too small"):
+            Residual._compute_asymmetric_quantiles(empty, rate)
+
+    @pytest.mark.parametrize("rate", [0.5, 0.9])
+    def test_symmetric_helper_raises_on_empty(self, rate):
+        empty = pl.DataFrame({"value": []}, schema={"value": pl.Float64})
+        with pytest.raises(ValueError, match="calibration set is too small"):
+            AbsoluteResidual._compute_symmetric_quantiles(empty, rate)
+
+
+def test_zero_coverage_rate_yields_a_degenerate_interval_per_column():
+    """``coverage_rate == 0`` is a documented special case: both bounds are the median.
+
+    It bypasses the conformal order statistic entirely, so it needs its own
+    coverage; the correction does not apply to a zero-width interval.
+    """
+    times = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(5)]
+    scores = pl.DataFrame({"time": times, "a": [-2.0, -1.0, 0.0, 1.0, 2.0], "b": [-20.0, -10.0, 0.0, 10.0, 20.0]})
+
+    lower, upper = Residual._compute_asymmetric_quantiles(scores.drop("time"), 0.0)
+
+    assert lower == upper
+    assert lower == [0.0, 0.0]

--- a/tests/metrics/test_conformity.py
+++ b/tests/metrics/test_conformity.py
@@ -314,10 +314,10 @@ class TestMultiColumnInverseScore:
         scorer = Residual().fit(self.scores)
         intervals = scorer.inverse_score(self.y_pred, self.scores, 0.6)
 
-        # At coverage 0.6 the tails are taken at 0.2 (method="lower") and 0.8
-        # (method="higher"). On five points those land on index 0 and index 4,
-        # so the bounds use each column's most extreme score: -0.1/0.1 added to
-        # a prediction of 1.0, and -10/10 added to 100.0.
+        # At coverage 0.6 the conformal tail indices on five scores are
+        # floor(6 * 0.2) = 1 and ceil(6 * 0.8) = 5, so the bounds use each
+        # column's most extreme score: -0.1/0.1 added to a prediction of 1.0,
+        # and -10/10 added to 100.0.
         assert intervals["small_lower_0.6"][0] == pytest.approx(0.9)
         assert intervals["small_upper_0.6"][0] == pytest.approx(1.1)
         assert intervals["big_lower_0.6"][0] == pytest.approx(90.0)
@@ -328,12 +328,13 @@ class TestMultiColumnInverseScore:
         scorer = AbsoluteResidual().fit(scores)
         intervals = scorer.inverse_score(self.y_pred, scores, 0.6)
 
-        # Symmetric: the 0.6 quantile (method="lower") of each column's sorted
-        # absolute scores, so one half-width per column, 0.05 and 5.0.
-        assert intervals["small_lower_0.6"][0] == pytest.approx(0.95)
-        assert intervals["small_upper_0.6"][0] == pytest.approx(1.05)
-        assert intervals["big_lower_0.6"][0] == pytest.approx(95.0)
-        assert intervals["big_upper_0.6"][0] == pytest.approx(105.0)
+        # Symmetric: one half-width per column at the conformal index
+        # ceil((n+1) * rate) = ceil(6 * 0.6) = 4, so the 4th smallest absolute
+        # score of each column, 0.1 and 10.0.
+        assert intervals["small_lower_0.6"][0] == pytest.approx(0.9)
+        assert intervals["small_upper_0.6"][0] == pytest.approx(1.1)
+        assert intervals["big_lower_0.6"][0] == pytest.approx(90.0)
+        assert intervals["big_upper_0.6"][0] == pytest.approx(110.0)
 
     def test_gamma_residual_scales_each_column_by_its_own_prediction(self):
         """The multiplicative path: per-column quantile times per-column denominator."""

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -57,8 +57,6 @@ _SKIP_COMMON = {
     "DistanceSimilarity",
     # Conformal adapter (not a standard estimator type; tested by TestConformalAdapterCommon)
     "AdaptiveConformalInference",
-    # Meta-forecasters requiring inner estimator (tested in tests/interval/)
-    "SplitConformalForecaster",
     # Requires a timezone-aware "time" column, which the common sweep's tz-naive
     # fixture cannot provide (fit would just silently skip). The systematic
     # check-generator sweep runs on tz-aware data in


### PR DESCRIPTION
## Description

Conformal prediction intervals were calibrated from the whole conformity frame at once on the default path, so every panel entity and every multivariate target received one shared interval width. This calibrates each value column from its own scores, makes similarity weights scale-free, keys adaptive levels per column, and applies the finite-sample conformal correction that all three quantile paths were missing.

Four breaking changes, detailed below. The last one widens every conformal interval, including single-column univariate ones.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Motivation and Context

`BaseConformityScorer._compute_asymmetric_quantiles` and `_compute_symmetric_quantiles` called `conformity_scores.to_numpy()` on the whole frame and reduced it with `np.quantile`, returning one scalar. `Residual.inverse_score` is the path `predict_interval` takes whenever `similarity` and `adapter` are both `None`, which is the default construction.

Measured on two entities differing 100x in scale (`SeasonalNaive(7)`, `calibration_size=50`, nominal 90%):

```
per-column quantile width, small: 1.840
per-column quantile width, big:   225.122
pooled quantile width:            185.633   <- what both entities received
```

Empirical coverage over 20 held-out steps was 20/20 for the small entity and 16/20 for the large one. It hit plain multivariate frames too, not just panels.

Three further defects surfaced from the same area:

- `DistanceSimilarity` converted distances to weights with no scale term, so weight concentration depended on the units of the data. Effective sample size out of 50 calibration rows ran 49.9, 13.4 and 2.9 at data scales 0.01, 1 and 100. On a frame mixing scales, all mass landed on one calibration row and `predict_interval` returned intervals of width exactly zero at nominal 90%.
- The ACI adapter fed the cross-entity **mean** miscoverage into a recursion the `adaptive-conformal-inference` spec defines with a binary indicator, so one chronically miscovered entity widened every other entity's intervals. Nothing in that change's proposal, design, tasks or spec mentioned the entity axis.
- The panel section of the interval-forecasting explanation described pooling behaviour keyed on `panel_strategy` that does not exist in either mode.

A fourth defect surfaced while investigating whether to warn about small calibration sets. Interval bounds used a plain empirical quantile instead of the split-conformal order statistic, so they under-covered at **every** sample size, not only short histories. The symmetric path made it clearest, because the deficiency oscillates with `n` rather than shrinking away:

```
   n  empirical coverage at nominal 80%  deficient?
   7                              71.4%        True
  10                              80.0%       False
  12                              75.0%        True
  19                              78.9%        True
```

Nine of the fifteen sample sizes between 5 and 19 under-covered. That is also why a "calibration set too small" warning could not have been the fix on its own: there is no threshold to warn below when `n=10` is fine and `n=12` is not.

None of this was caught because no test had ever asserted a panel interval value: `SplitConformalForecaster` was in `_SKIP_COMMON`, its systematic-check test ran `n_targets=1`, its panel tests asserted only that observation buffers advanced, and all adapter tests used a single column.

## Changes

- **Per-column quantiles.** Both quantile helpers reduce with `axis=0`; the three `inverse_score` implementations broadcast each column's quantile against its own prediction. The similarity and adapter paths already looped columns, so all three now agree.
- **Scale-free similarity weights.** Data-derived feature columns are standardized, and distances are divided by a median pairwise distance fitted at `fit` time. A new `bandwidth` parameter tunes concentration: `1.0` for `DistanceSimilarity`, `0.5` for `SeasonalSimilarity`, whose harmonic features are bounded on the unit circle and would otherwise sit near uniform. Both scales are frozen at `fit` so `predict` stays reproducible and `rewind` has no scale history to undo.
- **Per-column adaptive levels.** `adapters_` is keyed by step then value column, each updating from its own binary indicator. `alpha_pooling="shared"` pools across horizon steps within a column, never across columns.
- **Collapsed-weight warning** when a weight row falls below two effective calibration rows, checked where the weights are consumed so user-written similarities are covered.
- **`check_per_column_calibration_independence`**, a systematic check asserting that scaling one value column scales that column's width and leaves the others alone. It is verified against a deliberately-pooling fixture, so the check itself is known to detect the defect.
- **The finite-sample conformal correction.** Bounds are now taken at the split-conformal order statistic `ceil((n + 1) * q)` rather than a plain empirical quantile, so they are no longer one order statistic short. The weighted path had the same deficit by a different route: `_reserve_mass` adds the test point's share to each weight row and `weighted_quantile` then renormalized the row to sum to one, cancelling it, so the Barber et al. (2023) correction was computed and discarded. Uniform weights are now built as `1 / (n + 1)` so both paths select the same score.
- **A warning when a coverage rate exceeds what the calibration set can express**, naming the step, the rate and the required count.

## Breaking changes

There are four, and the last one is the widest.

1. Interval values change for multi-column targets, which is the per-column calibration fix.
2. They change for univariate targets using a `similarity`, because weight concentration is now scale-free (effective sample size moves from 13.4 to 31.2 at data scale 1.0 and is constant across scales afterwards).
3. `SplitConformalForecaster.adapters_` is now keyed by step and value column: read `adapters_["step_1"][column]`.
4. **Every conformal interval gets wider by one order statistic**, including single-column univariate ones, because of the finite-sample correction. Realized coverage moves up to or above the nominal rate: measured at or above nominal in all eight configurations tested across both scorer families and two calibration sizes, where it previously sat below.

The `bandwidth` defaults are chosen, not restored. Expressed in the new parameterisation, the pre-scaling concentration ranged from 0.47 to 1.66 across seasonalities and harmonic counts, so there was no single prior behaviour to return to; it varied precisely because it was unscaled.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

`ty check src/` clean, `prek run --all-files` clean, `just build-fast` exit 0.

Test runs: 794 passed (`tests/interval/`, `tests/metrics/`), 839 passed with 14 skipped and 2 xfailed (`tests/test_common.py`, `tests/compose/`, `tests/model_selection/`), 760 passed (`tests/ensemble/`, `tests/integration/`). The full suite was not run locally because it exhausts the development machine, so CI's full-suite job is the first thing to verify the untouched suites.

The rate-resolution threshold is computed exactly rather than from the closed form `q / (1 - q)`, which evaluates to `9.000000000000002` at `q = 0.9` and would demand ten calibration scores where nine suffice. It is verified against brute force across both scorer families and ten rates, with zero mismatches.

The explanation page's account of why calibration scores are not pooled across entities was corrected. It previously attributed the refusal solely to magnitude heterogeneity, which `GammaResidual` addresses by dividing by the predicted level. It does not address volatility heterogeneity (two entities of equal size whose errors differ threefold in spread stay incomparable), and no conformity score addresses the cross-sectional dependence that breaks exchangeability of a pooled sequence. Measured on a representative panel, same-timestamp correlation was +0.593 against +0.070 one step offset, and the effective gain from pooling saturates near `1 / rho`.

`SplitConformalForecaster` was removed from `_SKIP_COMMON`: it is default-constructible and the full common sweep passes with it included, so the recorded "requires inner estimator" reason was stale.

Two API reference rows for `AdaptiveConformalInference` and `BaseConformalAdapter` appear in `docs/pages/api/interval.md`. Those tables are generated, and the rows were missing from when the adapter shipped; running the docs build surfaced the gap rather than this change creating it.

Deliberately deferred, both recorded in the explanation page: a `calibration_pooling` parameter for pooling scores across entities, which needs a scale-free conformity scorer story first, and an `entity_pooling` parameter mirroring `alpha_pooling`.
