### PR TITLE
fix(compose): restore the verbose guard the sklearn ports dropped

### DIFF
--- a/docs/pages/how-to/control-diagnostic-output.md
+++ b/docs/pages/how-to/control-diagnostic-output.md
@@ -1,0 +1,102 @@
+# Control Yohou's Diagnostic Output
+
+Yohou reports two kinds of thing, through two different channels, and you control
+them separately.
+
+- **Warnings** mean *this may be wrong and you should look*. They go through
+  Python's `warnings` machinery.
+- **Log records** mean *here is what I did*. They go through the standard
+  `logging` module, under the `yohou` logger.
+
+Nothing is printed directly to standard output. If you see output from Yohou that
+you cannot turn off through either mechanism, that is a bug worth reporting.
+
+## Turn the log output on
+
+The library attaches only a `NullHandler` and **sets no level anywhere**, which is
+the standard convention for a library: Yohou emits, your application decides where
+records go and at what level. Until you configure something, you see nothing.
+
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO)
+```
+
+That is enough to see Yohou's records alongside the rest of your application's.
+
+## Target one subsystem
+
+Loggers follow the module path, so you can raise or lower one part of the library
+without touching the others:
+
+```python
+logging.getLogger("yohou").setLevel(logging.WARNING)          # quiet overall
+logging.getLogger("yohou.compose").setLevel(logging.DEBUG)    # except composition
+```
+
+`yohou.compose`, `yohou.model_selection`, `yohou.plotting` and the rest are all
+separately controllable. Setting a level on `yohou` affects every child that has
+not set its own.
+
+## Turn a warning off
+
+Warnings are ordinary Python warnings, so the usual filters apply:
+
+```python
+import warnings
+
+warnings.filterwarnings("ignore", message="X_forecast covers")
+```
+
+Prefer filtering by category where one exists, since message text is not a stable
+interface:
+
+```python
+from yohou import ForecastCoverageWarning
+
+warnings.filterwarnings("ignore", category=ForecastCoverageWarning)
+```
+
+## Read the coverage warning's detail
+
+`ForecastCoverageWarning` carries the per-column breakdown the check computed, not
+only the worst number, because which channel is starved is what tells you what to
+do:
+
+```python
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    forecaster.observe(y=frame)
+
+for entry in caught:
+    if isinstance(entry.message, ForecastCoverageWarning):
+        print(entry.message.coverage)             # {'temp': 0, 'load': 48}
+        print(entry.message.forecasting_horizon)  # 48
+```
+
+A value of `0` means every step feature derived from that column is null, so a
+model relying on it is predicting without it. A value between 0 and the horizon
+means the later steps are null.
+
+It subclasses `UserWarning`, so code that already catches `UserWarning` keeps
+working.
+
+## Estimator progress output
+
+`ColumnTransformer` and `FeatureUnion` accept `verbose`, matching the sklearn
+classes they mirror. It defaults to `False`, which means silent:
+
+```python
+ColumnTransformer(transformers=[...], verbose=True).fit(frame)
+# [ColumnTransformer] (step 1 of 4) Processing lags, total=0.1s
+```
+
+This output goes to standard output rather than through logging, because it
+mirrors sklearn's behaviour exactly. If you want it captured, set `verbose=False`
+and raise the level on the `yohou` logger instead.
+
+!!! note "Changed behaviour"
+
+    Before this was fixed, both classes printed on every fit regardless of
+    `verbose`. If you were relying on seeing those lines, set `verbose=True`.

--- a/docs/pages/how-to/index.md
+++ b/docs/pages/how-to/index.md
@@ -5,6 +5,7 @@ Task-oriented recipes for common Yohou workflows. Each guide assumes you have co
 ## Setup
 
 - [Installation](installation.md): Install Yohou with pip, uv, or conda, including optional extras and development setup.
+- [Control Diagnostic Output](control-diagnostic-output.md): Route Yohou's log records, filter its warnings, and read the coverage warning's per-column detail.
 
 ## Forecasting
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -268,6 +268,7 @@ nav:
   - How-to Guides:
     - pages/how-to/index.md
     - Installation: pages/how-to/installation.md
+    - Control Diagnostic Output: pages/how-to/control-diagnostic-output.md
     - Choose a Forecasting Method: pages/how-to/choose-forecasting-method.md
     - Evaluate Forecast Accuracy: pages/how-to/evaluate-forecast-accuracy.md
     - Evaluate with Multi-vintage Scoring: pages/how-to/multi-vintage-scoring.md

--- a/src/yohou/__init__.py
+++ b/src/yohou/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from sklearn import set_config
 
+from yohou.base.utils import ForecastCoverageWarning
 from yohou.utils._compat import COMPOSITE_METHODS, METHODS, SIMPLE_METHODS
 
 __version__ = version(__name__)
@@ -120,6 +121,7 @@ def __getattr__(name: str):  # noqa: ANN202
 
 
 __all__ = [
+    "ForecastCoverageWarning",
     "__version__",
     "base",
     "class_proba",

--- a/src/yohou/__init__.py
+++ b/src/yohou/__init__.py
@@ -1,5 +1,6 @@
 """Scikit-learn-compatible time series forecasting framework built on polars."""
 
+import logging
 import re
 from importlib.metadata import version
 from typing import Any
@@ -9,6 +10,14 @@ from sklearn import set_config
 from yohou.utils._compat import COMPOSITE_METHODS, METHODS, SIMPLE_METHODS
 
 __version__ = version(__name__)
+
+# The standard library convention for a library: emit, and let the application
+# decide where it goes and at what level. The null handler prevents Python's
+# "No handlers could be found" fallback without claiming stderr, and no level is
+# set anywhere in the package, so the application's configuration is
+# authoritative. Submodules use ``getLogger(__name__)``, so ``yohou.compose`` can
+# be turned down without silencing ``yohou.model_selection``.
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # Enable metadata routing globally for all Yohou estimators
 set_config(enable_metadata_routing=True)

--- a/src/yohou/base/utils.py
+++ b/src/yohou/base/utils.py
@@ -23,6 +23,34 @@ _YOHOU_ROOT = str(Path(__file__).resolve().parents[1])
 _SKLEARN_ROOT = str(Path(sklearn.__file__).resolve().parent)
 
 
+class ForecastCoverageWarning(UserWarning):
+    """Raised when ``X_forecast`` covers fewer steps than the forecasting horizon.
+
+    Carries the per-column breakdown the check computed rather than only the
+    worst number, because which channel is starved is what tells a reader what
+    to do. A consumer aggregating these across a long run can then report the
+    affected columns instead of only a count.
+
+    Subclasses ``UserWarning`` so existing ``pytest.warns(UserWarning)`` and
+    application ``filterwarnings`` entries keep matching.
+
+    Attributes
+    ----------
+    coverage : dict[str, int]
+        Base column name mapped to the worst number of covered forecast steps
+        observed for it. A value of 0 means every step feature derived from that
+        column is null.
+    forecasting_horizon : int
+        The number of steps full coverage would mean, so a reader can judge the
+        counts without holding the call's configuration in mind.
+    """
+
+    def __init__(self, message: str, *, coverage: dict[str, int], forecasting_horizon: int) -> None:
+        super().__init__(message)
+        self.coverage = coverage
+        self.forecasting_horizon = forecasting_horizon
+
+
 def _caller_stacklevel() -> int:
     """Return the ``stacklevel`` that points at the nearest frame outside the library.
 
@@ -1045,7 +1073,13 @@ def _derive_step_columns(
         # path passes warn_coverage=False and reports per column instead.
         if warn_coverage:
             coverage = _forecast_step_coverage(forecast_pivoted, list(value_cols_info), forecasting_horizon)
-            worst = min((min(counts) for counts in coverage.values()), default=forecasting_horizon)
+            # Worst per column, kept rather than collapsed. The single ``worst``
+            # below still decides which branch fires, but the breakdown rides on
+            # the warning so a reader learns which channel is starved and not
+            # merely that one is.
+            per_column = {base: min(counts) for base, counts in coverage.items()}
+            worst = min(per_column.values(), default=forecasting_horizon)
+            starved = sorted(base for base, count in per_column.items() if count < forecasting_horizon)
             if coverage and worst == 0:
                 # Distinct from partial coverage rather than its extreme: nothing
                 # derived from X_forecast carries a value, so a model relying on
@@ -1056,21 +1090,28 @@ def _derive_step_columns(
                 # the newest available vintage. Stated as a measurement rather than
                 # an error: a caller may reach this deliberately.
                 warnings.warn(
-                    f"X_forecast covers 0 of {forecasting_horizon} forecast steps, so every "
-                    f"step feature derived from it is null and a model relying on that channel "
-                    f"is predicting without it. This happens when the newest usable vintage is "
-                    f"at least {forecasting_horizon} intervals older than the observation point, "
-                    f"which a cached frame reaches once serving advances past the vintages it holds.",
-                    UserWarning,
+                    ForecastCoverageWarning(
+                        f"X_forecast covers 0 of {forecasting_horizon} forecast steps for "
+                        f"{', '.join(starved)}, so every step feature derived from those columns is "
+                        f"null and a model relying on them is predicting without them. This happens "
+                        f"when the newest usable vintage is at least {forecasting_horizon} intervals "
+                        f"older than the observation point, which a cached frame reaches once serving "
+                        f"advances past the vintages it holds.",
+                        coverage=per_column,
+                        forecasting_horizon=forecasting_horizon,
+                    ),
                     stacklevel=_caller_stacklevel(),
                 )
             elif coverage and worst < forecasting_horizon:
                 warnings.warn(
-                    f"X_forecast covers {worst} of {forecasting_horizon} "
-                    f"forecast steps. The remaining step features will be null. "
-                    f"This arises for short-range forecasts and when the "
-                    f"observation point has advanced past some forecast timestamps.",
-                    UserWarning,
+                    ForecastCoverageWarning(
+                        f"X_forecast covers {worst} of {forecasting_horizon} forecast steps, worst "
+                        f"over {', '.join(starved)}. The remaining step features will be null. This "
+                        f"arises for short-range forecasts and when the observation point has "
+                        f"advanced past some forecast timestamps.",
+                        coverage=per_column,
+                        forecasting_horizon=forecasting_horizon,
+                    ),
                     stacklevel=_caller_stacklevel(),
                 )
 

--- a/src/yohou/compose/column_transformer.py
+++ b/src/yohou/compose/column_transformer.py
@@ -478,7 +478,7 @@ class ColumnTransformer(BaseActualTransformer, _BaseComposition):
                     return trans
             raise KeyError(f"Transformer {ind} not found")
 
-    def _log_message(self, name: str, idx: int, total: int) -> str:
+    def _log_message(self, name: str, idx: int, total: int) -> str | None:
         """Get log message for a transformer.
 
         Parameters
@@ -492,10 +492,15 @@ class ColumnTransformer(BaseActualTransformer, _BaseComposition):
 
         Returns
         -------
-        message : str
-            Log message.
+        message : str or None
+            The step message, or ``None`` when ``verbose`` is false. ``None`` is
+            what makes the caller silent: ``_print_elapsed_time`` prints whenever
+            the message it is handed is not ``None``, so a port that always
+            returns a string prints on every fit regardless of the parameter.
 
         """
+        if not self.verbose:
+            return None
         return f"(step {idx} of {total}) Processing {name}"
 
     def _update_fitted_transformers(self, transformers: Any) -> None:

--- a/src/yohou/compose/feature_union.py
+++ b/src/yohou/compose/feature_union.py
@@ -260,7 +260,7 @@ class FeatureUnion(BaseActualTransformer, _BaseComposition):
         """
         return Bunch(**dict(self.transformer_list))
 
-    def _log_message(self, name: str, idx: int, total: int) -> str:
+    def _log_message(self, name: str, idx: int, total: int) -> str | None:
         """Get log message for a transformer.
 
         Parameters
@@ -274,10 +274,15 @@ class FeatureUnion(BaseActualTransformer, _BaseComposition):
 
         Returns
         -------
-        message : str
-            Log message.
+        message : str or None
+            The step message, or ``None`` when ``verbose`` is false. ``None`` is
+            what makes the caller silent: ``_print_elapsed_time`` prints whenever
+            the message it is handed is not ``None``, so a port that always
+            returns a string prints on every fit regardless of the parameter.
 
         """
+        if not self.verbose:
+            return None
         return f"(step {idx} of {total}) Processing {name}"
 
     def _parallel_func(self, X: pl.DataFrame, y: pl.DataFrame | None, func: Any, routed_params: Any) -> Any:

--- a/src/yohou/compose/per_vintage.py
+++ b/src/yohou/compose/per_vintage.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import warnings
+import logging
 
 import polars as pl
 from sklearn.base import clone
@@ -10,6 +10,8 @@ from sklearn.utils.validation import check_is_fitted
 
 from yohou.base.forecast_transformer import FORECAST_INDEX_COLS, BaseForecastTransformer
 from yohou.base.transformer import BaseActualTransformer
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["PerVintageActualTransformer"]
 
@@ -241,12 +243,16 @@ class PerVintageActualTransformer(BaseForecastTransformer):
             parts.append(transformed)
 
         if dropped:
-            warnings.warn(
-                f"PerVintageActualTransformer dropped {dropped} vintage(s) with fewer than "
-                f"{_MIN_VINTAGE_ROWS} rows, which cannot be fitted per vintage. This is expected "
-                f"for the truncated tail of a forecast frame; those vintages are absent from the output.",
-                UserWarning,
-                stacklevel=3,
+            # A record, not a warning. The condition is expected for the truncated
+            # tail of a forecast frame, so it states what the transformer did rather
+            # than something the caller may need to act on. As a warning it diluted
+            # the channel a consumer cannot easily ignore.
+            logger.info(
+                "PerVintageActualTransformer dropped %d vintage(s) with fewer than %d rows, which "
+                "cannot be fitted per vintage. This is expected for the truncated tail of a forecast "
+                "frame; those vintages are absent from the output.",
+                dropped,
+                _MIN_VINTAGE_ROWS,
             )
 
         if not parts:

--- a/src/yohou/plotting/forecasting.py
+++ b/src/yohou/plotting/forecasting.py
@@ -1,5 +1,6 @@
 """Forecast visualization functions."""
 
+import logging
 import re
 from typing import Literal
 
@@ -35,6 +36,8 @@ from yohou.plotting._utils import (
 )
 from yohou.plotting.evaluation import _discover_proba_targets
 from yohou.utils import inspect_panel, validate_plotting_data, validate_plotting_params
+
+logger = logging.getLogger(__name__)
 
 # The full palette list is used as the default effective palette in every
 # plot_forecast code path. Slots 0/1/2 are reserved for the three semantic
@@ -2428,7 +2431,6 @@ def _clean_series(series: pl.Series) -> np.ndarray:
         1-D float64 array with no missing values.
 
     """
-    import warnings  # noqa: PLC0415
 
     def _n_missing(s: pl.Series) -> int:
         """Count null and (for float columns) NaN entries in ``s``."""
@@ -2440,11 +2442,11 @@ def _clean_series(series: pl.Series) -> np.ndarray:
     clean = series.interpolate().forward_fill().backward_fill()
     n_interpolated = _n_missing(series) - _n_missing(clean)
     if n_interpolated > 0:
-        warnings.warn(
-            f"Interpolated {n_interpolated} NaN value(s) before decomposition.",
-            UserWarning,
-            stacklevel=4,
-        )
+        # A record, not a warning: it states what the helper did, not something
+        # the caller may need to act on. The interpolation is the documented
+        # behaviour of this path, so warning about it every time trained readers
+        # to skim a channel that should mean "look at this".
+        logger.info("Interpolated %d NaN value(s) before decomposition.", n_interpolated)
     return clean.to_numpy().astype(float)
 
 

--- a/tests/base/test_step_expansion_diagnostics.py
+++ b/tests/base/test_step_expansion_diagnostics.py
@@ -305,6 +305,59 @@ class TestForecastCoverageDiagnostic:
         assert _zero_coverage_warnings(record), "expected the dead-channel warning"
         assert not _partial_coverage_warnings(record)
 
+    def test_the_warning_carries_the_per_column_breakdown(self):
+        """Which channel is starved is what tells a reader what to do.
+
+        The check computes coverage per column and used to reduce it to the
+        worst number one line later, so a consumer aggregating these across a
+        run could report how often the condition occurred but never which
+        column caused it.
+        """
+        from yohou import ForecastCoverageWarning
+
+        forecaster = self._fitted(n_vintages=20)
+        later = pl.DataFrame({
+            "time": pl.datetime_range(
+                datetime(2021, 1, 21) + timedelta(days=self.HORIZON),
+                datetime(2021, 1, 21) + timedelta(days=self.HORIZON + 1),
+                interval="1d",
+                eager=True,
+            ),
+            "value": np.arange(2, dtype=float),
+        })
+        with _captured_warnings() as record:
+            forecaster.observe(y=later)
+
+        warned = [w for w in record if issubclass(w.category, ForecastCoverageWarning)]
+        assert warned, "the coverage warning no longer carries its own type"
+        payload = warned[0].message
+        assert payload.coverage, "the per-column breakdown was dropped"
+        assert payload.forecasting_horizon == self.HORIZON
+        assert all(isinstance(count, int) for count in payload.coverage.values())
+        assert "temp" in payload.coverage
+        assert "temp" in str(payload), "the starved column should also be named in the text"
+
+    def test_the_warning_is_still_catchable_as_a_user_warning(self):
+        """Existing `pytest.warns(UserWarning)` and filterwarnings must keep working."""
+        from yohou import ForecastCoverageWarning
+
+        assert issubclass(ForecastCoverageWarning, UserWarning)
+
+        forecaster = self._fitted(n_vintages=20)
+        later = pl.DataFrame({
+            "time": pl.datetime_range(
+                datetime(2021, 1, 21) + timedelta(days=self.HORIZON),
+                datetime(2021, 1, 21) + timedelta(days=self.HORIZON + 1),
+                interval="1d",
+                eager=True,
+            ),
+            "value": np.arange(2, dtype=float),
+        })
+        with _captured_warnings() as record:
+            forecaster.observe(y=later)
+
+        assert [w for w in record if issubclass(w.category, UserWarning) and "X_forecast covers" in str(w.message)]
+
     def test_partial_coverage_reports_the_column_at_fit(self):
         """A vintage carrying fewer steps than the horizon is short-range, not dead.
 

--- a/tests/compose/test_diagnostic_output.py
+++ b/tests/compose/test_diagnostic_output.py
@@ -1,0 +1,183 @@
+"""The library must not write to standard output unless the caller asks.
+
+`ColumnTransformer` and `FeatureUnion` were ported from sklearn without the
+opening guard in `_log_message`, so both printed on every fit regardless of
+`verbose`, which defaults to False. `_print_elapsed_time` prints whenever the
+message it is handed is not None, so returning a string unconditionally is
+enough to make it print.
+
+The output went to raw stdout rather than through logging, so no handler, level
+or filter in a consuming application could suppress it. One measured Azure ML
+tuning rank carried 1,588 such lines, about 90% of that step's log.
+
+The bug existed because nothing checked, which is what these tests are for.
+"""
+
+import logging
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from conftest import SimpleTransformer  # noqa: E402
+from yohou.compose import ColumnTransformer, FeatureUnion  # noqa: E402
+
+
+@pytest.fixture
+def frame() -> pl.DataFrame:
+    """A small three-column series, mirroring the other compose tests."""
+    length = 20
+    return pl.DataFrame({
+        "time": pl.datetime_range(
+            start=datetime(2021, 1, 1),
+            end=datetime(2021, 1, 1) + timedelta(seconds=length - 1),
+            interval="1s",
+            eager=True,
+        ),
+        "a": [float(x) for x in range(length)],
+        "b": [float(x) * 10 for x in range(length)],
+        "c": [float(x) * 100 for x in range(length)],
+    })
+
+
+def _column_transformer(**kwargs):
+    return ColumnTransformer(
+        transformers=[("t1", SimpleTransformer(observation_horizon=0), ["a"])],
+        remainder="drop",
+        **kwargs,
+    )
+
+
+def _feature_union(**kwargs):
+    return FeatureUnion(
+        transformer_list=[("t1", SimpleTransformer(observation_horizon=0))],
+        **kwargs,
+    )
+
+
+class TestDefaultConstructedEstimatorsAreSilent:
+    """`verbose` defaults to False, so the documented default must hold."""
+
+    def test_column_transformer_is_silent_on_fit(self, frame, capsys):
+        _column_transformer().fit(frame)
+
+        assert capsys.readouterr().out == ""
+
+    def test_column_transformer_is_silent_on_fit_transform(self, frame, capsys):
+        estimator = _column_transformer()
+        estimator.fit(frame)
+        estimator.transform(frame)
+
+        assert capsys.readouterr().out == ""
+
+    def test_feature_union_is_silent_on_fit(self, frame, capsys):
+        _feature_union().fit(frame)
+
+        assert capsys.readouterr().out == ""
+
+    def test_feature_union_is_silent_on_fit_transform(self, frame, capsys):
+        estimator = _feature_union()
+        estimator.fit(frame)
+        estimator.transform(frame)
+
+        assert capsys.readouterr().out == ""
+
+    def test_silence_holds_under_composition(self, frame, capsys):
+        """A nested composition must be silent at every level, not just the outer one."""
+        nested = ColumnTransformer(
+            transformers=[
+                (
+                    "inner",
+                    FeatureUnion(transformer_list=[("t1", SimpleTransformer(observation_horizon=0))]),
+                    ["a"],
+                )
+            ],
+            remainder="drop",
+        )
+        nested.fit(frame)
+        nested.transform(frame)
+
+        assert capsys.readouterr().out == ""
+
+
+class TestTheDocumentedParameterStillWorks:
+    """Restoring the guard must not delete the feature it guards."""
+
+    def test_column_transformer_reports_when_asked(self, frame, capsys):
+        _column_transformer(verbose=True).fit(frame)
+
+        out = capsys.readouterr().out
+        assert "ColumnTransformer" in out
+        assert "Processing t1" in out
+
+    def test_feature_union_reports_when_asked(self, frame, capsys):
+        _feature_union(verbose=True).fit(frame)
+
+        out = capsys.readouterr().out
+        assert "FeatureUnion" in out
+        assert "Processing t1" in out
+
+    @pytest.mark.parametrize("factory", [_column_transformer, _feature_union])
+    def test_the_message_is_none_at_the_default(self, factory):
+        """`None` is the mechanism: `_print_elapsed_time` prints anything else."""
+        assert factory()._log_message("t1", 1, 1) is None
+
+    @pytest.mark.parametrize("factory", [_column_transformer, _feature_union])
+    def test_the_message_is_a_string_when_verbose(self, factory):
+        message = factory(verbose=True)._log_message("t1", 1, 1)
+
+        assert isinstance(message, str)
+        assert "t1" in message
+
+
+class TestFeaturePipelineWasNeverAffected:
+    """It delegates to sklearn's implementation, which kept the guard.
+
+    Which is why `[FeaturePipeline]` lines never appeared in captured logs while
+    the other two did. Pinned so a future port does not lose the delegation.
+    """
+
+    def test_it_delegates_rather_than_reimplementing(self):
+        import inspect
+
+        from yohou.compose import FeaturePipeline
+
+        source = inspect.getsource(FeaturePipeline._log_message)
+        assert "sklearn_Pipeline._log_message" in source
+
+
+class TestTheLoggerNamespace:
+    """The library emits; the application decides where it goes."""
+
+    def test_the_package_logger_has_a_null_handler(self):
+        handlers = logging.getLogger("yohou").handlers
+
+        assert any(isinstance(h, logging.NullHandler) for h in handlers)
+
+    def test_the_library_sets_no_level(self):
+        """The application's configuration must be authoritative."""
+        assert logging.getLogger("yohou").level == logging.NOTSET
+
+    def test_submodules_are_separately_controllable(self):
+        """`yohou.compose` must be levellable without silencing the rest."""
+        compose = logging.getLogger("yohou.compose")
+        model_selection = logging.getLogger("yohou.model_selection")
+        try:
+            compose.setLevel(logging.ERROR)
+            assert compose.getEffectiveLevel() == logging.ERROR
+            assert model_selection.getEffectiveLevel() != logging.ERROR
+        finally:
+            compose.setLevel(logging.NOTSET)
+
+    def test_an_unconfigured_application_sees_no_fallback_output(self, capsys):
+        """The null handler exists to prevent the 'no handlers' message."""
+        logger = logging.getLogger("yohou.compose")
+        logger.debug("a diagnostic nobody configured a handler for")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "No handlers could be found" not in captured.err

--- a/tests/compose/test_per_vintage.py
+++ b/tests/compose/test_per_vintage.py
@@ -1,5 +1,6 @@
 """Tests for PerVintageActualTransformer and the actual/forecast kind split."""
 
+import logging
 from datetime import datetime, timedelta
 
 import polars as pl
@@ -330,7 +331,7 @@ def test_get_feature_names_out_delegates_to_inner():
     assert tx.get_feature_names_out() == ["net_load"]
 
 
-def test_sub_two_row_vintages_are_dropped_with_a_warning():
+def test_sub_two_row_vintages_are_dropped_and_reported(caplog):
     """A vintage too small to fit per vintage is dropped, with a warning, not transformed.
 
     The truncated tail of a real forecast frame is full of single-row vintages
@@ -354,8 +355,12 @@ def test_sub_two_row_vintages_are_dropped_with_a_warning():
     })
     tx = PerVintageActualTransformer(StandardScaler())
 
-    with pytest.warns(UserWarning, match="dropped 1 vintage"):
+    # A record rather than a warning: the message itself says the condition is
+    # expected for a truncated tail, so it states what the transformer did.
+    with caplog.at_level(logging.INFO, logger="yohou.compose.per_vintage"):
         out = tx.fit_transform(frame)
+
+    assert [r for r in caplog.records if "dropped 1 vintage" in r.getMessage()]
 
     # the two full vintages survive; the single-row vintage is gone
     assert out["vintage_time"].unique().sort().to_list() == [datetime(2020, 1, 1), datetime(2020, 1, 2)]

--- a/tests/plotting/test_forecasting.py
+++ b/tests/plotting/test_forecasting.py
@@ -444,8 +444,12 @@ class TestPlotDecompositionStl:
         )
         assert len(fig.data) == 2
 
-    def test_nan_interpolation_warning(self):
-        """STL mode warns when NaN values are interpolated."""
+    def test_nan_interpolation_is_logged_not_warned(self, caplog):
+        """Interpolating states what the helper did, so it is a record.
+
+        It was a warning, which diluted a channel a consumer cannot easily
+        ignore with something that is the documented behaviour of this path.
+        """
         dates = pl.date_range(
             pl.date(2018, 1, 1),
             pl.date(2022, 12, 31),
@@ -457,8 +461,12 @@ class TestPlotDecompositionStl:
         values[5] = None
         values[10] = None
         df = pl.DataFrame({"time": dates, "y": values})
-        with pytest.warns(UserWarning, match="Interpolated"):
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="yohou.plotting.forecasting"):
             fig = plot_decomposition(df, ["trend", "residual"], method="stl")
+
+        assert [r for r in caplog.records if "Interpolated" in r.getMessage()]
         assert_figure_valid(fig)
 
     def test_unsupported_interval_error(self):


### PR DESCRIPTION
## Description

`ColumnTransformer._log_message` and `FeatureUnion._log_message` were ported from sklearn without its opening guard:

```python
if not self.verbose:
    return None
```

`_print_elapsed_time` prints whenever the message it is handed is not `None`, so both classes printed on every fit regardless of `verbose`, which defaults to `False`. The output goes to raw stdout rather than through logging, so no handler, level or filter in a consuming application can suppress it.

This also adds the package logger namespace: a `NullHandler` on `yohou` and no level set anywhere, so an application can raise or lower the library's verbosity and target `yohou.compose` without silencing `yohou.model_selection`. The package had exactly one logging call before this, so `logging.getLogger("yohou")` controlled nothing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Motivation and Context

Measured on a real Azure ML tuning step in a consuming project, same variant and same 16-trial budget before and after:

| | lines | logged events | these prints |
| --- | --- | --- | --- |
| before | 1,758 | 132 | **1,588** |
| after | **132** | 109 | **0** |

Both folds ran their search to completion, so this is not a shorter step flattering the count. Those 1,588 lines were `(step 3 of 4) Processing realized_lags` and similar, repeated for every transformer of every fold of every trial, from a flag nobody set.

`FeaturePipeline._log_message` delegates to sklearn's implementation and keeps the guard, which is why `[FeaturePipeline]` lines never appeared while the other two did. A test now pins that delegation so a future port cannot lose it quietly, which is exactly how these two were lost.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

**This is the first slice of a larger change**, and more will land on this branch: recategorising the diagnostics that are statements of behaviour rather than warnings, giving the forecast-coverage warning its per-column breakdown instead of only the worst column, and the documentation for the new logger namespace. The guard and the namespace are separable and carry essentially all of the volume, which is why they come first.

Note on `just lint`: it runs `ty check src` without `--extra plotting`, so it reports 8 unresolved `plotly_resampler` imports on a default sync. The pre-commit hook passes that extra and is clean; the discrepancy predates this change.

Behaviour change worth calling out for anyone who has been reading those lines: output that previously always appeared on fit is now gated behind `verbose`, which is what the parameter documents and what sklearn does.
