### PR TITLE
docs(diagnostics): give the coverage warning an API page and reconcile the docs

### DIFF
--- a/docs/pages/api/base.md
+++ b/docs/pages/api/base.md
@@ -16,5 +16,5 @@ Base classes for transformers and forecasters.
 | [`BaseReductionForecaster`](generated/yohou.base.BaseReductionForecaster.md) | Base class for forecasters using reduction to supervised learning. |
 | [`BaseStandardForecaster`](generated/yohou.base.BaseStandardForecaster.md) | Mixin providing standard (single DataFrame) forecaster operations. |
 | [`BaseStepTransformer`](generated/yohou.base.BaseStepTransformer.md) | Base class for ``"step"``-kind transformers over the derived step frame. |
-| [`ForecastCoverageWarning`](generated/yohou.base.ForecastCoverageWarning.md) | Raised when ``X_forecast`` covers fewer steps than the forecasting horizon. |
 | [`BaseActualTransformer`](generated/yohou.base.BaseActualTransformer.md) | Base class for single-axis (``"actual"``-kind) time series transformers. |
+| [`ForecastCoverageWarning`](generated/yohou.base.ForecastCoverageWarning.md) | Raised when ``X_forecast`` covers fewer steps than the forecasting horizon. |

--- a/docs/pages/api/base.md
+++ b/docs/pages/api/base.md
@@ -16,4 +16,5 @@ Base classes for transformers and forecasters.
 | [`BaseReductionForecaster`](generated/yohou.base.BaseReductionForecaster.md) | Base class for forecasters using reduction to supervised learning. |
 | [`BaseStandardForecaster`](generated/yohou.base.BaseStandardForecaster.md) | Mixin providing standard (single DataFrame) forecaster operations. |
 | [`BaseStepTransformer`](generated/yohou.base.BaseStepTransformer.md) | Base class for ``"step"``-kind transformers over the derived step frame. |
+| [`ForecastCoverageWarning`](generated/yohou.base.ForecastCoverageWarning.md) | Raised when ``X_forecast`` covers fewer steps than the forecasting horizon. |
 | [`BaseActualTransformer`](generated/yohou.base.BaseActualTransformer.md) | Base class for single-axis (``"actual"``-kind) time series transformers. |

--- a/docs/pages/explanation/exogenous-features.md
+++ b/docs/pages/explanation/exogenous-features.md
@@ -306,13 +306,24 @@ earlier observation whose horizon does reach it. Where the resolved vintage
 carries no value at a step's target time, that step column is padded with null
 and a `UserWarning` is emitted.
 
-Coverage is measured per observation and per base column. At fit, a column
-that fails to cover some training observations is named in a per-column
-`UserWarning`, with the count of observations it misses, so a channel that is
-dead for most of the batch is visible rather than hidden behind a single
-covered row. On the observe and predict paths the per-call warning reports the
-worst-covered observation, distinguishing zero coverage (the channel
-contributes nothing) from partial coverage (a short-range forecast).
+Coverage is measured per observation and per base column, and both paths report
+at that granularity. At fit, a column that fails to cover some training
+observations is named in a per-column warning, with the count of observations it
+misses, so a channel that is dead for most of the batch is visible rather than
+hidden behind a single covered row. On the observe and predict paths the
+per-call warning is a
+[`ForecastCoverageWarning`](/pages/api/generated/yohou.base.ForecastCoverageWarning/),
+which names the starved columns in its message and carries the whole per-column
+breakdown on its `coverage` attribute. It still distinguishes zero coverage (the
+channel contributes nothing) from partial coverage (a short-range forecast),
+because those are different conditions rather than degrees of one.
+
+The two paths previously disagreed about how much to say: fit reported per
+column while observe and predict reduced the same measurement to a single worst
+number one line after computing it. Which channel is starved is what tells a
+reader what to do, so that detail is no longer discarded, and a consumer
+aggregating these across a long run can report the affected columns rather than
+only a count.
 
 ## Heterogeneous Vintage Cadence
 

--- a/docs/pages/how-to/contributing.md
+++ b/docs/pages/how-to/contributing.md
@@ -240,6 +240,47 @@ Run all quality checks by combining the fix and test steps above:
     uv run prek run --all-files --show-diff-on-failure && uv run pytest
     ```
 
+### Diagnostics: warning or log record
+
+Yohou has two channels and they mean different things.
+
+- `warnings.warn` means **this may be wrong and you should look**. It is the
+  channel a consumer cannot easily ignore, so putting a statement of fact in it
+  trains readers to skim the one place that should always be worth reading.
+- `logging` under the `yohou` namespace means **here is what I did**. Use
+  `logging.getLogger(__name__)` at module level so the submodule hierarchy comes
+  for free and an application can turn one subsystem down without silencing the
+  rest.
+
+The library attaches only a `NullHandler` and **sets no level anywhere**. Routing
+and levels belong to the application.
+
+Moving a diagnostic between channels is a **breaking change** for anyone catching
+it, so name it explicitly in the pull request body with a `BREAKING CHANGE:`
+footer. `CHANGELOG.md` is generated from merged pull requests, so a hand-written
+entry there does not survive.
+
+**A log call in a hot path costs even when the level is disabled**, because the
+arguments are evaluated before the call decides to discard them. Pass values
+rather than pre-formatted strings, so the formatting happens only if a handler
+wants it:
+
+```python
+logger.info("Dropped %d vintage(s) below %d rows", dropped, minimum)   # cheap
+logger.info(f"Dropped {dropped} vintage(s) below {minimum} rows")      # not
+```
+
+The same applies to warnings, with an extra trap: repetition. Python's filter
+deduplicates per raise site, but that registry is per module and a fresh worker
+process does not inherit it, so a warning that looks like it fires once locally
+can fire once per worker. Audited at the time of writing: no warning site sits in
+a per-row or per-fold loop. Every one that sits in a loop at all iterates
+something bounded, such as columns, pipeline steps or coverage rates. The high
+counts seen downstream (134 occurrences of the forecast-coverage warning in one
+tuning step) came from repeated *calls* across trials and folds, not from a loop,
+which is why the fix there was aggregation in the consumer rather than anything
+here.
+
 ### Docstring Standards
 
 All public functions, methods, and classes require **NumPy-style** docstrings. Coverage is enforced at 100% by `interrogate`.

--- a/docs/pages/how-to/control-diagnostic-output.md
+++ b/docs/pages/how-to/control-diagnostic-output.md
@@ -82,6 +82,22 @@ means the later steps are null.
 It subclasses `UserWarning`, so code that already catches `UserWarning` keeps
 working.
 
+## Diagnostics that used to be warnings
+
+Two diagnostics moved from the warning channel to the log channel, because both
+state what the library did rather than something you may need to act on. If you
+were catching either, catch the log record instead.
+
+| what | where it goes now |
+| --- | --- |
+| `PerVintageActualTransformer` dropped N vintages with too few rows | `yohou.compose.per_vintage`, at INFO |
+| `Interpolated N NaN value(s) before decomposition` | `yohou.plotting.forecasting`, at INFO |
+
+The first says "this is expected for the truncated tail of a forecast frame" in
+its own text, which is the clearest sign it was never a warning. Everything else
+that warns today still warns: a condition you may need to act on stays in the
+channel you cannot easily ignore.
+
 ## Estimator progress output
 
 `ColumnTransformer` and `FeatureUnion` accept `verbose`, matching the sklearn

--- a/src/yohou/base/__init__.py
+++ b/src/yohou/base/__init__.py
@@ -10,6 +10,7 @@ from .reduction import BaseReductionForecaster
 from .standard import BaseStandardForecaster
 from .step_transformer import BaseStepTransformer
 from .transformer import BaseActualTransformer
+from .utils import ForecastCoverageWarning
 
 __all__ = [
     "BaseActualTransformer",
@@ -19,5 +20,6 @@ __all__ = [
     "BaseReductionForecaster",
     "BaseStandardForecaster",
     "BaseStepTransformer",
+    "ForecastCoverageWarning",
     "PredictionType",
 ]


### PR DESCRIPTION
## Description

Follow-up to #159, covering the documentation half.

`ForecastCoverageWarning` was exported from the package root but not from `yohou.base`, so the API generator never gave it a page: it documents a submodule's declarations and its `__all__` re-exports, and the class lives in `yohou.base.utils`. Exporting it from `yohou.base` is enough, and the page generates.

The exogenous-features explanation still described the asymmetry #159 removed, saying the fit path reports per column while observe and predict reduce the same measurement to one worst number. Both now report per column.

The how-to gained a section naming the two diagnostics that moved out of the warning channel, since a consumer catching either is silently affected.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change (see below)
- [x] Documentation update
- [ ] Refactoring

## Motivation and Context

The two recategorised diagnostics are a silent break for anyone catching them, and a generated changelog is a thin place to learn that. The commit carries a `BREAKING CHANGE:` footer naming both, so the release notes surface them rather than only the guard fix from #159.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Tests run: the two suites touching this change, 41 passing. I did not run the full suite locally because it takes about 14 minutes on this machine; CI covers it.

`CHANGELOG.md` is deliberately untouched, since git-cliff generates it from merged pull requests at release time.